### PR TITLE
feat: add Prisma transaction utility and @Transactional decorator

### DIFF
--- a/backend/src/shared/utils/Transactional.ts
+++ b/backend/src/shared/utils/Transactional.ts
@@ -1,0 +1,64 @@
+import { PrismaClient } from '@prisma/client';
+import { TransactionOptions, TransactionClient } from './UnitOfWork';
+
+/**
+ * Symbol used to attach the PrismaClient instance to a service class.
+ *
+ * The decorated service must expose a `prisma` property (public or protected):
+ *
+ *   class MyService {
+ *     constructor(private readonly prisma: PrismaClient) {}
+ *
+ *     @Transactional()
+ *     async createUserWithOrg(userData: any, orgData: any, tx?: TransactionClient) {
+ *       const org  = await (tx ?? this.prisma).organization.create({ data: orgData });
+ *       const user = await (tx ?? this.prisma).user.create({ data: { ...userData, organizationId: org.id } });
+ *       return { user, org };
+ *     }
+ *   }
+ *
+ * When called normally the decorator starts a new transaction and passes the
+ * transaction client as the last argument.  If a `TransactionClient` is already
+ * provided as the last argument the method runs inside the existing transaction
+ * (transaction propagation).
+ */
+export function Transactional(options?: TransactionOptions) {
+  return function (
+    _target: object,
+    _propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<(...args: any[]) => Promise<any>>,
+  ): TypedPropertyDescriptor<(...args: any[]) => Promise<any>> {
+    const original = descriptor.value!;
+
+    descriptor.value = async function (this: { prisma: PrismaClient }, ...args: any[]) {
+      const last = args[args.length - 1];
+      const alreadyInTx = isTransactionClient(last);
+
+      // Propagate: already inside a transaction — call through directly.
+      if (alreadyInTx) {
+        return original.apply(this, args);
+      }
+
+      // Start a new transaction and inject the client as the last argument.
+      return this.prisma.$transaction(async (tx: TransactionClient) => {
+        return original.apply(this, [...args, tx]);
+      }, options);
+    };
+
+    return descriptor;
+  };
+}
+
+/**
+ * Heuristic: a TransactionClient has the same model delegates as PrismaClient
+ * but lacks the connection/lifecycle methods stripped by Prisma's type.
+ * We check for the absence of `$connect` (present on PrismaClient, absent on tx).
+ */
+function isTransactionClient(value: unknown): value is TransactionClient {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !('$connect' in value) &&
+    '$queryRaw' in value
+  );
+}

--- a/backend/src/shared/utils/UnitOfWork.ts
+++ b/backend/src/shared/utils/UnitOfWork.ts
@@ -1,87 +1,99 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { createLogger } from '../lib/logger';
 
 const logger = createLogger('unitOfWork');
 
-/**
- * Repository interface for Unit of Work pattern
- */
+/** Prisma interactive-transaction client type */
+export type TransactionClient = Omit<
+  PrismaClient,
+  '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
+>;
+
+export interface TransactionOptions {
+  /** Max time (ms) Prisma waits to acquire a connection. Default: 2000 */
+  maxWait?: number;
+  /** Max time (ms) the transaction may run before being aborted. Default: 5000 */
+  timeout?: number;
+  isolationLevel?: Prisma.TransactionIsolationLevel;
+}
+
 export interface IRepository {
   [key: string]: any;
 }
 
-/**
- * Unit of Work context containing transaction-scoped repositories
- */
 export interface IUnitOfWorkContext {
-  prisma: PrismaClient;
+  prisma: TransactionClient;
   repositories: IRepository;
 }
 
