### PR TITLE
feat: implement standardized global API pagination

### DIFF
--- a/backend/src/controllers/ListingController.ts
+++ b/backend/src/controllers/ListingController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { listingService } from '../services/ListingService';
+import { parsePageLimit, buildPageResponse } from '../utils/pagination';
 
 export const toggleListingVisibility = async (req: Request, res: Response) => {
   try {
@@ -31,13 +32,11 @@ export const toggleListingVisibility = async (req: Request, res: Response) => {
 
 export const searchListings = async (req: Request, res: Response) => {
   try {
-    const query = req.query.q as string || '';
-    const listings = await listingService.searchListings(query);
+    const query  = (req.query.q as string) || '';
+    const params = parsePageLimit(req);
+    const { data, total } = await listingService.searchListings(query, params);
 
-    res.json({
-      success: true,
-      data: listings
-    });
+    res.json(buildPageResponse(req, data, total, params));
   } catch (error: any) {
     res.status(500).json({ success: false, message: error.message });
   }

--- a/backend/src/controllers/organization.ts
+++ b/backend/src/controllers/organization.ts
@@ -2,6 +2,7 @@ import { Response } from 'express';
 import { randomUUID } from 'crypto';
 import { prisma } from '../lib/prisma';
 import { AuthRequest } from '../middleware/authMiddleware';
+import { parsePageLimit, toSkipTake, buildPageResponse } from '../utils/pagination';
 
 /** POST /api/organizations — create a new org, caller becomes owner */
 export async function createOrganization(req: AuthRequest, res: Response): Promise<void> {
@@ -30,12 +31,16 @@ export async function createOrganization(req: AuthRequest, res: Response): Promi
 
 /** GET /api/organizations — list orgs the caller belongs to */
 export async function listOrganizations(req: AuthRequest, res: Response): Promise<void> {
-  const memberships = await prisma.organizationMember.findMany({
-    where: { userId: req.userId! },
-    include: { organization: true },
-  });
+  const params = parsePageLimit(req);
+  const where  = { userId: req.userId! };
 
-  res.json(memberships.map((m: typeof memberships[number]) => ({ ...m.organization, role: m.role })));
+  const [total, memberships] = await Promise.all([
+    prisma.organizationMember.count({ where }),
+    prisma.organizationMember.findMany({ where, include: { organization: true }, ...toSkipTake(params) }),
+  ]);
+
+  const data = memberships.map((m: typeof memberships[number]) => ({ ...m.organization, role: m.role }));
+  res.json(buildPageResponse(req, data, total, params));
 }
 
 /** GET /api/organizations/:orgId — get a single org (must be a member) */

--- a/backend/src/controllers/webhooks.ts
+++ b/backend/src/controllers/webhooks.ts
@@ -5,16 +5,21 @@ import { AuthRequest } from '../middleware/authMiddleware';
 import { NotFoundError, ForbiddenError } from '../lib/errors';
 import { dispatchEvent } from '../services/WebhookDispatcher';
 import { CreateWebhookInput, UpdateWebhookInput } from '../schemas/webhooks';
+import { parsePageLimit, toSkipTake, buildPageResponse } from '../utils/pagination';
 
 // ── List subscriptions ────────────────────────────────────────────────────────
 export async function listWebhooks(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    const subs = await prisma.webhookSubscription.findMany({
-      where: { userId: req.userId! },
-      orderBy: { createdAt: 'desc' },
-      select: { id: true, url: true, events: true, isActive: true, createdAt: true, updatedAt: true },
-    });
-    res.json(subs);
+    const params = parsePageLimit(req);
+    const where  = { userId: req.userId! };
+    const select = { id: true, url: true, events: true, isActive: true, createdAt: true, updatedAt: true };
+
+    const [total, subs] = await Promise.all([
+      prisma.webhookSubscription.count({ where }),
+      prisma.webhookSubscription.findMany({ where, orderBy: { createdAt: 'desc' }, select, ...toSkipTake(params) }),
+    ]);
+
+    res.json(buildPageResponse(req, subs, total, params));
   } catch (err) {
     next(err);
   }
@@ -110,17 +115,20 @@ export async function testWebhook(req: AuthRequest, res: Response, next: NextFun
 export async function listDeliveries(req: AuthRequest, res: Response, next: NextFunction) {
   try {
     await findOwned(req.params.id, req.userId!);
-    const deliveries = await prisma.webhookDelivery.findMany({
-      where: { subscriptionId: req.params.id },
-      orderBy: { createdAt: 'desc' },
-      take: 50,
-      select: {
-        id: true, eventType: true, status: true,
-        attempts: true, responseStatus: true, errorMessage: true,
-        createdAt: true, nextRetryAt: true,
-      },
-    });
-    res.json(deliveries);
+    const params = parsePageLimit(req);
+    const where  = { subscriptionId: req.params.id };
+    const select = {
+      id: true, eventType: true, status: true,
+      attempts: true, responseStatus: true, errorMessage: true,
+      createdAt: true, nextRetryAt: true,
+    };
+
+    const [total, deliveries] = await Promise.all([
+      prisma.webhookDelivery.count({ where }),
+      prisma.webhookDelivery.findMany({ where, orderBy: { createdAt: 'desc' }, select, ...toSkipTake(params) }),
+    ]);
+
+    res.json(buildPageResponse(req, deliveries, total, params));
   } catch (err) {
     next(err);
   }

--- a/backend/src/routes/audit.ts
+++ b/backend/src/routes/audit.ts
@@ -1,17 +1,22 @@
 import { Router, Request, Response } from 'express';
 import { authMiddleware, AuthRequest } from '../middleware/authMiddleware';
 import { AuditLogStore } from '../models/AuditLog';
+import { parsePageLimit, buildPageResponse } from '../utils/pagination';
 
 const router = Router();
 
 /**
  * GET /api/audit
  * Returns the most recent audit log entries (admin view).
- * Query: limit (default 100, max 500)
+ * Query: page (default 1), limit (default 20, max 100)
  */
 router.get('/', authMiddleware, (req: Request, res: Response) => {
-  const limit = Math.min(Number(req.query.limit) || 100, 500);
-  return res.json(AuditLogStore.recent(limit));
+  const params  = parsePageLimit(req);
+  const all     = AuditLogStore.recent(500);
+  const total   = all.length;
+  const start   = (params.page - 1) * params.limit;
+  const data    = all.slice(start, start + params.limit);
+  return res.json(buildPageResponse(req, data, total, params));
 });
 
 /**
@@ -19,8 +24,12 @@ router.get('/', authMiddleware, (req: Request, res: Response) => {
  * Returns audit log entries for the authenticated user.
  */
 router.get('/me', authMiddleware, (req: AuthRequest, res: Response) => {
-  const limit = Math.min(Number(req.query.limit) || 100, 500);
-  return res.json(AuditLogStore.forActor(req.userId!, limit));
+  const params  = parsePageLimit(req);
+  const all     = AuditLogStore.forActor(req.userId!, 500);
+  const total   = all.length;
+  const start   = (params.page - 1) * params.limit;
+  const data    = all.slice(start, start + params.limit);
+  return res.json(buildPageResponse(req, data, total, params));
 });
 
 /**

--- a/backend/src/services/ListingService.ts
+++ b/backend/src/services/ListingService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { PageLimitParams, toSkipTake } from '../utils/pagination';
 
 const prisma = new PrismaClient();
 
@@ -30,21 +31,26 @@ export class ListingService {
   /**
    * Search listings, excluding hidden ones
    * @param query Search string
+   * @param params Page/limit pagination params
    */
-  async searchListings(query: string = '') {
+  async searchListings(query: string = '', params: PageLimitParams): Promise<{ data: any[]; total: number }> {
     const q = query.trim();
-    
-    return prisma.listing.findMany({
-      where: {
-        isActive: true, // Hidden listings excluded from search
-        ...(q ? {
-          OR: [
-            { title: { contains: q, mode: 'insensitive' } },
-            { description: { contains: q, mode: 'insensitive' } }
-          ]
-        } : {})
-      }
-    });
+    const where = {
+      isActive: true,
+      ...(q ? {
+        OR: [
+          { title: { contains: q, mode: 'insensitive' as const } },
+          { description: { contains: q, mode: 'insensitive' as const } },
+        ],
+      } : {}),
+    };
+
+    const [total, data] = await Promise.all([
+      prisma.listing.count({ where }),
+      prisma.listing.findMany({ where, ...toSkipTake(params) }),
+    ]);
+
+    return { data, total };
   }
 }
 

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -1,0 +1,170 @@
+import { Request } from 'express';
+import { z } from 'zod';
+
+// ── Schemas ───────────────────────────────────────────────────────────────────
+
+export const pageLimitSchema = z.object({
+  page:  z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export const cursorSchema = z.object({
+  cursor: z.string().optional(),
+  limit:  z.coerce.number().int().min(1).max(100).default(20),
+});
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface PageLimitParams {
+  page:  number;
+  limit: number;
+}
+
+export interface CursorParams {
+  cursor?: string;
+  limit:   number;
+}
+
+export interface PaginatedResponse<T> {
+  data:       T[];
+  pagination: PageMeta | CursorMeta;
+}
+
+export interface PageMeta {
+  total:    number;
+  page:     number;
+  limit:    number;
+  pages:    number;
+  hasNext:  boolean;
+  hasPrev:  boolean;
+  links: {
+    self:  string;
+    next:  string | null;
+    prev:  string | null;
+    first: string;
+    last:  string;
+  };
+}
+
+export interface CursorMeta {
+  limit:      number;
+  hasNext:    boolean;
+  nextCursor: string | null;
+  links: {
+    self: string;
+    next: string | null;
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse and validate page/limit query params from a request.
+ * Falls back to defaults on invalid input.
+ */
+export function parsePageLimit(req: Request): PageLimitParams {
+  const result = pageLimitSchema.safeParse(req.query);
+  return result.success ? result.data : { page: 1, limit: 20 };
+}
+
+/**
+ * Parse and validate cursor query params from a request.
+ */
+export function parseCursor(req: Request): CursorParams {
+  const result = cursorSchema.safeParse(req.query);
+  return result.success ? result.data : { limit: 20 };
+}
+
+/**
+ * Build Prisma skip/take args from page/limit params.
+ */
+export function toSkipTake(params: PageLimitParams): { skip: number; take: number } {
+  return {
+    skip: (params.page - 1) * params.limit,
+    take: params.limit,
+  };
+}
+
+/**
+ * Build Prisma cursor/take args from cursor params.
+ * Fetches limit+1 to detect if there's a next page.
+ */
+export function toCursorArgs(params: CursorParams): { cursor?: { id: string }; take: number; skip?: number } {
+  return {
+    ...(params.cursor ? { cursor: { id: params.cursor }, skip: 1 } : {}),
+    take: params.limit + 1, // fetch one extra to detect next page
+  };
+}
+
+/**
+ * Build the base URL for pagination links (path + non-pagination query params).
+ */
+function buildBaseUrl(req: Request): string {
+  const { page: _p, limit: _l, cursor: _c, ...rest } = req.query as Record<string, string>;
+  const base = req.baseUrl + req.path;
+  const qs = new URLSearchParams(rest).toString();
+  return qs ? `${base}?${qs}&` : `${base}?`;
+}
+
+/**
+ * Build a paginated response with page/limit metadata and navigation links.
+ */
+export function buildPageResponse<T>(
+  req: Request,
+  data: T[],
+  total: number,
+  params: PageLimitParams,
+): PaginatedResponse<T> {
+  const pages   = Math.ceil(total / params.limit) || 1;
+  const hasNext = params.page < pages;
+  const hasPrev = params.page > 1;
+  const base    = buildBaseUrl(req);
+
+  return {
+    data,
+    pagination: {
+      total,
+      page:    params.page,
+      limit:   params.limit,
+      pages,
+      hasNext,
+      hasPrev,
+      links: {
+        self:  `${base}page=${params.page}&limit=${params.limit}`,
+        next:  hasNext ? `${base}page=${params.page + 1}&limit=${params.limit}` : null,
+        prev:  hasPrev ? `${base}page=${params.page - 1}&limit=${params.limit}` : null,
+        first: `${base}page=1&limit=${params.limit}`,
+        last:  `${base}page=${pages}&limit=${params.limit}`,
+      },
+    },
+  };
+}
+
+/**
+ * Build a cursor-paginated response.
+ * Pass the raw items fetched with toCursorArgs (limit+1 items).
+ * The extra item is used to detect hasNext and is stripped from the response.
+ */
+export function buildCursorResponse<T extends { id: string }>(
+  req: Request,
+  rawItems: T[],
+  params: CursorParams,
+): PaginatedResponse<T> {
+  const hasNext    = rawItems.length > params.limit;
+  const data       = hasNext ? rawItems.slice(0, params.limit) : rawItems;
+  const nextCursor = hasNext ? data[data.length - 1].id : null;
+  const base       = buildBaseUrl(req);
+
+  return {
+    data,
+    pagination: {
+      limit:      params.limit,
+      hasNext,
+      nextCursor,
+      links: {
+        self: `${base}limit=${params.limit}${params.cursor ? `&cursor=${params.cursor}` : ''}`,
+        next: nextCursor ? `${base}limit=${params.limit}&cursor=${nextCursor}` : null,
+      },
+    },
+  };
+}


### PR DESCRIPTION
- Add src/utils/pagination.ts with page/limit and cursor-based helpers
- Zod-validated query params with safe defaults (page=1, limit=20, max=100)
- buildPageResponse: wraps data with total, pages, hasNext/hasPrev, nav links
- buildCursorResponse: cursor pagination with nextCursor and nav links
- toSkipTake / toCursorArgs: Prisma query arg builders

Updated list endpoints:
- GET /api/webhooks — page/limit pagination
- GET /api/webhooks/:id/deliveries — replaced hardcoded take:50
- GET /api/organizations — page/limit pagination
- GET /api/listings/search — page/limit pagination (service updated)
- GET /api/audit and /api/audit/me — page/limit pagination

Closes #246 