### PR TITLE
perf: implement Redis caching for high-traffic API routes

### DIFF
--- a/backend/src/controllers/organization.ts
+++ b/backend/src/controllers/organization.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { prisma } from '../lib/prisma';
 import { AuthRequest } from '../middleware/authMiddleware';
 import { parsePageLimit, toSkipTake, buildPageResponse } from '../utils/pagination';
+import { withCache, invalidateCache, invalidateCachePattern, CacheTTL } from '../utils/cache';
 
 /** POST /api/organizations — create a new org, caller becomes owner */
 export async function createOrganization(req: AuthRequest, res: Response): Promise<void> {
@@ -26,42 +27,52 @@ export async function createOrganization(req: AuthRequest, res: Response): Promi
     include: { members: true },
   });
 
+  // Invalidate the caller's org list cache
+  await invalidateCachePattern(`org-list:${req.userId!}:*`);
+
   res.status(201).json(org);
 }
 
 /** GET /api/organizations — list orgs the caller belongs to */
 export async function listOrganizations(req: AuthRequest, res: Response): Promise<void> {
   const params = parsePageLimit(req);
-  const where = { userId: req.userId! };
+  const userId = req.userId!;
+  const cacheKey = `org-list:${userId}:${params.page}:${params.limit}`;
 
-  const [total, memberships] = await Promise.all([
-    prisma.organizationMember.count({ where }),
-    prisma.organizationMember.findMany({
-      where,
-      include: { organization: true },
-      ...toSkipTake(params),
-    }),
-  ]);
+  const result = await withCache(cacheKey, CacheTTL.ORG_LIST, async () => {
+    const where = { userId };
+    const [total, memberships] = await Promise.all([
+      prisma.organizationMember.count({ where }),
+      prisma.organizationMember.findMany({
+        where,
+        include: { organization: true },
+        ...toSkipTake(params),
+      }),
+    ]);
+    const data = memberships.map((m: (typeof memberships)[number]) => ({
+      ...m.organization,
+      role: m.role,
+    }));
+    return buildPageResponse(req, data, total, params);
+  });
 
-  const data = memberships.map((m: (typeof memberships)[number]) => ({
-    ...m.organization,
-    role: m.role,
-  }));
-  res.json(buildPageResponse(req, data, total, params));
+  res.json(result);
 }
 
 /** GET /api/organizations/:orgId — get a single org (must be a member) */
 export async function getOrganization(req: AuthRequest, res: Response): Promise<void> {
   const { orgId } = req.params;
 
-  const membership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
-    include: {
-      organization: {
-        include: { members: { include: { user: { select: { id: true, email: true } } } } },
+  const membership = await withCache(`org:${orgId}:${req.userId}`, CacheTTL.ORG, () =>
+    prisma.organizationMember.findUnique({
+      where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+      include: {
+        organization: {
+          include: { members: { include: { user: { select: { id: true, email: true } } } } },
+        },
       },
-    },
-  });
+    }),
+  );
 
   if (!membership) {
     res.status(404).json({ message: 'Organization not found' });
@@ -89,6 +100,12 @@ export async function addMember(req: AuthRequest, res: Response): Promise<void> 
     data: { id: randomUUID(), organizationId: orgId, userId, role },
   });
 
+  // Invalidate org cache for all affected users
+  await Promise.all([
+    invalidateCachePattern(`org:${orgId}:*`),
+    invalidateCachePattern(`org-list:${userId}:*`),
+  ]);
+
   res.status(201).json(member);
 }
 
@@ -107,6 +124,12 @@ export async function removeMember(req: AuthRequest, res: Response): Promise<voi
   await prisma.organizationMember.delete({
     where: { organizationId_userId: { organizationId: orgId, userId } },
   });
+
+  // Invalidate org cache for the removed user and the org itself
+  await Promise.all([
+    invalidateCachePattern(`org:${orgId}:*`),
+    invalidateCachePattern(`org-list:${userId}:*`),
+  ]);
 
   res.status(204).send();
 }

--- a/backend/src/repositories/UserRepository.ts
+++ b/backend/src/repositories/UserRepository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, User, Prisma } from '@prisma/client';
 import { prisma as defaultPrisma } from '../lib/prisma';
+import { withCache, invalidateCache, CacheTTL } from '../utils/cache';
 
 export type CreateUserInput = Prisma.UserCreateInput;
 export type UpdateUserInput = Prisma.UserUpdateInput;
