### PR TITLE
feat: implement Redis-based JWT blacklisting for secure logout (#57)

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { UserStore } from '../models/User';
 import { auditLogger } from '../services/AuditLogger';
 import { PasswordHistoryService } from '../services/PasswordHistoryService';
+import { AuthBlacklistService } from '../services/AuthBlacklistService';
 import { prisma } from '../lib/prisma';
 
 const SALT_ROUNDS = 12;
@@ -95,7 +96,7 @@ export function refresh(req: Request, res: Response): void {
   res.json({ accessToken: signAccess(user.id), refreshToken: newRefresh });
 }
 
-export function logout(req: Request, res: Response): void {
+export async function logout(req: Request, res: Response): Promise<void> {
   const { refreshToken } = req.body as { refreshToken: string };
 
   let payload: jwt.JwtPayload;
@@ -112,6 +113,22 @@ export function logout(req: Request, res: Response): void {
       refreshTokens: user.refreshTokens.filter((t) => t !== refreshToken),
     });
     auditLogger.log({ actorId: user.id, action: 'auth:logout', ip: req.ip, userAgent: req.headers['user-agent'] });
+  }
+
+  // Blacklist the current access token if present in the Authorization header
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    const accessToken = authHeader.slice(7);
+    try {
+      const accessPayload = jwt.verify(accessToken, jwtSecret()) as jwt.JwtPayload;
+      const tokenKey = AuthBlacklistService.keyFromPayload(accessPayload);
+      const ttl = accessPayload.exp
+        ? accessPayload.exp - Math.floor(Date.now() / 1000)
+        : AuthBlacklistService.accessTokenTTL();
+      await AuthBlacklistService.blacklistToken(tokenKey, ttl);
+    } catch {
+      // Access token already expired or invalid — nothing to blacklist
+    }
   }
 
   res.status(204).send();
@@ -147,6 +164,22 @@ export async function changePassword(req: Request, res: Response): Promise<void>
   // Hash and record the new password
   const newPasswordHash = await PasswordHistoryService.hashPassword(newPassword);
   await PasswordHistoryService.recordPasswordChange(userId, newPasswordHash);
+
+  // Blacklist the current access token — forces re-login after password change
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    const accessToken = authHeader.slice(7);
+    try {
+      const accessPayload = jwt.verify(accessToken, jwtSecret()) as jwt.JwtPayload;
+      const tokenKey = AuthBlacklistService.keyFromPayload(accessPayload);
+      const ttl = accessPayload.exp
+        ? accessPayload.exp - Math.floor(Date.now() / 1000)
+        : AuthBlacklistService.accessTokenTTL();
+      await AuthBlacklistService.blacklistToken(tokenKey, ttl);
+    } catch {
+      // Token already expired — nothing to blacklist
+    }
+  }
 
   auditLogger.log({ actorId: userId, action: 'auth:change-password', ip: req.ip, userAgent: req.headers['user-agent'] });
   res.json({ message: 'Password changed successfully' });

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { AuthBlacklistService } from '../services/AuthBlacklistService';
 
 const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
@@ -8,7 +9,7 @@ export interface AuthRequest extends Request {
   activeOrgId?: string;
 }
 
