### PR TITLE
feat: integrate YouTube Data API for video channel analytics

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,3 +29,10 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
 
 # Set to 'true' to enable verbose OTel diagnostic logs (uses SimpleSpanProcessor)
 OTEL_DEBUG=false
+
+# ─── YouTube Data API v3 ──────────────────────────────────────────────────────
+YOUTUBE_CLIENT_ID=your_google_oauth_client_id
+YOUTUBE_CLIENT_SECRET=your_google_oauth_client_secret
+YOUTUBE_REDIRECT_URI=http://localhost:3000/api/youtube/callback
+# Cron schedule for periodic analytics sync (default: every 6 hours)
+YOUTUBE_SYNC_CRON=0 */6 * * *

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -32,6 +32,9 @@ app.get('/health', (req, res) => {
 // app.use('/api/auth', authRoutes);
 // app.use('/api/users', userRoutes);
 
+import youtubeRoutes from './routes/youtube';
+app.use('/api/youtube', youtubeRoutes);
+
 // 404 handler - must be after all routes
 app.use(notFoundHandler);
 

--- a/backend/src/config/circuitBreaker.config.ts
+++ b/backend/src/config/circuitBreaker.config.ts
@@ -97,6 +97,17 @@ export const CIRCUIT_CONFIGS = {
     volumeThreshold: 5,
     name: 'price-service',
   } as CircuitBreakerConfig,
+
+  // YouTube Data API v3
+  youtube: {
+    timeout: 15000,              // 15 seconds
+    errorThresholdPercentage: 50,
+    resetTimeout: 60000,         // 1 minute cooldown
+    rollingCountTimeout: 20000,
+    rollingCountBuckets: 10,
+    volumeThreshold: 3,
+    name: 'youtube-service',
+  } as CircuitBreakerConfig,
 };
 
 /**

--- a/backend/src/jobs/youtubeSyncJob.ts
+++ b/backend/src/jobs/youtubeSyncJob.ts
@@ -1,0 +1,92 @@
+import { Queue, Worker } from 'bullmq';
+import { getRedisConnection } from '../config/runtime';
+import { createLogger } from '../lib/logger';
+import { youTubeService } from '../services/YouTubeService';
+
+const logger = createLogger('youtube-sync-job');
+
+const QUEUE_NAME = 'youtube-analytics-sync';
+const JOB_NAME = 'sync-youtube-analytics';
+const REPEAT_JOB_ID = 'youtube-analytics-repeat';
+
+// Cron: every 6 hours
+const SYNC_CRON = process.env.YOUTUBE_SYNC_CRON || '0 */6 * * *';
+
+let queue: Queue | null = null;
+let worker: Worker | null = null;
+
+export interface YouTubeSyncPayload {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+export const startYouTubeSyncJob = async (): Promise<void> => {
+  if (!youTubeService.isConfigured()) {
+    logger.info('YouTube API not configured, sync job skipped');
+    return;
+  }
+
+  if (!queue) {
+    queue = new Queue(QUEUE_NAME, { connection: getRedisConnection() });
+  }
+
+  if (!worker) {
+    worker = new Worker(
+      QUEUE_NAME,
+      async (job) => {
+        const { accessToken, refreshToken, expiresAt } = job.data as YouTubeSyncPayload;
+
+        let token = accessToken;
+        if (Date.now() >= expiresAt) {
+          logger.info('Access token expired, refreshing', { jobId: job.id });
+          const refreshed = await youTubeService.refreshAccessToken(refreshToken);
+          token = refreshed.accessToken;
+        }
+
+        const videoIds = await youTubeService.listChannelVideos(token);
+        const stats = await youTubeService.getVideoStats(token, videoIds);
+
+        logger.info('YouTube analytics synced', {
+          jobId: job.id,
+          videoCount: stats.length,
+        });
+
+        return { synced: stats.length, timestamp: new Date().toISOString() };
+      },
+      { connection: getRedisConnection() }
+    );
+
+    worker.on('completed', (job) => {
+      logger.info('YouTube sync job completed', { jobId: job.id, result: job.returnvalue });
+    });
+
+    worker.on('failed', (job, error) => {
+      logger.error('YouTube sync job failed', { jobId: job?.id, error: error.message });
+    });
+  }
+
+  await queue.add(JOB_NAME, {}, {
+    repeat: { pattern: SYNC_CRON },
+    jobId: REPEAT_JOB_ID,
+    removeOnComplete: 50,
+    removeOnFail: 100,
+  });
+
+  logger.info('YouTube analytics sync job started', { cron: SYNC_CRON });
+};
+
+export const stopYouTubeSyncJob = async (): Promise<void> => {
+  if (worker) { await worker.close(); worker = null; }
+  if (queue) { await queue.close(); queue = null; }
+  logger.info('YouTube analytics sync job stopped');
+};
+
+/** Manually enqueue a one-off sync (e.g. after OAuth callback) */
+export const enqueueYouTubeSync = async (payload: YouTubeSyncPayload): Promise<void> => {
+  if (!queue) {
+    queue = new Queue(QUEUE_NAME, { connection: getRedisConnection() });
+  }
+  await queue.add(JOB_NAME, payload, { removeOnComplete: 10, removeOnFail: 20 });
+  logger.info('YouTube one-off sync enqueued');
+};

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -1,0 +1,98 @@
+import { Router, Request, Response } from 'express';
+import { youTubeService } from '../services/YouTubeService';
+import { enqueueYouTubeSync } from '../jobs/youtubeSyncJob';
+import { createLogger } from '../lib/logger';
+
+const router = Router();
+const logger = createLogger('youtube-routes');
+
+/**
+ * GET /api/youtube/auth
+ * Redirects the user to Google's OAuth2 consent screen.
+ */
+router.get('/auth', (_req: Request, res: Response) => {
+  if (!youTubeService.isConfigured()) {
+    return res.status(503).json({ error: 'YouTube API not configured.' });
+  }
+  return res.redirect(youTubeService.getAuthUrl());
+});
+
+/**
+ * GET /api/youtube/callback
+ * Handles the OAuth2 redirect, exchanges the code for tokens,
+ * and triggers an immediate analytics sync.
+ */
+router.get('/callback', async (req: Request, res: Response) => {
+  const { code, error } = req.query;
+
+  if (error) {
+    logger.warn('OAuth callback error', { error });
+    return res.status(400).json({ error: String(error) });
+  }
+
+  if (!code || typeof code !== 'string') {
+    return res.status(400).json({ error: 'Missing authorization code.' });
+  }
+
+  try {
+    const tokens = await youTubeService.exchangeCode(code);
+    // Trigger an immediate sync with the fresh tokens
+    await enqueueYouTubeSync(tokens);
+    return res.json({ message: 'YouTube connected. Analytics sync queued.', expiresAt: tokens.expiresAt });
+  } catch (err) {
+    logger.error('OAuth callback failed', { error: (err as Error).message });
+    return res.status(500).json({ error: 'Failed to complete OAuth flow.' });
+  }
+});
+
+/**
+ * GET /api/youtube/channel
+ * Returns channel metadata for the authenticated user.
+ * Expects ?access_token=<token> (in production, read from session/DB).
+ */
+router.get('/channel', async (req: Request, res: Response) => {
+  const accessToken = req.query.access_token as string;
+  if (!accessToken) return res.status(400).json({ error: 'access_token query param required.' });
+
+  try {
+    const channel = await youTubeService.getChannel(accessToken);
+    return res.json(channel);
+  } catch (err) {
+    logger.error('Failed to fetch channel', { error: (err as Error).message });
+    return res.status(502).json({ error: (err as Error).message });
+  }
+});
+
+/**
+ * GET /api/youtube/videos/stats
+ * Returns statistics for given video IDs.
+ * Query: access_token, ids (comma-separated)
+ */
+router.get('/videos/stats', async (req: Request, res: Response) => {
+  const { access_token, ids } = req.query;
+  if (!access_token || !ids) {
+    return res.status(400).json({ error: 'access_token and ids query params required.' });
+  }
+
+  const videoIds = (ids as string).split(',').map((id) => id.trim()).filter(Boolean);
+  try {
+    const stats = await youTubeService.getVideoStats(access_token as string, videoIds);
+    return res.json(stats);
+  } catch (err) {
+    logger.error('Failed to fetch video stats', { error: (err as Error).message });
+    return res.status(502).json({ error: (err as Error).message });
+  }
+});
+
+/**
+ * GET /api/youtube/status
+ * Returns circuit breaker status and configuration health.
+ */
+router.get('/status', (_req: Request, res: Response) => {
+  return res.json({
+    configured: youTubeService.isConfigured(),
+    circuit: youTubeService.getCircuitStatus(),
+  });
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import app from './app';
 import { getBackendPort } from './config/runtime';
 import { startDataPruningJob, stopDataPruningJob } from './jobs/dataPruningJob';
+import { startYouTubeSyncJob, stopYouTubeSyncJob } from './jobs/youtubeSyncJob';
 import { startWorkerMonitor, stopWorkerMonitor } from './monitoring/workerMonitorInstance';
 import { createLogger } from './lib/logger';
 import { prisma } from './lib/prisma';
@@ -64,6 +65,16 @@ const gracefulShutdown = async (signal: string, exitCode: number = 0): Promise<v
       logger.info('Data pruning job stopped');
     } catch (error) {
       logger.error('Failed to stop data pruning job', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Stop YouTube sync job
+    try {
+      await stopYouTubeSyncJob();
+      logger.info('YouTube sync job stopped');
+    } catch (error) {
+      logger.error('Failed to stop YouTube sync job', {
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -156,6 +167,16 @@ const bootstrap = async (): Promise<void> => {
       logger.info('Data pruning job started');
     } catch (error) {
       logger.error('Failed to start data pruning job', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Start YouTube analytics sync job
+    try {
+      await startYouTubeSyncJob();
+      logger.info('YouTube analytics sync job started');
+    } catch (error) {
+      logger.error('Failed to start YouTube sync job', {
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/backend/src/services/YouTubeService.ts
+++ b/backend/src/services/YouTubeService.ts
@@ -1,0 +1,217 @@
+import { circuitBreakerService } from './CircuitBreakerService';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('youtube-service');
+
+export interface YouTubeVideoStats {
+  videoId: string;
+  title: string;
+  publishedAt: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  channelId: string;
+  channelTitle: string;
+}
+
+export interface YouTubeChannel {
+  id: string;
+  title: string;
+  subscriberCount: number;
+  videoCount: number;
+  viewCount: number;
+}
+
+export interface YouTubeTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+const API_BASE = 'https://www.googleapis.com/youtube/v3';
+const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+class YouTubeService {
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly redirectUri: string;
+
+  constructor() {
+    this.clientId = process.env.YOUTUBE_CLIENT_ID || '';
+    this.clientSecret = process.env.YOUTUBE_CLIENT_SECRET || '';
+    this.redirectUri = process.env.YOUTUBE_REDIRECT_URI || 'http://localhost:3000/api/youtube/callback';
+  }
+
+  public isConfigured(): boolean {
+    return !!this.clientId && !!this.clientSecret;
+  }
+
+  /** Step 1: Build the Google OAuth2 authorization URL */
+  public getAuthUrl(): string {
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      redirect_uri: this.redirectUri,
+      response_type: 'code',
+      scope: 'https://www.googleapis.com/auth/youtube.readonly',
+      access_type: 'offline',
+      prompt: 'consent',
+    });
+    return `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+  }
+
+  /** Step 2: Exchange authorization code for tokens */
+  public async exchangeCode(code: string): Promise<YouTubeTokens> {
+    const response = await fetch(OAUTH_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        redirect_uri: this.redirectUri,
+        grant_type: 'authorization_code',
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(`OAuth token exchange failed: ${JSON.stringify(err)}`);
+    }
+
+    const data = await response.json() as any;
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  /** Refresh an expired access token */
+  public async refreshAccessToken(refreshToken: string): Promise<YouTubeTokens> {
+    const response = await fetch(OAUTH_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        refresh_token: refreshToken,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(`Token refresh failed: ${JSON.stringify(err)}`);
+    }
+
+    const data = await response.json() as any;
+    return {
+      accessToken: data.access_token,
+      refreshToken,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  /** Fetch channel info for the authenticated user */
+  public async getChannel(accessToken: string): Promise<YouTubeChannel> {
+    return circuitBreakerService.execute(
+      'youtube',
+      async () => {
+        const params = new URLSearchParams({
+          part: 'snippet,statistics',
+          mine: 'true',
+        });
+        const response = await fetch(`${API_BASE}/channels?${params}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) throw new Error(`YouTube API error: ${response.status}`);
+
+        const data = await response.json() as any;
+        const ch = data.items?.[0];
+        if (!ch) throw new Error('No channel found for this account');
+
+        return {
+          id: ch.id,
+          title: ch.snippet.title,
+          subscriberCount: Number(ch.statistics.subscriberCount ?? 0),
+          videoCount: Number(ch.statistics.videoCount ?? 0),
+          viewCount: Number(ch.statistics.viewCount ?? 0),
+        };
+      },
+      async () => {
+        logger.warn('YouTube circuit breaker open, channel fetch skipped');
+        throw new Error('YouTube API temporarily unavailable');
+      }
+    );
+  }
+
+  /** Fetch statistics for a list of video IDs */
+  public async getVideoStats(accessToken: string, videoIds: string[]): Promise<YouTubeVideoStats[]> {
+    if (!videoIds.length) return [];
+
+    return circuitBreakerService.execute(
+      'youtube',
+      async () => {
+        const params = new URLSearchParams({
+          part: 'snippet,statistics',
+          id: videoIds.join(','),
+        });
+        const response = await fetch(`${API_BASE}/videos?${params}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) throw new Error(`YouTube API error: ${response.status}`);
+
+        const data = await response.json() as any;
+        return (data.items ?? []).map((item: any) => ({
+          videoId: item.id,
+          title: item.snippet.title,
+          publishedAt: item.snippet.publishedAt,
+          viewCount: Number(item.statistics.viewCount ?? 0),
+          likeCount: Number(item.statistics.likeCount ?? 0),
+          commentCount: Number(item.statistics.commentCount ?? 0),
+          channelId: item.snippet.channelId,
+          channelTitle: item.snippet.channelTitle,
+        }));
+      },
+      async () => {
+        logger.warn('YouTube circuit breaker open, returning empty video stats');
+        return [];
+      }
+    );
+  }
+
+  /** List the most recent videos for the authenticated channel */
+  public async listChannelVideos(accessToken: string, maxResults = 25): Promise<string[]> {
+    return circuitBreakerService.execute(
+      'youtube',
+      async () => {
+        const params = new URLSearchParams({
+          part: 'id',
+          forMine: 'true',
+          type: 'video',
+          maxResults: String(maxResults),
+        });
+        const response = await fetch(`${API_BASE}/search?${params}`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!response.ok) throw new Error(`YouTube API error: ${response.status}`);
+
+        const data = await response.json() as any;
+        return (data.items ?? []).map((item: any) => item.id.videoId as string);
+      },
+      async () => {
+        logger.warn('YouTube circuit breaker open, returning empty video list');
+        return [];
+      }
+    );
+  }
+
+  public getCircuitStatus() {
+    return circuitBreakerService.getStats('youtube');
+  }
+}
+
+export const youTubeService = new YouTubeService();


### PR DESCRIPTION
### Summary

Integrates the YouTube Data API v3 into the SocialFlow backend, enabling OAuth 2.0 
authentication with Google and syncing video metadata and performance statistics for 
dashboard analytics.

### Changes

New files:
- backend/src/services/YouTubeService.ts — Core service wrapping the YouTube Data API. 
Handles the full Google OAuth2 flow (auth URL generation, authorization code exchange, 
token refresh) and fetches channel metadata and video statistics (views, likes, comments). 
All API calls are protected by the circuit breaker.
- backend/src/jobs/youtubeSyncJob.ts — BullMQ-based background job that periodically syncs 
YouTube analytics (default: every 6 hours via cron). Supports one-off sync triggers (e.g. 
immediately after OAuth callback) and handles token refresh automatically.
- backend/src/routes/youtube.ts — Express routes exposing the YouTube integration:
  - GET /api/youtube/auth — Redirects to Google OAuth2 consent screen
  - GET /api/youtube/callback — Handles OAuth redirect, exchanges code for tokens, triggers
immediate sync
  - GET /api/youtube/channel — Returns channel metadata for authenticated user
  - GET /api/youtube/videos/stats — Returns stats for given video IDs
  - GET /api/youtube/status — Circuit breaker status and config health check

Modified files:
- backend/src/config/circuitBreaker.config.ts — Added youtube circuit breaker config (15s 
timeout, 50% error threshold, 1min reset)
- backend/src/app.ts — Registered /api/youtube routes
- backend/src/server.ts — Wired startYouTubeSyncJob / stopYouTubeSyncJob into bootstrap and
graceful shutdown
- backend/.env.example — Added YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET, 
YOUTUBE_REDIRECT_URI, YOUTUBE_SYNC_CRON

### Setup

1. Create a Google Cloud project and enable the YouTube Data API v3
2. Create OAuth 2.0 credentials (Web application), add your redirect URI
3. Set the following env vars:
YOUTUBE_CLIENT_ID=...
YOUTUBE_CLIENT_SECRET=...
YOUTUBE_REDIRECT_URI=http://localhost:3000/api/youtube/callback
YOUTUBE_SYNC_CRON=0 */6 * * *   # optional, defaults to every 6h

4. Visit /api/youtube/auth to kick off the OAuth flow

### Notes
- If YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET are not set, the service gracefully skips 
initialization (no crash)
- Token storage is left to the caller — in production, persist tokens in the DB and pass 
them per-request or via session


closes #320