@@ -18,7 +19,9 @@ export class UserRepository {
    * Returns null when no matching record exists.
    */
   async findById(id: string): Promise<User | null> {
-    return this.db.user.findUnique({ where: { id } });
+    return withCache(`user:${id}`, CacheTTL.USER_PROFILE, () =>
+      this.db.user.findUnique({ where: { id } }),
+    );
   }
 
   /**
@@ -43,7 +46,9 @@ export class UserRepository {
    */
   async update(id: string, data: UpdateUserInput): Promise<User | null> {
     try {
-      return await this.db.user.update({ where: { id }, data });
+      const user = await this.db.user.update({ where: { id }, data });
+      await invalidateCache(`user:${id}`);
+      return user;
     } catch (err) {
       // P2025 — record not found
       if ((err as any)?.code === 'P2025') return null;
@@ -57,7 +62,9 @@ export class UserRepository {
    */
   async delete(id: string): Promise<User | null> {
     try {
-      return await this.db.user.delete({ where: { id } });
+      const user = await this.db.user.delete({ where: { id } });
+      await invalidateCache(`user:${id}`);
+      return user;
     } catch (err) {
       if ((err as any)?.code === 'P2025') return null;
       throw err;

--- a/backend/src/utils/cache.ts
+++ b/backend/src/utils/cache.ts
@@ -1,0 +1,73 @@
+import Redis from 'ioredis';
+import { getRedisConnection } from '../config/runtime';
+
+const CACHE_PREFIX = 'cache:';
+
+let _redis: Redis | null = null;
+
+function getRedis(): Redis {
+  if (!_redis) {
+    _redis = new Redis(getRedisConnection());
+  }
+  return _redis;
+}
+
+/**
+ * Cache-Aside helper.
+ * On miss: calls `fetcher`, stores the result with TTL, then returns it.
+ */
+export async function withCache<T>(
+  key: string,
+  ttlSeconds: number,
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  const redis = getRedis();
+  const cacheKey = `${CACHE_PREFIX}${key}`;
+
+  const cached = await redis.get(cacheKey);
+  if (cached !== null) {
+    return JSON.parse(cached) as T;
+  }
+
+  const value = await fetcher();
+  if (value !== null && value !== undefined) {
+    await redis.set(cacheKey, JSON.stringify(value), 'EX', ttlSeconds);
+  }
+  return value;
+}
+
+/** Delete one or more cache keys. Supports glob patterns via SCAN. */
+export async function invalidateCache(...keys: string[]): Promise<void> {
+  const redis = getRedis();
+  const pipeline = redis.pipeline();
+  for (const key of keys) {
+    pipeline.del(`${CACHE_PREFIX}${key}`);
+  }
+  await pipeline.exec();
+}
+
+/** Delete all cache keys matching a pattern (e.g. "org:*"). */
+export async function invalidateCachePattern(pattern: string): Promise<void> {
+  const redis = getRedis();
+  const fullPattern = `${CACHE_PREFIX}${pattern}`;
+  let cursor = '0';
+  const keys: string[] = [];
+
+  do {
+    const [next, batch] = await redis.scan(cursor, 'MATCH', fullPattern, 'COUNT', 100);
+    cursor = next;
+    keys.push(...batch);
+  } while (cursor !== '0');
+
+  if (keys.length > 0) {
+    await redis.unlink(...keys);
+  }
+}
+
+export const CacheTTL = {
+  USER_PROFILE: 300,      // 5 minutes
+  ORG: 300,               // 5 minutes
+  ORG_LIST: 120,          // 2 minutes
+  ANALYTICS: 60,          // 1 minute
+  FEED: 30,               // 30 seconds
+} as const;


### PR DESCRIPTION

Title: perf: implement Redis caching for high-traffic API routes

Body:

## Overview
Implements a Cache-Aside caching strategy using Redis (ioredis) to significantly reduce database load on frequently accessed endpoints.

## Changes

### New: `backend/src/utils/cache.ts`
- `withCache(key, ttl, fetcher)` — Cache-Aside pattern; serves from Redis on hit, fetches from DB on miss and stores result with TTL
- `invalidateCache(...keys)` — pipeline-based deletion for known keys
- `invalidateCachePattern(pattern)` — SCAN + UNLINK for wildcard invalidation
- `CacheTTL` — centralized TTL constants

### Modified: `backend/src/repositories/UserRepository.ts`
- `findById` — cached with 5-minute TTL
- `update` / `delete` — invalidate user cache on write

### Modified: `backend/src/controllers/organization.ts`
- `getOrganization` — cached per org+user (5-minute TTL)
- `listOrganizations` — cached per user+page (2-minute TTL)
- `createOrganization`, `addMember`, `removeMember` — invalidate affected cache keys on mutation

## Cache Key Design
| Key pattern | TTL | Invalidated on |
|---|---|---|
| `cache:user:{id}` | 5m | update, delete |
| `cache:org:{orgId}:{userId}` | 5m | addMember, removeMember |
| `cache:org-list:{userId}:*` | 2m | createOrg, addMember, removeMember |

## Notes
- No new dependencies — uses existing `ioredis` and `getRedisConnection()`
- All keys prefixed with `cache:` to avoid collisions with BullMQ, JWT blacklist, and Redlock
- `null` results are never cached to avoid stale "not found" responses
- Pattern invalidation uses non-blocking `UNLINK` instead of `DEL`

closes #226