-export function authMiddleware(req: AuthRequest, res: Response, next: NextFunction): void {
+export async function authMiddleware(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
     res.status(401).json({ message: 'Missing or malformed Authorization header' });
@@ -16,11 +17,20 @@ export function authMiddleware(req: AuthRequest, res: Response, next: NextFuncti
   }
 
   const token = authHeader.slice(7);
+  let payload: jwt.JwtPayload;
   try {
-    const payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
-    req.userId = payload.sub as string;
-    next();
+    payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
   } catch {
     res.status(401).json({ message: 'Invalid or expired access token' });
+    return;
   }
+
+  const tokenKey = AuthBlacklistService.keyFromPayload(payload);
+  if (await AuthBlacklistService.isBlacklisted(tokenKey)) {
+    res.status(401).json({ message: 'Token has been revoked' });
+    return;
+  }
+
+  req.userId = payload.sub as string;
+  next();
 }

--- a/backend/src/middleware/authenticate.ts
+++ b/backend/src/middleware/authenticate.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { AuthBlacklistService } from '../services/AuthBlacklistService';
 
 const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
@@ -7,7 +8,7 @@ export interface AuthRequest extends Request {
   user?: { id: string };
 }
 
-export function authenticate(req: AuthRequest, res: Response, next: NextFunction): void {
+export async function authenticate(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
     res.status(401).json({ message: 'Missing or malformed Authorization header' });
@@ -15,11 +16,20 @@ export function authenticate(req: AuthRequest, res: Response, next: NextFunction
   }
 
   const token = authHeader.slice(7);
+  let payload: jwt.JwtPayload;
   try {
-    const payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
-    req.user = { id: payload.sub as string };
-    next();
+    payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
   } catch {
     res.status(401).json({ message: 'Invalid or expired access token' });
+    return;
   }
+
+  const tokenKey = AuthBlacklistService.keyFromPayload(payload);
+  if (await AuthBlacklistService.isBlacklisted(tokenKey)) {
+    res.status(401).json({ message: 'Token has been revoked' });
+    return;
+  }
+
+  req.user = { id: payload.sub as string };
+  next();
 }

--- a/backend/src/services/AuthBlacklistService.ts
+++ b/backend/src/services/AuthBlacklistService.ts
@@ -1,0 +1,63 @@
+import Redis from 'ioredis';
+import { getRedisConnection } from '../config/runtime';
+
+const BLACKLIST_PREFIX = 'jwt:blacklist:';
+
+/**
+ * Parses a JWT expiry string (e.g. "15m", "7d", "1h") into seconds.
+ * Falls back to the provided default if parsing fails.
+ */
+function parseTTLSeconds(value: string | undefined, fallbackSeconds: number): number {
+  if (!value) return fallbackSeconds;
+  const match = value.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) return fallbackSeconds;
+  const n = parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+  return n * multipliers[unit];
+}
+
+let _redis: Redis | null = null;
+
+function getRedis(): Redis {
+  if (!_redis) {
+    _redis = new Redis(getRedisConnection());
+  }
+  return _redis;
+}
+
+export const AuthBlacklistService = {
+  /**
+   * Blacklist an access token until it naturally expires.
+   * @param jti  - unique token identifier (jti claim); falls back to sub+iat as key
+   * @param ttlSeconds - remaining lifetime of the token in seconds
+   */
+  blacklistToken: async (tokenKey: string, ttlSeconds: number): Promise<void> => {
+    if (ttlSeconds <= 0) return; // already expired, nothing to store
+    await getRedis().set(`${BLACKLIST_PREFIX}${tokenKey}`, '1', 'EX', ttlSeconds);
+  },
+
+  /**
+   * Returns true if the token has been blacklisted.
+   */
+  isBlacklisted: async (tokenKey: string): Promise<boolean> => {
+    const result = await getRedis().get(`${BLACKLIST_PREFIX}${tokenKey}`);
+    return result !== null;
+  },
+
+  /**
+   * Derive a stable cache key from JWT payload fields.
+   * Prefers jti; falls back to "<sub>:<iat>" so we never store the raw token.
+   */
+  keyFromPayload: (payload: { sub?: string; jti?: string; iat?: number }): string => {
+    if (payload.jti) return payload.jti;
+    return `${payload.sub ?? 'unknown'}:${payload.iat ?? 0}`;
+  },
+
+  /**
+   * Compute remaining TTL in seconds for an access token.
+   */
+  accessTokenTTL: (): number => {
+    return parseTTLSeconds(process.env.JWT_EXPIRES_IN, 15 * 60); // default 15 min
+  },
+};


### PR DESCRIPTION

Summary
Closes #307  — implements a Redis-backed JWT blacklist to invalidate access tokens on logout and password change, fixing the stateless JWT logout problem.

Changes
AuthBlacklistService.ts
 (new) — Redis service that stores revoked token keys with TTL matching the original JWT expiry. Uses jti claim as key (falls back to sub:iat) so raw tokens are never persisted.
authMiddleware.ts
 — adds blacklist check on every authenticated request after JWT verification.
authenticate.ts
 — same blacklist check for routes using the authenticate middleware.
auth.ts
 — blacklists the current access token on POST /logout and POST /change-password.
How it works
On logout or password change, the access token from the Authorization header is extracted and stored in Redis with EX set to its remaining lifetime.
On every subsequent request, both auth middlewares do a single Redis GET — if the key exists, the request is rejected with 401 Token has been revoked.
Keys auto-expire in Redis, so no cleanup job is needed.
Notes
No new dependencies — uses the existing ioredis client and getRedisConnection() config already in the project.
Redis overhead is a single GET per request, well within the ~<5ms target.
Requires REDIS_HOST / REDIS_PORT env vars to be set (already documented in .env.example).