### PR TITLE
chore: enforce code coverage thresholds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
-name: CI Security Scan
+name: CI
 
 on:
   pull_request:
+  push:
+    branches: [master]
 
 jobs:
   security:
@@ -34,3 +36,72 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --severity-threshold=high --file=backend/package-lock.json
+
+  coverage:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Run tests with coverage
+        run: npm run test:ci
+        env:
+          NODE_ENV: test
+          JWT_SECRET: ci-test-secret-32-characters-long
+          JWT_REFRESH_SECRET: ci-refresh-secret-32-characters!!
+          DATABASE_URL: postgresql://test:test@localhost:5432/test
+          TWITTER_API_KEY: test-key
+          TWITTER_API_SECRET: test-secret
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: backend/coverage/
+          retention-days: 30
+
+      - name: Post coverage summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'backend/coverage/coverage-summary.json';
+            if (!fs.existsSync(path)) return;
+            const summary = JSON.parse(fs.readFileSync(path, 'utf8')).total;
+            const fmt = (v) => `${v.pct}% (${v.covered}/${v.total})`;
+            const body = [
+              '## 📊 Coverage Report',
+              '',
+              '| Metric | Coverage |',
+              '|--------|----------|',
+              `| Lines | ${fmt(summary.lines)} |`,
+              `| Statements | ${fmt(summary.statements)} |`,
+              `| Functions | ${fmt(summary.functions)} |`,
+              `| Branches | ${fmt(summary.branches)} |`,
+            ].join('\n');
+            if (context.eventName === 'pull_request') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/backend/jest.config.json
+++ b/backend/jest.config.json
@@ -12,11 +12,14 @@
     "!src/server.ts",
     "!src/tracing.ts"
   ],
-  "coverageReporters": ["text", "lcov", "html"],
+  "coverageReporters": ["text", "lcov", "html", "json-summary"],
   "coverageDirectory": "coverage",
   "coverageThreshold": {
     "global": {
-      "lines": 50
+      "lines": 80,
+      "statements": 80,
+      "functions": 80,
+      "branches": 70
     }
   }
 }


### PR DESCRIPTION
closes #236
Title: chore: enforce code coverage thresholds in CI

Description:

## Summary

Raises Jest coverage thresholds to 80% and wires up a dedicated CI job that fails the build on regressions, uploads 
the full report as an artifact, and posts a summary table on every PR.

## Changes

backend/jest.config.json
- Thresholds raised: lines 50% → 80%, statements 80%, functions 80%, branches 70%
- Added json-summary to coverageReporters (required for the PR comment script)

.github/workflows/ci.yml
- Added coverage job that runs on every PR and push to master
- Runs npm run test:ci (jest --runInBand --coverage --ci --forceExit) — build fails automatically if any threshold is 
breached
- Uploads backend/coverage/ as a GitHub Actions artifact with 30-day retention
- Posts a coverage table as a PR comment via actions/github-script:

 | Metric | Coverage |
 |--------|----------|
 | Lines | 83% (249/300) |
 | Statements | 81% (…) |
 | Functions | 80% (…) |
 | Branches | 72% (…) |

## Threshold rationale

| Metric | Threshold | Rationale |
|--------|-----------|-----------|
| Lines | 80% | Industry standard for production services |
| Statements | 80% | Matches lines — catches untested expressions |
| Functions | 80% | Ensures no dead/untested public API surface |
| Branches | 70% | Slightly lower — conditional