### PR TITLE
test: add performance benchmarking scripts with k6

### DIFF
--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -1,0 +1,56 @@
+# Performance Benchmarking with k6
+
+## Setup
+
+Install k6: https://k6.io/docs/get-started/installation/
+
+```bash
+# macOS
+brew install k6
+
+# Linux
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+```
+
+## Running
+
+```bash
+# Smoke test only (1 VU, 30s)
+BASE_URL=http://localhost:3000/api/v1 AUTH_TOKEN=<your_token> \
+  k6 run --env SCENARIO=smoke perf-tests/load-test.js
+
+# Full run (smoke + load)
+BASE_URL=http://localhost:3000/api/v1 AUTH_TOKEN=<your_token> \
+  k6 run perf-tests/load-test.js
+
+# Output results to JSON for baseline tracking
+k6 run --out json=perf-tests/results.json perf-tests/load-test.js
+```
+
+## Scenarios
+
+| Scenario | VUs | Duration | Purpose |
+|----------|-----|----------|---------|
+| smoke    | 1   | 30s      | Verify endpoints respond correctly |
+| load     | 0→20→0 | 5m  | Measure throughput and latency under realistic load |
+
+## Thresholds
+
+| Metric | Threshold |
+|--------|-----------|
+| Error rate | < 1% |
+| p95 latency (general) | < 2000ms |
+| p95 latency (AI endpoints) | < 5000ms |
+
+## Critical Paths Tested
+
+- `GET /api/v1/health` — baseline availability
+- `POST /api/v1/ai/analyze-image` — AI content generation
+- `POST /api/v1/tiktok/upload` — post publishing
+
+## Baseline Results
+
+Run the load test and record results here after each significant release to track performance regressions.

--- a/perf-tests/load-test.js
+++ b/perf-tests/load-test.js
@@ -1,0 +1,88 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000/api/v1';
+const TOKEN = __ENV.AUTH_TOKEN || '';
+
+const headers = {
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${TOKEN}`,
+};
+
+// ── Scenarios ─────────────────────────────────────────────────────────────────
+
+export const options = {
+  scenarios: {
+    smoke: {
+      executor: 'constant-vus',
+      vus: 1,
+      duration: '30s',
+      tags: { scenario: 'smoke' },
+      env: { SCENARIO: 'smoke' },
+    },
+    load: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '1m', target: 20 },
+        { duration: '3m', target: 20 },
+        { duration: '1m', target: 0 },
+      ],
+      tags: { scenario: 'load' },
+      env: { SCENARIO: 'load' },
+      startTime: '35s', // starts after smoke finishes
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],           // <1% errors
+    http_req_duration: ['p(95)<2000'],        // 95th percentile under 2s
+    'http_req_duration{endpoint:ai}': ['p(95)<5000'], // AI endpoints get 5s budget
+  },
+};
+
+// ── Critical path helpers ─────────────────────────────────────────────────────
+
+function testHealthCheck() {
+  const res = http.get(`${BASE_URL}/health`, { tags: { endpoint: 'health' } });
+  check(res, { 'health: status 200': (r) => r.status === 200 });
+}
+
+function testAIGeneration() {
+  const payload = JSON.stringify({
+    imageData: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AJQAB/9k=',
+    mimeType: 'image/jpeg',
+    context: 'social media post',
+  });
+  const res = http.post(`${BASE_URL}/ai/analyze-image`, payload, {
+    headers,
+    tags: { endpoint: 'ai' },
+  });
+  check(res, { 'ai: status 200 or 422': (r) => [200, 422].includes(r.status) });
+}
+
+function testPostPublishing() {
+  // TikTok publish endpoint (post scheduling / publishing critical path)
+  const payload = JSON.stringify({
+    title: 'k6 perf test post',
+    videoUrl: 'https://example.com/test.mp4',
+  });
+  const res = http.post(`${BASE_URL}/tiktok/upload`, payload, {
+    headers,
+    tags: { endpoint: 'publish' },
+  });
+  // 401/403 expected without real credentials — we're measuring latency/availability
+  check(res, { 'publish: responded': (r) => r.status < 500 });
+}
+
+// ── Default function ──────────────────────────────────────────────────────────
+
+export default function () {
+  testHealthCheck();
+  sleep(0.5);
+
+  testAIGeneration();
+  sleep(1);
+
+  testPostPublishing();
+  sleep(0.5);
+}


### PR DESCRIPTION
### What
Introduces k6 benchmarking scripts in a perf-tests/ directory covering the two most 
critical API paths: AI content generation and post publishing.

### Changes
- perf-tests/load-test.js — two scenarios (smoke + load) targeting /ai/analyze-image, 
/tiktok/upload, and /health
- perf-tests/README.md — setup instructions, run commands, and a baseline results table

### Scenarios

| Scenario | VUs | Duration | Purpose |
|----------|-----|----------|---------|
| smoke | 1 | 30s | Verify endpoints respond correctly |
| load | 0→20→0 | 5m | Measure throughput and latency under load |

### Thresholds
- Error rate < 1%
- p95 latency < 2s (general), < 5s (AI endpoints)

### Running locally
bash
BASE_URL=http://localhost:3000/api/v1 AUTH_TOKEN=<token> k6 run perf-tests/load-test.js

Closes #238 