### PR TITLE
feat: integrate Meilisearch for full-text search

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -93,3 +93,11 @@ REDIS_DB=0
 #   ai      : p95=2000ms p99=3000ms
 #   general : p95=500ms  p99=1000ms
 GRAFANA_ADMIN_PASSWORD=admin
+
+# ─── Meilisearch ──────────────────────────────────────────────────────────────
+# Run locally: docker run -p 7700:7700 getmeili/meilisearch
+MEILISEARCH_HOST=http://localhost:7700
+# Admin (master) key — used server-side only
+MEILISEARCH_ADMIN_KEY=
+# Search-only key — safe to expose to the frontend (generate in Meilisearch dashboard)
+MEILISEARCH_SEARCH_KEY=

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -37,6 +37,7 @@
         "ioredis": "^5.8.1",
         "ipaddr.js": "^2.3.0",
         "jsonwebtoken": "^9.0.3",
+        "meilisearch": "^0.56.0",
         "morgan": "^1.10.0",
         "prom-client": "^15.1.3",
         "rate-limit-redis": "^4.2.0",
@@ -10207,6 +10208,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/meilisearch": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.56.0.tgz",
+      "integrity": "sha512-kBXba8DcSrLWHYqopCm2JL90oBy97VdIfHkP1ii7/eHufeEEEk9Zu5Vv/IFQpNzmhEpWszVFVlGvZoI6QJeGzA==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "ioredis": "^5.8.1",
     "ipaddr.js": "^2.3.0",
     "jsonwebtoken": "^9.0.3",
