### PR TITLE
infra: add Prometheus metrics and Grafana dashboard support

### DIFF
--- a/backend/elk/grafana/provisioning/dashboards/nodejs-dashboard.json
+++ b/backend/elk/grafana/provisioning/dashboards/nodejs-dashboard.json
@@ -1,0 +1,175 @@
+{
+  "uid": "socialflow-nodejs",
+  "title": "SocialFlow — Node.js Runtime",
+  "tags": ["nodejs", "performance", "memory"],
+  "schemaVersion": 38,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "gauge",
+      "title": "Event Loop Lag (ms)",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 6 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "nodejs_event_loop_lag_ms", "legendFormat": "lag" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "max": 500,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "gauge",
+      "title": "Heap Usage %",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 6 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "nodejs_heap_size_used_bytes / nodejs_heap_size_total_bytes * 100",
+          "legendFormat": "heap %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "RSS Memory",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 3 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "process_resident_memory_bytes", "legendFormat": "RSS" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "External Memory",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 3 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "nodejs_external_memory_bytes", "legendFormat": "external" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Active Handles",
+      "gridPos": { "x": 12, "y": 3, "w": 6, "h": 3 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "nodejs_active_handles_total", "legendFormat": "handles" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Active Requests",
+      "gridPos": { "x": 18, "y": 3, "w": 6, "h": 3 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "nodejs_active_requests_total", "legendFormat": "requests" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Heap Used vs Total (bytes)",
+      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "nodejs_heap_size_used_bytes", "legendFormat": "used" },
+        { "expr": "nodejs_heap_size_total_bytes", "legendFormat": "total" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Event Loop Lag over Time (ms)",
+      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "nodejs_event_loop_lag_ms", "legendFormat": "lag" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "custom": { "thresholdsStyle": { "mode": "line" } }
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "GC Duration (s/s) by Kind",
+      "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(nodejs_gc_duration_seconds_sum[5m])",
+          "legendFormat": "{{ kind }}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "CPU Usage (process)",
+      "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[1m])",
+          "legendFormat": "cpu"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit" } }
+    }
+  ]
+}

--- a/backend/elk/prometheus/alerts.yml
+++ b/backend/elk/prometheus/alerts.yml
@@ -120,3 +120,44 @@ groups:
         annotations:
           summary: "High SLI breach rate for {{ $labels.category }}"
           description: "{{ $value | humanize }} breaches/s in category {{ $labels.category }}."
+
+  - name: nodejs_runtime
+    interval: 30s
+    rules:
+      - alert: EventLoopLagHigh
+        expr: nodejs_event_loop_lag_ms > 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Node.js event loop lag > 100ms"
+          description: "Event loop lag is {{ $value | humanize }}ms — the process may be CPU-bound."
+
+      - alert: EventLoopLagCritical
+        expr: nodejs_event_loop_lag_ms > 500
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Node.js event loop lag > 500ms"
+          description: "Event loop lag is {{ $value | humanize }}ms — requests are likely timing out."
+
+      - alert: HeapUsageHigh
+        expr: |
+          nodejs_heap_size_used_bytes / nodejs_heap_size_total_bytes > 0.85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Node.js heap usage > 85%"
+          description: "Heap is {{ $value | humanizePercentage }} full — risk of OOM."
+
+      - alert: HeapUsageCritical
+        expr: |
+          nodejs_heap_size_used_bytes / nodejs_heap_size_total_bytes > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Node.js heap usage > 95%"
+          description: "Heap is {{ $value | humanizePercentage }} full — OOM imminent."

--- a/backend/elk/prometheus/prometheus.yml
+++ b/backend/elk/prometheus/prometheus.yml
@@ -9,5 +9,5 @@ scrape_configs:
   - job_name: socialflow-backend
     static_configs:
       - targets:
-          - host.docker.internal:3000
+          - host.docker.internal:3001
     metrics_path: /metrics

--- a/backend/src/lib/metrics.ts
+++ b/backend/src/lib/metrics.ts
@@ -1,8 +1,28 @@
-import { Registry, Histogram, Counter, collectDefaultMetrics } from 'prom-client';
+import { Registry, Histogram, Counter, Gauge, collectDefaultMetrics } from 'prom-client';
 
 export const register = new Registry();
 
 collectDefaultMetrics({ register });
+
+/**
+ * Event loop lag gauge — sampled every 500 ms.
+ * Measures the delta between when a setTimeout(fn, 0) was scheduled and when it fired.
+ * High values (>100 ms) indicate the event loop is blocked.
+ */
+export const eventLoopLag = new Gauge({
+  name: 'nodejs_event_loop_lag_ms',
+  help: 'Current event loop lag in milliseconds',
+  registers: [register],
+});
+
+(function sampleEventLoopLag() {
+  const interval = setInterval(() => {
+    const start = Date.now();
+    setImmediate(() => eventLoopLag.set(Date.now() - start));
+  }, 500);
+  // Allow the process to exit cleanly even if this timer is still running
+  interval.unref();
+})();
 
 /**
  * SLI buckets (ms) covering health (<200ms p95), general (<500ms p95), AI (<2s p95).


### PR DESCRIPTION
Instrumentation (backend/src/lib/metrics.ts)
- Add nodejs_event_loop_lag_ms Gauge, sampled every 500ms via setImmediate delta — high values (>100ms) indicate a blocked event loop
- prom-client collectDefaultMetrics already covers heap, RSS, GC duration, CPU seconds, active handles/requests; no extra dependencies needed
- /metrics endpoint was already wired in app.ts → routes/metrics.ts

Prometheus (backend/elk/prometheus/)
- prometheus.yml: fix scrape target port 3000 → 3001 (matches BACKEND_PORT)
- alerts.yml: add nodejs_runtime alert group with four new rules:
    • EventLoopLagHigh    — lag > 100ms for 2m  (warning)
    • EventLoopLagCritical — lag > 500ms for 1m  (critical)
    • HeapUsageHigh       — heap > 85% for 5m   (warning)
    • HeapUsageCritical   — heap > 95% for 2m   (critical)
  Existing SLI latency alerts (p95/p99 per category) are unchanged

Grafana (backend/elk/grafana/provisioning/dashboards/)
- nodejs-dashboard.json: new auto-provisioned dashboard uid=socialflow-nodejs Panels: • Event Loop Lag gauge  (green/yellow@100ms/red@500ms)
    • Heap Usage % gauge    (green/yellow@75%/red@90%)
    • RSS Memory stat
    • External Memory stat
    • Active Handles stat
    • Active Requests stat
    • Heap Used vs Total timeseries
    • Event Loop Lag timeseries with threshold lines
    • GC Duration by kind timeseries
    • CPU Usage timeseries
- sli-dashboard.json: existing SLI dashboard unchanged (p95/p99 latency,
  breach rate, throughput, error rate)
- Grafana auto-provisions both dashboards on startup via provider.yml

Closes #244