### PR TITLE
feat: add withTransaction utility for atomic Prisma operations

### DIFF
--- a/backend/src/lib/transaction.ts
+++ b/backend/src/lib/transaction.ts
@@ -1,0 +1,29 @@
+import { prisma } from '../lib/prisma';
+
+/**
+ * The transactional Prisma client passed into the callback.
+ * Use this instead of the global `prisma` inside the callback so all
+ * operations participate in the same transaction.
+ */
+export type TxClient = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
+
+/**
+ * Wraps a callback in a Prisma interactive transaction.
+ * All operations performed via the `tx` argument are atomic —
+ * any thrown error rolls back the entire transaction.
+ *
+ * @example
+ * const result = await withTransaction(async (tx) => {
+ *   const org = await tx.organization.create({ data: orgData });
+ *   const member = await tx.organizationMember.create({
+ *     data: { organizationId: org.id, userId, role: 'owner' },
+ *   });
+ *   return { org, member };
+ * });
+ */
+export async function withTransaction<T>(
+  callback: (tx: TxClient) => Promise<T>,
+  options?: Parameters<typeof prisma.$transaction>[1],
+): Promise<T> {
+  return prisma.$transaction(callback, options);
+}


### PR DESCRIPTION
## Summary
Adds a minimal `withTransaction` helper that wraps Prisma's interactive transactions for easy use in the service layer.

## Usage
```ts
import { withTransaction, TxClient } from '../lib/transaction';

const result = await withTransaction(async (tx) => {
  const org = await tx.organization.create({ data: orgData });
  await tx.organizationMember.create({
    data: { organizationId: org.id, userId, role: 'owner' },
  });
  return org;
});
```

## Details
- Single `withTransaction(callback, options?)` function — no class boilerplate
- `TxClient` type derived from `prisma.$transaction` — stays in sync with Prisma automatically
- Supports Prisma transaction options (`maxWait`, `timeout`, `isolationLevel`) via optional second arg
- Any thrown error inside the callback rolls back the entire transaction

## Files
| File | Change |
|---|---|
| `backend/src/lib/transaction.ts` | New utility |