### PR TITLE
test: add moderation mode behavior tests for fail-open/fail-closed, timeout, and malformed response (#492)

### DIFF
--- a/backend/src/__tests__/ModerationService.test.ts
+++ b/backend/src/__tests__/ModerationService.test.ts
@@ -1,0 +1,157 @@
+/**
+ * ModerationService — moderation mode behavior tests (#492)
+ *
+ * Covers:
+ *   - Missing API key in fail-open vs fail-closed mode
+ *   - Logger warn/error emission for bypass conditions
+ *   - Provider timeout in both modes
+ *   - Malformed API response in both modes
+ */
+import nock from 'nock';
+
+const BASE = 'https://api.openai.com';
+
+// ── Logger spy setup ──────────────────────────────────────────────────────────
+// Must happen before the module is imported so the spy is in place at load time.
+const warnSpy = jest.fn();
+const errorSpy = jest.fn();
+
+jest.mock('../lib/logger', () => ({
+  createLogger: () => ({ warn: warnSpy, error: errorSpy, info: jest.fn() }),
+}));
+
+// Set a key so the module loads in "configured" state by default;
+// individual tests override as needed.
+process.env.OPENAI_API_KEY = 'test-key';
+
+import { ModerationService } from '../services/ModerationService';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function cleanResponse() {
+  return {
+    results: [{
+      flagged: false,
+      categories: { hate: false, 'hate/threatening': false, 'sexual/minors': false, violence: false, 'violence/graphic': false, 'self-harm/instructions': false },
+      category_scores: { hate: 0.01, 'hate/threatening': 0.01, 'sexual/minors': 0.01, violence: 0.01, 'violence/graphic': 0.01, 'self-harm/instructions': 0.01 },
+    }],
+  };
+}
+
+beforeAll(() => nock.disableNetConnect());
+afterAll(() => nock.enableNetConnect());
+
+afterEach(() => {
+  nock.cleanAll();
+  warnSpy.mockClear();
+  errorSpy.mockClear();
+  process.env.OPENAI_API_KEY = 'test-key';
+  delete process.env.MODERATION_MODE;
+});
+
+// ── Missing API key ───────────────────────────────────────────────────────────
+
+describe('missing OPENAI_API_KEY', () => {
+  beforeEach(() => { delete process.env.OPENAI_API_KEY; });
+
+  it('fail-open (default): returns clean bypass result', async () => {
+    const result = await ModerationService.moderate('hello');
+    expect(result).toEqual({ flagged: false, blocked: false, categories: {}, scores: {} });
+  });
+
+  it('fail-open (default): emits a warn log', async () => {
+    await ModerationService.moderate('hello');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('OPENAI_API_KEY not set'),
+    );
+  });
+
+  it('fail-closed: throws', async () => {
+    process.env.MODERATION_MODE = 'fail-closed';
+    await expect(ModerationService.moderate('hello')).rejects.toThrow(
+      'Moderation unavailable: OPENAI_API_KEY not set',
+    );
+  });
+
+  it('fail-closed: emits an error log before throwing', async () => {
+    process.env.MODERATION_MODE = 'fail-closed';
+    await ModerationService.moderate('hello').catch(() => {});
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('OPENAI_API_KEY not set'),
+    );
+  });
+});
+
+// ── Provider timeout ──────────────────────────────────────────────────────────
+
+describe('provider timeout', () => {
+  beforeEach(() => {
+    // Simulate a connection timeout via nock
+    nock(BASE).post('/v1/moderations').replyWithError({ code: 'ETIMEDOUT' });
+  });
+
+  it('fail-open (default): returns clean bypass result', async () => {
+    const result = await ModerationService.moderate('hello');
+    expect(result).toEqual({ flagged: false, blocked: false, categories: {}, scores: {} });
+  });
+
+  it('fail-open (default): emits error then warn logs', async () => {
+    await ModerationService.moderate('hello');
+    expect(errorSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failing open'));
+  });
+
+  it('fail-closed: throws', async () => {
+    process.env.MODERATION_MODE = 'fail-closed';
+    await expect(ModerationService.moderate('hello')).rejects.toThrow();
+  });
+
+  it('fail-closed: does not emit a warn log (no bypass)', async () => {
+    process.env.MODERATION_MODE = 'fail-closed';
+    await ModerationService.moderate('hello').catch(() => {});
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('failing open'));
+  });
+});
+
+// ── Malformed response ────────────────────────────────────────────────────────
+
+describe('malformed API response', () => {
+  it('fail-open (default): returns clean bypass result when body is not valid JSON', async () => {
+    nock(BASE).post('/v1/moderations').reply(200, 'not-json', { 'content-type': 'text/plain' });
+    const result = await ModerationService.moderate('hello');
+    expect(result).toEqual({ flagged: false, blocked: false, categories: {}, scores: {} });
+  });
+
+  it('fail-open (default): returns clean bypass result when results array is missing', async () => {
+    nock(BASE).post('/v1/moderations').reply(200, { unexpected: true });
+    const result = await ModerationService.moderate('hello');
+    expect(result).toEqual({ flagged: false, blocked: false, categories: {}, scores: {} });
+  });
+
+  it('fail-open (default): emits error and warn logs for malformed response', async () => {
+    nock(BASE).post('/v1/moderations').reply(200, { unexpected: true });
+    await ModerationService.moderate('hello');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('malformed'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failing open'));
+  });
+
+  it('fail-closed: throws on malformed response', async () => {
+    process.env.MODERATION_MODE = 'fail-closed';
+    nock(BASE).post('/v1/moderations').reply(200, { unexpected: true });
+    await expect(ModerationService.moderate('hello')).rejects.toThrow('malformed');
+  });
+
+  it('fail-closed: does not emit a warn log (no bypass)', async () => {
+    process.env.MODERATION_MODE = 'fail-closed';
+    nock(BASE).post('/v1/moderations').reply(200, { unexpected: true });
+    await ModerationService.moderate('hello').catch(() => {});
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('failing open'));
+  });
+
+  it('succeeds normally when response is well-formed', async () => {
+    nock(BASE).post('/v1/moderations').reply(200, cleanResponse());
+    const result = await ModerationService.moderate('hello');
+    expect(result.flagged).toBe(false);
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/backend/src/services/ModerationService.ts
+++ b/backend/src/services/ModerationService.ts
@@ -42,6 +42,21 @@ function getSensitivity(): SensitivityLevel {
   return 'medium';
 }
 
+/**
+ * MODERATION_MODE controls behaviour when the provider is unavailable
+ * (missing API key, timeout, or malformed response):
+ *
+ *   fail-open   (default) — bypass moderation and allow the content through.
+ *                           Logs a warning. Use when availability > safety.
+ *   fail-closed           — block the content and throw.
+ *                           Use when safety > availability.
+ */
+function getMode(): 'fail-open' | 'fail-closed' {
+  return process.env.MODERATION_MODE === 'fail-closed' ? 'fail-closed' : 'fail-open';
+}
+
+const BYPASS_RESULT: ModerationResult = { flagged: false, blocked: false, categories: {}, scores: {} };
+
 export const ModerationService = {
   isConfigured(): boolean {
     return !!process.env.OPENAI_API_KEY;
@@ -49,12 +64,20 @@ export const ModerationService = {
 
   /**
    * Moderate content using the OpenAI Moderation API.
-   * Returns a safe pass-through result if the API is not configured.
+   *
+   * When the provider is unavailable the behaviour depends on MODERATION_MODE:
+   *   fail-open   — returns a clean pass-through result (default)
+   *   fail-closed — throws so the caller can block the content
    */
   async moderate(text: string): Promise<ModerationResult> {
     if (!this.isConfigured()) {
-      logger.warn('ModerationService: OPENAI_API_KEY not set — skipping moderation');
-      return { flagged: false, blocked: false, categories: {}, scores: {} };
+      const msg = 'ModerationService: OPENAI_API_KEY not set — skipping moderation';
+      if (getMode() === 'fail-closed') {
+        logger.error(msg);
+        throw new Error('Moderation unavailable: OPENAI_API_KEY not set');
+      }
+      logger.warn(msg);
+      return BYPASS_RESULT;
     }
 
     const response = await fetch('https://api.openai.com/v1/moderations', {
@@ -64,7 +87,17 @@ export const ModerationService = {
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({ input: text }),
+      signal: AbortSignal.timeout(10_000),
+    }).catch((err: unknown) => {
+      const isTimeout = err instanceof Error && err.name === 'TimeoutError';
+      const msg = isTimeout ? 'Moderation API timeout' : 'Moderation API unreachable';
+      logger.error(msg, { error: err instanceof Error ? err.message : String(err) });
+      if (getMode() === 'fail-closed') throw new Error(msg);
+      logger.warn(`${msg} — failing open`);
+      return null;
     });
+
+    if (response === null) return BYPASS_RESULT;
 
     if (!response.ok) {
       const body = await response.text();
@@ -72,13 +105,24 @@ export const ModerationService = {
       throw new Error(`Moderation API returned ${response.status}`);
     }
 
-    const data = (await response.json()) as {
+    let data: {
       results: Array<{
         flagged: boolean;
         categories: Record<string, boolean>;
         category_scores: Record<string, number>;
       }>;
     };
+
+    try {
+      data = (await response.json()) as typeof data;
+      if (!Array.isArray(data?.results) || !data.results[0]) throw new Error('unexpected shape');
+    } catch {
+      const msg = 'Moderation API returned malformed response';
+      logger.error(msg);
+      if (getMode() === 'fail-closed') throw new Error(msg);
+      logger.warn(`${msg} — failing open`);
+      return BYPASS_RESULT;
+    }
 
     const result = data.results[0];
     const sensitivity = getSensitivity();


### PR DESCRIPTION
Title: 
test: add moderation mode behavior tests for fail-open/fail-closed, timeout, and malformed response (#492)

Description:

Closes #492

Service change (ModerationService.ts)

Added MODERATION_MODE env var support (fail-open | fail-closed, 
default fail-open) so the bypass strategy is explicit and testable.
Three bypass paths now respect the mode:
- Missing OPENAI_API_KEY — warn + bypass (fail-open) or error + 
throw (fail-closed)
- Network error / timeout — AbortSignal.timeout(10_000) added; 
error + warn + bypass (fail-open) or throw (fail-closed)
- Malformed response — missing/invalid results array; error + warn 
+ bypass (fail-open) or throw (fail-closed)

Tests (src/__tests__/ModerationService.test.ts)

14 new tests across 3 describe blocks:

| Block | Tests |
|---|---|
| missing OPENAI_API_KEY | fail-open returns bypass result; fail-
open emits warn; fail-closed throws; fail-closed emits error |
| provider timeout | fail-open returns bypass result; fail-open 
emits error + warn; fail-closed throws; fail-closed does not emit 
bypass warn |
| malformed API response | fail-open on non-JSON body; fail-open on
missing results; fail-open emits error + warn; fail-closed throws;
fail-closed no bypass warn; well-formed response succeeds normally
|

Logger is spied on via jest.mock before module import so all log 
assertions are exact. nock intercepts all outbound HTTP — no real 
network calls.