### PR TITLE
fix: remove hard process.exit from shutdown paths

### DIFF
--- a/backend/src/__tests__/gracefulShutdown.test.ts
+++ b/backend/src/__tests__/gracefulShutdown.test.ts
@@ -50,7 +50,7 @@ jest.mock('../app', () => ({
   },
 }));
 
-import { gracefulShutdown, _resetShutdownState, ShutdownDeps } from '../server';
+import { gracefulShutdown, _resetShutdownState, bootstrap, ShutdownDeps } from '../server';
 import { prisma } from '../lib/prisma';
 import { stopWorkerMonitor } from '../monitoring/workerMonitorInstance';
 import { stopHealthMonitoringJob } from '../jobs/healthMonitoringJob';
@@ -222,5 +222,69 @@ describe('gracefulShutdown — cleanup resilience', () => {
     await gracefulShutdown('SIGTERM', 0, makeDeps(), { exit, timeoutMs: 5000 });
     expect(exit).toHaveBeenCalledWith(0);
     expect(prisma.$disconnect).toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// bootstrap — exit code injection
+// ═══════════════════════════════════════════════════════════════════════════════
+
+import app from '../app';
+
+describe('bootstrap — exit code injection', () => {
+  it('calls exit(1) via injected handler when bootstrap throws', async () => {
+    const exit = jest.fn();
+    (app.listen as jest.Mock).mockImplementationOnce(() => { throw new Error('port in use'); });
+    await bootstrap(exit);
+    expect(exit).toHaveBeenCalledWith(1);
+    // process.exit must NOT have been called directly
+    expect(mockProcessExit).not.toHaveBeenCalled();
+  });
+
+  it('does not call exit when bootstrap succeeds', async () => {
+    const exit = jest.fn();
+    (app.listen as jest.Mock).mockImplementationOnce((_port: number, cb: () => void) => {
+      cb();
+      return { on: jest.fn() };
+    });
+    await bootstrap(exit);
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// shutdownOtel — timeout control
+// ═══════════════════════════════════════════════════════════════════════════════
+
+jest.mock('../tracing', () => {
+  const sdkShutdown = jest.fn();
+  return { sdk: { shutdown: sdkShutdown }, shutdownOtel: jest.requireActual('../tracing').shutdownOtel };
+});
+
+// Re-import after mock so we get the mocked sdk
+import { shutdownOtel } from '../tracing';
+import { sdk } from '../tracing';
+
+describe('shutdownOtel — timeout control', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('resolves when sdk.shutdown() completes within timeout', async () => {
+    (sdk.shutdown as jest.Mock).mockResolvedValueOnce(undefined);
+    await expect(shutdownOtel(1000)).resolves.toBeUndefined();
+  });
+
+  it('logs error and resolves when sdk.shutdown() rejects', async () => {
+    (sdk.shutdown as jest.Mock).mockRejectedValueOnce(new Error('export failed'));
+    await expect(shutdownOtel(1000)).resolves.toBeUndefined();
+  });
+
+  it('logs error and resolves when sdk.shutdown() exceeds timeoutMs', async () => {
+    (sdk.shutdown as jest.Mock).mockImplementationOnce(
+      () => new Promise(() => { /* never resolves */ }),
+    );
+    const p = shutdownOtel(100);
+    jest.advanceTimersByTime(100);
+    await expect(p).resolves.toBeUndefined();
   });
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -225,9 +225,12 @@ process.on('SIGTERM', () => {
 });
 
 /**
- * Bootstrap the application
+ * Bootstrap the application.
+ * @param exit - Injectable exit handler (defaults to process.exit). Injected in tests.
  */
-const bootstrap = async (): Promise<void> => {
+export const bootstrap = async (
+  exit: (code: number) => void = (code) => process.exit(code),
+): Promise<void> => {
   try {
     // Initialize job queue workers
     logger.info('Initializing job queue workers...');
@@ -331,7 +334,7 @@ const bootstrap = async (): Promise<void> => {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    process.exit(1);
+    exit(1);
   }
 };
 

--- a/backend/src/tracing.ts
+++ b/backend/src/tracing.ts
@@ -92,9 +92,14 @@ logger.info('OpenTelemetry tracing initialised', {
 });
 
 // Flush spans on graceful shutdown
-process.on('SIGTERM', () => {
-  sdk
-    .shutdown()
+export const shutdownOtel = (timeoutMs = 5_000): Promise<void> =>
+  Promise.race([
+    sdk.shutdown(),
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('OTel shutdown timed out')), timeoutMs),
+    ),
+  ])
     .then(() => logger.info('OTel SDK shut down cleanly'))
     .catch((err: unknown) => logger.error('OTel SDK shutdown error', err));
-});
+
+process.on('SIGTERM', () => { void shutdownOtel(); });


### PR DESCRIPTION
- Export bootstrap() with injectable exit handler; replaces direct process.exit(1) on startup failure
- Add shutdownOtel() with configurable timeout (default 5 s) so a hung OTel exporter cannot block SIGTERM indefinitely; export for testability
- Add tests: bootstrap exit injection, shutdownOtel timeout/rejection paths

closes #475 