-/**
- * Unit of Work callback function
- */
 export type UnitOfWorkCallback<T> = (context: IUnitOfWorkContext) => Promise<T>;
 
 /**
- * Unit of Work Pattern Implementation
- * Manages atomic transactions across multiple repositories
+ * Wraps Prisma interactive transactions with a clean service-layer API.
+ *
+ * Usage:
+ *   const uow = new UnitOfWork(prisma);
+ *   const result = await uow.execute(async ({ prisma: tx }) => {
+ *     const user = await tx.user.create({ data: userData });
+ *     await tx.subscription.create({ data: { userId: user.id, ...subData } });
+ *     return user;
+ *   });
  */
 export class UnitOfWork {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
-   * Execute a callback within a transaction context
-   * All database operations are atomic - either all succeed or all rollback
+   * Run `callback` inside a single Prisma interactive transaction.
+   * Rolls back automatically on any thrown error.
    */
-  async execute<T>(callback: UnitOfWorkCallback<T>, repositories?: IRepository): Promise<T> {
-    try {
-      logger.debug('Starting Unit of Work transaction');
-
-      const result = await this.prisma.$transaction(async (tx) => {
-        const context: IUnitOfWorkContext = {
-          prisma: tx as PrismaClient,
-          repositories: repositories || {},
-        };
-
-        return await callback(context);
-      });
-
-      logger.debug('Unit of Work transaction committed');
-      return result;
-    } catch (error) {
-      logger.error('Unit of Work transaction failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
+  async execute<T>(
+    callback: UnitOfWorkCallback<T>,
+    options?: TransactionOptions,
+    repositories?: IRepository,
+  ): Promise<T> {
+    logger.debug('Starting Unit of Work transaction');
+    const result = await this.prisma.$transaction(async (tx) => {
+      return callback({ prisma: tx, repositories: repositories ?? {} });
+    }, options);
+    logger.debug('Unit of Work transaction committed');
+    return result;
   }
 
   /**
-   * Execute multiple operations in a single transaction
+   * Run an array of operations sequentially inside one transaction.
+   * Each operation receives the same transaction client so later steps
+   * can depend on results from earlier ones.
    */
-  async executeMultiple<T>(operations: Array<(tx: PrismaClient) => Promise<T>>): Promise<T[]> {
-    try {
-      logger.debug('Starting multi-operation Unit of Work transaction');
-
-      const results = await this.prisma.$transaction(async (tx) => {
-        return Promise.all(operations.map((op) => op(tx as PrismaClient)));
-      });
-
-      logger.debug('Multi-operation Unit of Work transaction committed');
+  async executeSequential<T>(
+    operations: Array<(tx: TransactionClient) => Promise<T>>,
+    options?: TransactionOptions,
+  ): Promise<T[]> {
+    logger.debug('Starting sequential Unit of Work transaction');
+    return this.prisma.$transaction(async (tx) => {
+      const results: T[] = [];
+      for (const op of operations) {
+        results.push(await op(tx));
+      }
       return results;
-    } catch (error) {
-      logger.error('Multi-operation Unit of Work transaction failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
+    }, options);
+  }
+
+  /**
+   * Run an array of independent operations in parallel inside one transaction.
+   * Use `executeSequential` when operations depend on each other.
+   */
+  async executeParallel<T>(
+    operations: Array<(tx: TransactionClient) => Promise<T>>,
+    options?: TransactionOptions,
+  ): Promise<T[]> {
+    logger.debug('Starting parallel Unit of Work transaction');
+    return this.prisma.$transaction(
+      (tx) => Promise.all(operations.map((op) => op(tx))),
+      options,
+    );
   }
 }
 
-/**
- * Factory function to create Unit of Work instance
- */
 export function createUnitOfWork(prisma: PrismaClient): UnitOfWork {
   return new UnitOfWork(prisma);
 }

--- a/backend/src/shared/utils/UnitOfWorkExample.ts
+++ b/backend/src/shared/utils/UnitOfWorkExample.ts
@@ -1,149 +1,88 @@
+/**
+ * Usage examples for UnitOfWork and @Transactional.
+ * These are illustrative — not production code.
+ */
 import { PrismaClient } from '@prisma/client';
-import { UnitOfWork } from './UnitOfWork';
-import { UserRepository, OrganizationRepository, SubscriptionRepository } from './BaseRepository';
-import { createLogger } from '../lib/logger';
+import { UnitOfWork, TransactionClient } from './UnitOfWork';
+import { Transactional } from './Transactional';
 
-const logger = createLogger('unitOfWorkExample');
-
-/**
- * Example: Using Unit of Work for atomic multi-repository operations
- */
-
-export async function exampleCreateUserWithOrganization(
+// ---------------------------------------------------------------------------
+// 1. UnitOfWork.execute — callback style
+// ---------------------------------------------------------------------------
+export async function createUserWithOrganization(
   prisma: PrismaClient,
   userData: any,
   orgData: any,
 ) {
-  const unitOfWork = new UnitOfWork(prisma);
+  const uow = new UnitOfWork(prisma);
 
-  try {
-    const result = await unitOfWork.execute(async (context) => {
-      const userRepo = new UserRepository(context.prisma);
-      const orgRepo = new OrganizationRepository(context.prisma);
-
-      // Create organization first
-      const organization = await orgRepo.create(orgData);
-      logger.info('Organization created', { orgId: organization.id });
-
-      // Create user linked to organization
-      const user = await userRepo.create({
-        ...userData,
-        organizationId: organization.id,
-      });
-      logger.info('User created', { userId: user.id });
-
-      return { user, organization };
-    });
-
-    logger.info('Transaction completed successfully', { result });
-    return result;
-  } catch (error) {
-    logger.error('Transaction failed - all changes rolled back', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
+  return uow.execute(async ({ prisma: tx }) => {
+    const org  = await tx.organization.create({ data: orgData });
+    const user = await tx.user.create({ data: { ...userData, organizationId: org.id } });
+    return { user, org };
+  });
 }
 
-/**
- * Example: Complex transaction with subscription creation
- */
-export async function exampleCreateUserWithSubscription(
-  prisma: PrismaClient,
-  userData: any,
-  orgData: any,
-  subscriptionData: any,
-) {
-  const unitOfWork = new UnitOfWork(prisma);
+// ---------------------------------------------------------------------------
+// 2. UnitOfWork.executeSequential — ordered, dependent operations
+// ---------------------------------------------------------------------------
+export async function provisionAccount(prisma: PrismaClient, userData: any, subData: any) {
+  const uow = new UnitOfWork(prisma);
 
-  try {
-    const result = await unitOfWork.execute(async (context) => {
-      const userRepo = new UserRepository(context.prisma);
-      const orgRepo = new OrganizationRepository(context.prisma);
-      const subRepo = new SubscriptionRepository(context.prisma);
-
-      // Step 1: Create organization
-      const organization = await orgRepo.create(orgData);
-
-      // Step 2: Create user
-      const user = await userRepo.create({
-        ...userData,
-        organizationId: organization.id,
-      });
-
-      // Step 3: Create subscription
-      const subscription = await subRepo.create({
-        ...subscriptionData,
-        userId: user.id,
-        organizationId: organization.id,
-      });
-
-      return { user, organization, subscription };
-    });
-
-    logger.info('Complex transaction completed', { result });
-    return result;
-  } catch (error) {
-    logger.error('Complex transaction failed - all changes rolled back', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
+  return uow.executeSequential([
+    (tx) => tx.user.create({ data: userData }),
+    async (tx) => {
+      const user = await tx.user.findFirstOrThrow({ where: { email: userData.email } });
+      return tx.subscription.create({ data: { ...subData, userId: user.id } });
+    },
+  ]);
 }
 
-/**
- * Example: Update multiple entities atomically
- */
-export async function exampleUpdateUserAndOrganization(
+// ---------------------------------------------------------------------------
+// 3. UnitOfWork.executeParallel — independent operations
+// ---------------------------------------------------------------------------
+export async function updateUserAndOrg(
   prisma: PrismaClient,
   userId: string,
   orgId: string,
   userData: any,
   orgData: any,
 ) {
-  const unitOfWork = new UnitOfWork(prisma);
+  const uow = new UnitOfWork(prisma);
 
-  try {
-    const result = await unitOfWork.execute(async (context) => {
-      const userRepo = new UserRepository(context.prisma);
-      const orgRepo = new OrganizationRepository(context.prisma);
-
-      // Update both entities atomically
-      const [user, organization] = await Promise.all([
-        userRepo.update(userId, userData),
-        orgRepo.update(orgId, orgData),
-      ]);
-
-      return { user, organization };
-    });
-
-    logger.info('Update transaction completed', { result });
-    return result;
-  } catch (error) {
-    logger.error('Update transaction failed - all changes rolled back', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
+  return uow.executeParallel([
+    (tx) => tx.user.update({ where: { id: userId }, data: userData }),
+    (tx) => tx.organization.update({ where: { id: orgId }, data: orgData }),
+  ]);
 }
 
-/**
- * Example: Using executeMultiple for independent operations
- */
-export async function exampleMultipleOperations(
-  prisma: PrismaClient,
-  operations: Array<(tx: PrismaClient) => Promise<any>>,
-) {
-  const unitOfWork = new UnitOfWork(prisma);
+// ---------------------------------------------------------------------------
+// 4. @Transactional decorator — service-layer style
+//    The decorator starts a transaction and injects `tx` as the last arg.
+//    Pass an existing `tx` to propagate into an outer transaction.
+// ---------------------------------------------------------------------------
+export class UserService {
+  constructor(private readonly prisma: PrismaClient) {}
 
-  try {
-    const results = await unitOfWork.executeMultiple(operations);
-    logger.info('Multiple operations completed', { count: results.length });
-    return results;
-  } catch (error) {
-    logger.error('Multiple operations failed - all changes rolled back', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
+  @Transactional({ timeout: 10_000 })
+  async createWithSubscription(userData: any, subData: any, tx?: TransactionClient) {
+    const client = tx ?? this.prisma; // tx is always set by the decorator
+    const user = await client.user.create({ data: userData });
+    await client.subscription.create({ data: { ...subData, userId: user.id } });
+    return user;
+  }
+
+  // Calls the decorated method above — passes its own tx for propagation.
+  @Transactional()
+  async createWithOrgAndSubscription(
+    userData: any,
+    orgData: any,
+    subData: any,
+    tx?: TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+    const org = await client.organization.create({ data: orgData });
+    // Propagates the outer tx into createWithSubscription
+    return this.createWithSubscription({ ...userData, organizationId: org.id }, subData, tx);
   }
 }


### PR DESCRIPTION
## What was created / changed

### backend/src/shared/utils/UnitOfWork.ts (rewritten)

Key improvements over the original:

- **TransactionClient type** — the proper Prisma interactive-tx client type (strips lifecycle methods). Used 
everywhere instead of the incorrect PrismaClient cast.
- **TransactionOptions** — exposes maxWait, timeout, and isolationLevel so callers can tune per-operation.
- **execute(callback, options?, repositories?)** — same callback style as before, now with options support.
- **executeSequential(ops[], options?)** — runs operations one-by-one in a single transaction. Safe when step N 
depends on step N-1.
- **executeParallel(ops[], options?)** — runs independent operations concurrently in one transaction (replaces the old
executeMultiple which silently used Promise.all).
- Removed the try/catch wrappers — errors propagate naturally; Prisma rolls back on throw.

### backend/src/shared/utils/Transactional.ts (new)

A @Transactional(options?) method decorator for service classes:

ts
class PostService {
  constructor(private readonly prisma: PrismaClient) {}

  @Transactional({ timeout: 10_000 })
  async publish(postId: string, tx?: TransactionClient) {
    const client = tx ?? this.prisma; // decorator always injects tx
    await client.post.update({ where: { id: postId }, data: { status: 'published' } });
    await client.auditLog.create({ data: { action: 'publish', postId } });
  }
}


Two behaviours:
- **No tx passed by caller** → decorator starts a new $transaction and injects the client as the last argument.
- **tx already passed** → decorator detects it (via isTransactionClient) and calls through directly — this is 
transaction propagation, so nested @Transactional methods join the outer transaction instead of starting a new one.

The service class just needs a prisma: PrismaClient property (standard constructor injection).

Closes #218 