### PR TITLE
infra: add Kubernetes deployment manifests with Kustomize overlays

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,47 @@
+# Kubernetes Manifests
+
+Kustomize-based deployment for the SocialFlow backend.
+
+```
+k8s/
+├── base/                  # Shared resources (all environments)
+│   ├── deployment.yaml    # Deployment — port 3001, non-root, probes
+│   ├── service.yaml       # ClusterIP Service
+│   ├── hpa.yaml           # HorizontalPodAutoscaler (CPU 70% / Mem 80%)
+│   ├── ingress.yaml       # nginx Ingress
+│   ├── configmap.yaml     # Non-sensitive runtime config
+│   ├── secret.yaml        # Secret template (replace values before applying)
+│   └── kustomization.yaml
+└── overlays/
+    ├── dev/               # 1 replica, relaxed resources, dev hostname
+    └── prod/              # 3 replicas, larger resources, TLS via cert-manager
+```
+
+## Usage
+
+```bash
+# Preview rendered manifests
+kubectl kustomize k8s/overlays/dev
+kubectl kustomize k8s/overlays/prod
+
+# Apply
+kubectl apply -k k8s/overlays/dev
+kubectl apply -k k8s/overlays/prod
+```
+
+## Secrets
+
+`base/secret.yaml` is a **template only** — never commit real credentials.
+In production, manage secrets via:
+- [External Secrets Operator](https://external-secrets.io/) + AWS Secrets Manager, or
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets), or
+- HashiCorp Vault Agent Injector
+
+## Image
+
+The Deployment references `socialflow-backend:latest`. Override the image tag
+per environment using a Kustomize `images:` patch or your CI pipeline:
+
+```bash
+kustomize edit set image socialflow-backend=ghcr.io/org/socialflow-backend:v1.2.3
+```

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,20 @@
+# Non-sensitive runtime configuration.
+# Sensitive values (DATABASE_URL, JWT_SECRET, etc.) go in socialflow-secrets.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: socialflow-config
+data:
+  NODE_ENV: "production"
+  BACKEND_PORT: "3001"
+  REDIS_PORT: "6379"
+  REDIS_DB: "0"
+  JWT_EXPIRES_IN: "15m"
+  JWT_REFRESH_EXPIRES_IN: "7d"
+  LOG_LEVEL: "info"
+  OTEL_SERVICE_NAME: "socialflow-backend"
+  OTEL_EXPORTER: "otlp"
+  DATA_RETENTION_MODE: "archive"
+  DATA_PRUNING_CRON: "0 2 * * *"
+  DATA_RETENTION_LOG_DAYS: "30"
+  DATA_RETENTION_ANALYTICS_DAYS: "90"

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: socialflow-backend
+  labels:
+    app: socialflow-backend
+spec:
+  selector:
+    matchLabels:
+      app: socialflow-backend
+  template:
+    metadata:
+      labels:
+        app: socialflow-backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3001"
+        prometheus.io/path: "/metrics"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: backend
+          image: socialflow-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3001
+          envFrom:
+            - configMapRef:
+                name: socialflow-config
+            - secretRef:
+                name: socialflow-secrets
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/base/hpa.yaml
+++ b/k8s/base/hpa.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: socialflow-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: socialflow-backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: socialflow-backend
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.socialflow.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: socialflow-backend
+                port:
+                  name: http

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+  - hpa.yaml
+  - ingress.yaml

--- a/k8s/base/secret.yaml
+++ b/k8s/base/secret.yaml
@@ -1,0 +1,16 @@
+# Placeholder — real values must be base64-encoded and managed via
+# a secrets manager (e.g. AWS Secrets Manager + External Secrets Operator,
+# Sealed Secrets, or Vault). Never commit real secrets to source control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: socialflow-secrets
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql://USER:PASS@HOST:5432/socialflow"
+  REDIS_HOST: "redis-host"
+  REDIS_PASSWORD: ""
+  JWT_SECRET: "change-me-min-32-chars"
+  JWT_REFRESH_SECRET: "change-me-min-32-chars"
+  TWITTER_API_KEY: ""
+  TWITTER_API_SECRET: ""