+    "meilisearch": "^0.56.0",
     "morgan": "^1.10.0",
     "prom-client": "^15.1.3",
     "rate-limit-redis": "^4.2.0",

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -105,6 +105,11 @@ const envSchema = z.object({
 
   // ── Webhooks ──────────────────────────────────────────────────────────────
   HMAC_TIMESTAMP_TOLERANCE_MS: z.coerce.number().default(300000),
+
+  // ── Meilisearch ───────────────────────────────────────────────────────────
+  MEILISEARCH_HOST: z.string().default('http://localhost:7700'),
+  MEILISEARCH_ADMIN_KEY: z.string().optional(),
+  MEILISEARCH_SEARCH_KEY: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/backend/src/controllers/PostController.ts
+++ b/backend/src/controllers/PostController.ts
@@ -5,6 +5,7 @@ import { AuthRequest } from '../middleware/authMiddleware';
 import { ModerationService } from '../services/ModerationService';
 import { BadRequestError } from '../lib/errors';
 import { createLogger } from '../lib/logger';
+import { indexPost } from '../services/SearchService';
 
 const logger = createLogger('post-controller');
 
@@ -42,6 +43,16 @@ export async function createPost(req: AuthRequest, res: Response, next: NextFunc
         platform,
         scheduledAt: scheduledAt ? new Date(scheduledAt) : null,
       },
+    });
+
+    // Fire-and-forget — don't block the response on indexing
+    indexPost({
+      id: post.id,
+      organizationId: post.organizationId,
+      content: post.content,
+      platform: post.platform,
+      scheduledAt: post.scheduledAt?.toISOString() ?? null,
+      createdAt: post.createdAt.toISOString(),
     });
 
     res.status(201).json({

--- a/backend/src/lib/meilisearch.ts
+++ b/backend/src/lib/meilisearch.ts
@@ -1,0 +1,14 @@
+import { MeiliSearch } from 'meilisearch';
+import { config } from '../config/config';
+
+let _client: MeiliSearch | null = null;
+
+export function getMeiliClient(): MeiliSearch {
+  if (!_client) {
+    _client = new MeiliSearch({
+      host: config.MEILISEARCH_HOST,
+      apiKey: config.MEILISEARCH_ADMIN_KEY,
+    });
+  }
+  return _client;
+}

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -1,0 +1,34 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { authMiddleware } from '../middleware/authMiddleware';
+import { validate } from '../middleware/validate';
+import { searchPosts } from '../services/SearchService';
+import { config } from '../config/config';
+
+const router = Router();
+
+const searchQuerySchema = z.object({
+  q: z.string().min(1),
+  organizationId: z.string().uuid().optional(),
+  platform: z.enum(['twitter', 'linkedin', 'instagram', 'tiktok', 'facebook', 'youtube']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+/** GET /api/v1/search/posts — authenticated full-text search */
+router.get('/posts', authMiddleware, validate(searchQuerySchema, 'query'), async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { q, organizationId, platform, limit, offset } = req.query as unknown as z.infer<typeof searchQuerySchema>;
+    const results = await searchPosts(q, { organizationId, platform, limit, offset });
+    res.json(results);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** GET /api/v1/search/key — returns the public search-only API key for frontend use */
+router.get('/key', authMiddleware, (_req: Request, res: Response) => {
+  res.json({ searchKey: config.MEILISEARCH_SEARCH_KEY, host: config.MEILISEARCH_HOST });
+});
+
+export default router;

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -29,6 +29,7 @@ import webhookRoutes      from '../webhooks';
 import twitterWebhookRoutes from '../twitter-webhook';
 import youtubeRoutes      from '../youtube';
 import linkedInRoutes     from '../linkedin';
+import searchRoutes       from '../search';
 
 const router = Router();
 
@@ -77,5 +78,6 @@ router.use('/webhooks',      generalLimiter, webhookRoutes);
 router.use('/webhooks/twitter', twitterWebhookRoutes);
 router.use('/youtube',       generalLimiter, youtubeRoutes);
 router.use('/linkedin',      generalLimiter, linkedInRoutes);
+router.use('/search',        generalLimiter, searchRoutes);
 
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,6 +17,7 @@ import { createLogger } from './lib/logger';
 import { prisma } from './lib/prisma';
 import { Worker } from 'bullmq';
 import { Server } from 'http';
+import { initSearchIndex } from './services/SearchService';
 
 const logger = createLogger('server');
 const PORT = config.BACKEND_PORT;
@@ -275,6 +276,15 @@ const bootstrap = async (): Promise<void> => {
       logger.info('Twitter webhook worker started');
     } catch (error) {
       logger.error('Failed to start Twitter webhook worker', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Initialise Meilisearch index
+    try {
+      await initSearchIndex();
+    } catch (error) {
+      logger.error('Failed to initialise Meilisearch index', {
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/backend/src/services/SearchService.ts
+++ b/backend/src/services/SearchService.ts
@@ -1,0 +1,60 @@
+import { getMeiliClient } from '../lib/meilisearch';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('search-service');
+
+export const POSTS_INDEX = 'posts';
+
+export interface PostDocument {
+  id: string;
+  organizationId: string;
+  content: string;
+  platform: string;
+  scheduledAt: string | null;
+  createdAt: string;
+}
+
+/** Ensure the posts index exists with the correct settings. Call once at startup. */
+export async function initSearchIndex(): Promise<void> {
+  const client = getMeiliClient();
+  await client.createIndex(POSTS_INDEX, { primaryKey: 'id' });
+  const index = client.index(POSTS_INDEX);
+  await index.updateSettings({
+    searchableAttributes: ['content', 'platform'],
+    filterableAttributes: ['organizationId', 'platform', 'scheduledAt'],
+    sortableAttributes: ['createdAt', 'scheduledAt'],
+  });
+  logger.info('Meilisearch index initialised', { index: POSTS_INDEX });
+}
+
+/** Index (upsert) a single post document. */
+export async function indexPost(doc: PostDocument): Promise<void> {
+  try {
+    await getMeiliClient().index(POSTS_INDEX).addDocuments([doc]);
+  } catch (err) {
+    logger.error('Failed to index post', { id: doc.id, error: (err as Error).message });
+  }
+}
+
+/** Full-text search across posts with optional filters. */
+export async function searchPosts(
+  query: string,
+  opts: {
+    organizationId?: string;
+    platform?: string;
+    limit?: number;
+    offset?: number;
+  } = {},
+) {
+  const filter: string[] = [];
+  if (opts.organizationId) filter.push(`organizationId = "${opts.organizationId}"`);
+  if (opts.platform) filter.push(`platform = "${opts.platform}"`);
+
+  return getMeiliClient()
+    .index(POSTS_INDEX)
+    .search(query, {
+      filter: filter.length ? filter : undefined,
+      limit: opts.limit ?? 20,
+      offset: opts.offset ?? 0,
+    });
+}


### PR DESCRIPTION
Closes #225

---

## Summary
Integrates Meilisearch for fast, typo-tolerant full-text search across social media posts.

## Changes
- `backend/src/lib/meilisearch.ts` — lazy MeiliSearch client singleton
- `backend/src/services/SearchService.ts` — index init, post indexing, search helpers
- `backend/src/controllers/PostController.ts` — fire-and-forget `indexPost()` after post creation
- `backend/src/routes/search.ts` — `GET /api/v1/search/posts` (full-text + filters) and `GET /api/v1/search/key` (frontend search key)
- `backend/src/routes/v1/index.ts` — wires `/search` under `generalLimiter`
- `backend/src/server.ts` — calls `initSearchIndex()` at bootstrap (non-fatal)
- `backend/src/config/config.ts` + `backend/.env.example` — adds `MEILISEARCH_HOST`, `MEILISEARCH_ADMIN_KEY`, `MEILISEARCH_SEARCH_KEY`

## Local setup
```bash
docker run -p 7700:7700 getmeili/meilisearch
```
Then set the three `MEILISEARCH_*` vars in `.env`.