### PR TITLE
doc: define standardized webhook event schemas

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,6 +12,7 @@ This document provides comprehensive API documentation for all SocialFlow servic
 2. [Type Definitions](#type-definitions)
 3. [Error Handling](#error-handling)
 4. [Best Practices](#best-practices)
+5. [Webhooks](#webhooks)
 
 ---
 
@@ -435,6 +436,54 @@ async function getCachedCaption(topic: string, platform: string) {
   const caption = await generateCaption(topic, platform);
   cache.set(key, caption);
   return caption;
+}
+```
+
+---
+
+## Webhooks
+
+**Module:** `src/schemas/webhooks.ts`
+
+To ensure consistency across the ecosystem, all incoming and outgoing webhooks follow a standardized JSON schema and TypeScript interfaces.
+
+### Standard Webhook Payload
+
+All webhooks share a standard envelope containing metadata about the event and a `data` field for the specific payload.
+
+```typescript
+interface WebhookEvent<T = any> {
+  id: string;                    // Unique identifier for the webhook event
+  version: string;               // Schema version (e.g., '1.0')
+  event: string;                 // The event type identifier
+  createdAt: string;             // ISO 8601 timestamp
+  source: string;                // Source system generating the event
+  data: T;                       // The event-specific payload
+}
+```
+
+### Supported Event Types
+
+- `post.published`: Emitted when a scheduled post goes live.
+- `post.failed`: Emitted when a post fails to publish.
+- `analytics.report_ready`: Emitted when an async analytics report is generated.
+- `blockchain.transaction_completed`: Emitted when a Stellar/Soroban transaction confirms.
+
+### Example Payload
+
+```json
+{
+  "id": "wh_1234567890",
+  "version": "1.0",
+  "event": "post.published",
+  "createdAt": "2026-03-24T10:00:00Z",
+  "source": "socialflow-core",
+  "data": {
+    "postId": "post_123",
+    "platform": "instagram",
+    "url": "https://instagram.com/p/123456",
+    "publishedAt": "2026-03-24T10:00:00Z"
+  }
 }
 ```
 

--- a/src/schemas/webhooks.ts
+++ b/src/schemas/webhooks.ts
@@ -1,0 +1,69 @@
+/**
+ * Standardized Webhook Event Schema
+ * 
+ * Defines the common envelope and payload structures for all incoming 
+ * and outgoing webhooks across the SocialFlow ecosystem.
+ */
+
+export type WebhookEventVersion = '1.0';
+
+export type WebhookEventType = 
+  | 'post.published'
+  | 'post.failed'
+  | 'analytics.report_ready'
+  | 'blockchain.transaction_completed'
+  | 'blockchain.transaction_failed'
+  | 'system.health_check';
+
+/**
+ * Base envelope for all webhook events
+ */
+export interface WebhookEvent<T = Record<string, any>> {
+  /** Unique identifier for the webhook event delivery */
+  id: string;
+  
+  /** The schema version of the event payload */
+  version: WebhookEventVersion;
+  
+  /** The type of event that occurred */
+  event: WebhookEventType;
+  
+  /** ISO 8601 timestamp of when the event occurred */
+  createdAt: string;
+  
+  /** The source system or service that generated the event */
+  source: string;
+  
+  /** The event-specific data payload */
+  data: T;
+}
+
+// --- Specific Event Payloads ---
+
+export interface PostPublishedPayload {
+  postId: string;
+  platform: string;
+  url: string;
+  publishedAt: string;
+}
+
+export interface PostFailedPayload {
+  postId: string;
+  platform: string;
+  error: string;
+  failedAt: string;
+}
+
+export interface AnalyticsReportReadyPayload {
+  reportId: string;
+  period: string;
+  downloadUrl: string;
+}
+
+export interface BlockchainTransactionPayload {
+  transactionHash: string;
+  status: 'success' | 'failed';
+  amount?: number;
+  asset?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Title: doc: define standardized webhook event schemas

Closes #344  

## Summary
Defined a formal JSON schema using TypeScript interfaces for all outgoing and incoming webhooks to ensure consistency across the ecosystem.

## Changes
- **Webhook Schemas:** Created `src/schemas/webhooks.ts` outlining the standard structure for webhook envelopes, including versioning (`version: '1.0'`) and specific event payloads (e.g., `post.published`, `blockchain.transaction_completed`).
- **API Documentation:** Updated `docs/API_REFERENCE.md` with a new `Webhooks` section that documents the standard payload envelope, details the supported event types, and provides a sample JSON payload.

## Motivation & Context
Fixes #344 / issue #94. This standardization ensures predictable data formats and robust versioning for schemas, satisfying the requirement to formalize webhook definitions across the platform's services.