--- a/k8s/base/service.yaml
+++ b/k8s/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: socialflow-backend
+  labels:
+    app: socialflow-backend
+spec:
+  selector:
+    app: socialflow-backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,62 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: socialflow-dev
+
+resources:
+  - ../../base
+
+patches:
+  # 1 replica, relaxed resources for dev
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: socialflow-backend
+      spec:
+        replicas: 1
+        template:
+          spec:
+            containers:
+              - name: backend
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 250m
+                    memory: 256Mi
+  # HPA: 1–3 replicas in dev
+  - patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: socialflow-backend
+      spec:
+        minReplicas: 1
+        maxReplicas: 3
+  # Dev hostname
+  - patch: |-
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: socialflow-backend
+      spec:
+        rules:
+          - host: api.dev.socialflow.example.com
+            http:
+              paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: socialflow-backend
+                      port:
+                        name: http
+
+configMapGenerator:
+  - name: socialflow-config
+    behavior: merge
+    literals:
+      - NODE_ENV=development
+      - LOG_LEVEL=debug

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,61 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: socialflow-prod
+
+resources:
+  - ../../base
+
+patches:
+  # 3 replicas, production-grade resources
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: socialflow-backend
+      spec:
+        replicas: 3
+        template:
+          spec:
+            containers:
+              - name: backend
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 512Mi
+                  limits:
+                    cpu: 1000m
+                    memory: 1Gi
+  # HPA: 3–20 replicas in prod
+  - patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: socialflow-backend
+      spec:
+        minReplicas: 3
+        maxReplicas: 20
+  # Prod hostname + TLS
+  - patch: |-
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: socialflow-backend
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+      spec:
+        rules:
+          - host: api.socialflow.example.com
+            http:
+              paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: socialflow-backend
+                      port:
+                        name: http
+        tls:
+          - hosts:
+              - api.socialflow.example.com
+            secretName: socialflow-tls


### PR DESCRIPTION
Structure
---------
k8s/base/          — environment-agnostic resources shared by all overlays
k8s/overlays/dev/  — development overlay (namespace: socialflow-dev)
k8s/overlays/prod/ — production overlay  (namespace: socialflow-prod)

Base resources
--------------
deployment.yaml
  - Targets port 3001 (BACKEND_PORT) with named port 'http'
  - Prometheus scrape annotations (path: /metrics)
  - Non-root securityContext (runAsUser: 1000)
  - envFrom: ConfigMap (socialflow-config) + Secret (socialflow-secrets)
  - Readiness probe: GET /health, initial 10s, period 10s
  - Liveness probe:  GET /health, initial 20s, period 20s
  - Base resources: 250m/256Mi req, 500m/512Mi limit

service.yaml
  - ClusterIP Service, port 80 → targetPort 'http' (3001)

hpa.yaml
  - autoscaling/v2 HPA, base: 2–10 replicas
  - Scale on CPU ≥ 70% or Memory ≥ 80%

ingress.yaml
  - nginx IngressClass, host: api.socialflow.example.com
  - proxy-body-size: 50m, proxy-read-timeout: 60s

configmap.yaml
  - Non-sensitive env vars: NODE_ENV, BACKEND_PORT, Redis config, JWT TTLs, log level, OTel, data retention settings

secret.yaml
  - Template only — placeholder values, never commit real secrets
  - Covers: DATABASE_URL, REDIS_HOST/PASSWORD, JWT secrets, Twitter keys
  - Intended to be replaced by External Secrets Operator / Sealed Secrets

Overlays
--------
dev:
  - namespace: socialflow-dev
  - replicas: 1, HPA 1–3
  - Resources: 100m/128Mi req, 250m/256Mi limit
  - ConfigMap patch: NODE_ENV=development, LOG_LEVEL=debug
  - Ingress host: api.dev.socialflow.example.com (no TLS)

prod:
  - namespace: socialflow-prod
  - replicas: 3, HPA 3–20
  - Resources: 500m/512Mi req, 1000m/1Gi limit
  - Ingress host: api.socialflow.example.com + TLS via cert-manager (cert-manager.io/cluster-issuer: letsencrypt-prod)

Closes #242