### PR TITLE
feat: emit startup warnings and readiness signal for disabled integra…

### DIFF
--- a/backend/src/__tests__/healthReadiness.test.ts
+++ b/backend/src/__tests__/healthReadiness.test.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /health/readiness — unit tests
+ */
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../../lib/integrationStatus', () => ({
+  getIntegrationSnapshot: jest.fn(),
+}));
+jest.mock('../../services/serviceFactory', () => ({
+  getHealthService: jest.fn(),
+  getHealthMonitor: jest.fn(),
+  getAlertConfigService: jest.fn(),
+}));
+
+import { getIntegrationSnapshot } from '../../lib/integrationStatus';
+import healthRouter from '../../routes/health';
+
+const app = express();
+app.use('/health', healthRouter);
+
+describe('GET /health/readiness', () => {
+  it('returns 503 with status=starting when snapshot is null', async () => {
+    (getIntegrationSnapshot as jest.Mock).mockReturnValue(null);
+    const res = await request(app).get('/health/readiness');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('starting');
+  });
+
+  it('returns 200 with status=ready when all integrations are enabled', async () => {
+    (getIntegrationSnapshot as jest.Mock).mockReturnValue([
+      { name: 'youtube', enabled: true },
+      { name: 'stripe', enabled: true },
+    ]);
+    const res = await request(app).get('/health/readiness');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ready');
+  });
+
+  it('returns 503 with status=degraded when any integration is disabled', async () => {
+    (getIntegrationSnapshot as jest.Mock).mockReturnValue([
+      { name: 'youtube', enabled: false, reason: 'YOUTUBE_CLIENT_ID not set' },
+      { name: 'stripe', enabled: true },
+    ]);
+    const res = await request(app).get('/health/readiness');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('degraded');
+    expect(res.body.integrations).toHaveLength(2);
+  });
+});

--- a/backend/src/__tests__/integrationStatus.test.ts
+++ b/backend/src/__tests__/integrationStatus.test.ts
@@ -1,0 +1,96 @@
+/**
+ * integrationStatus unit tests
+ */
+import { checkIntegrations, getIntegrationSnapshot, _resetSnapshot } from '../../lib/integrationStatus';
+
+// Minimal env so config validation passes
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+process.env.JWT_SECRET = 'test-secret-that-is-at-least-32-chars!!';
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-32-chars!!!!!';
+process.env.TWITTER_API_KEY = 'test-key';
+process.env.TWITTER_API_SECRET = 'test-secret';
+
+jest.mock('../../lib/logger', () => ({
+  createLogger: () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+// Re-import logger mock so we can spy on warn
+import { createLogger } from '../../lib/logger';
+const mockLogger = createLogger('integration-status');
+
+beforeEach(() => {
+  _resetSnapshot();
+  jest.clearAllMocks();
+  // Clear integration-related env vars
+  delete process.env.REQUIRE_INTEGRATIONS;
+  delete process.env.YOUTUBE_CLIENT_ID;
+  delete process.env.YOUTUBE_CLIENT_SECRET;
+  delete process.env.STRIPE_SECRET_KEY;
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+});
+
+describe('checkIntegrations — disabled integrations', () => {
+  it('returns enabled=false for unconfigured integrations', () => {
+    const states = checkIntegrations();
+    const youtube = states.find((s) => s.name === 'youtube')!;
+    expect(youtube.enabled).toBe(false);
+    expect(youtube.reason).toBeTruthy();
+  });
+
+  it('emits a warn log for each disabled integration', () => {
+    checkIntegrations();
+    expect(mockLogger.warn).toHaveBeenCalled();
+    // Every warn call should mention the integration name
+    const calls = (mockLogger.warn as jest.Mock).mock.calls;
+    expect(calls.some((c: any[]) => c[0].includes('youtube'))).toBe(true);
+  });
+
+  it('returns enabled=true when credentials are present', () => {
+    process.env.YOUTUBE_CLIENT_ID = 'id';
+    process.env.YOUTUBE_CLIENT_SECRET = 'secret';
+    // Reset config singleton so it picks up new env
+    jest.resetModules();
+    const { checkIntegrations: check, _resetSnapshot: reset } = require('../../lib/integrationStatus');
+    reset();
+    const states = check();
+    const youtube = states.find((s: any) => s.name === 'youtube')!;
+    expect(youtube.enabled).toBe(true);
+    expect(youtube.reason).toBeUndefined();
+  });
+});
+
+describe('checkIntegrations — REQUIRE_INTEGRATIONS policy', () => {
+  it('throws when a required integration is not configured', () => {
+    process.env.REQUIRE_INTEGRATIONS = 'youtube';
+    expect(() => checkIntegrations()).toThrow(/Required integrations are not configured: youtube/);
+  });
+
+  it('does not throw when required integration is configured', () => {
+    process.env.YOUTUBE_CLIENT_ID = 'id';
+    process.env.YOUTUBE_CLIENT_SECRET = 'secret';
+    process.env.REQUIRE_INTEGRATIONS = 'youtube';
+    jest.resetModules();
+    const { checkIntegrations: check, _resetSnapshot: reset } = require('../../lib/integrationStatus');
+    reset();
+    expect(() => check()).not.toThrow();
+  });
+
+  it('does not throw when REQUIRE_INTEGRATIONS is empty', () => {
+    process.env.REQUIRE_INTEGRATIONS = '';
+    expect(() => checkIntegrations()).not.toThrow();
+  });
+});
+
+describe('getIntegrationSnapshot', () => {
+  it('returns null before checkIntegrations is called', () => {
+    expect(getIntegrationSnapshot()).toBeNull();
+  });
+
+  it('returns the cached result after checkIntegrations is called', () => {
+    checkIntegrations();
+    const snapshot = getIntegrationSnapshot();
+    expect(Array.isArray(snapshot)).toBe(true);
+    expect(snapshot!.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -103,6 +103,12 @@ const envSchema = z.object({
   // ── YouTube Sync ──────────────────────────────────────────────────────────
   YOUTUBE_SYNC_CRON: z.string().default('0 */6 * * *'),
 
+  // ── Required integrations policy ─────────────────────────────────────────
+  // Comma-separated list of integration names that must be configured.
+  // If any listed integration is disabled, startup fails.
+  // Example: REQUIRE_INTEGRATIONS=youtube,tiktok,stripe
+  REQUIRE_INTEGRATIONS: z.string().optional(),
+
   // ── Webhooks ──────────────────────────────────────────────────────────────
   HMAC_TIMESTAMP_TOLERANCE_MS: z.coerce.number().default(300000),
 

--- a/backend/src/lib/integrationStatus.ts
+++ b/backend/src/lib/integrationStatus.ts
@@ -1,0 +1,118 @@
+/**
+ * integrationStatus.ts
+ *
+ * Checks which optional integrations are configured at startup.
+ * - Emits a one-time `warn` log for every disabled integration.
+ * - Exposes a readiness snapshot consumed by GET /health/readiness.
+ * - Throws if REQUIRE_INTEGRATIONS lists an integration that is disabled.
+ */
+import { config } from '../config/config';
+import { createLogger } from './logger';
+
+const logger = createLogger('integration-status');
+
+export interface IntegrationState {
+  name: string;
+  enabled: boolean;
+  reason?: string;
+}
+
+/** Definitions of every optional integration and how to detect it. */
+const INTEGRATIONS: Array<{ name: string; check: () => boolean; reason: string }> = [
+  {
+    name: 'youtube',
+    check: () => Boolean(config.YOUTUBE_CLIENT_ID && config.YOUTUBE_CLIENT_SECRET),
+    reason: 'YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET not set — YouTube sync job will not run',
+  },
+  {
+    name: 'tiktok',
+    check: () => Boolean(config.TIKTOK_CLIENT_KEY && config.TIKTOK_CLIENT_SECRET),
+    reason: 'TIKTOK_CLIENT_KEY / TIKTOK_CLIENT_SECRET not set — TikTok video worker will not run',
+  },
+  {
+    name: 'facebook',
+    check: () => Boolean(config.FACEBOOK_APP_ID && config.FACEBOOK_APP_SECRET),
+    reason: 'FACEBOOK_APP_ID / FACEBOOK_APP_SECRET not set — Facebook integration disabled',
+  },
+  {
+    name: 'linkedin',
+    check: () => Boolean(config.LINKEDIN_CLIENT_ID && config.LINKEDIN_CLIENT_SECRET),
+    reason: 'LINKEDIN_CLIENT_ID / LINKEDIN_CLIENT_SECRET not set — LinkedIn integration disabled',
+  },
+  {
+    name: 'stripe',
+    check: () => Boolean(config.STRIPE_SECRET_KEY && config.STRIPE_WEBHOOK_SECRET),
+    reason: 'STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET not set — billing routes will fail',
+  },
+  {
+    name: 'deepl',
+    check: () => Boolean(config.DEEPL_API_KEY),
+    reason: 'DEEPL_API_KEY not set — DeepL translation unavailable',
+  },
+  {
+    name: 'google-translate',
+    check: () => Boolean(config.GOOGLE_TRANSLATE_API_KEY),
+    reason: 'GOOGLE_TRANSLATE_API_KEY not set — Google Translate unavailable',
+  },
+  {
+    name: 'elevenlabs',
+    check: () => Boolean(config.ELEVENLABS_API_KEY),
+    reason: 'ELEVENLABS_API_KEY not set — ElevenLabs TTS unavailable',
+  },
+  {
+    name: 'slack',
+    check: () => Boolean(config.SLACK_WEBHOOK_URL),
+    reason: 'SLACK_WEBHOOK_URL not set — Slack health alerts disabled',
+  },
+  {
+    name: 'elasticsearch',
+    check: () => Boolean(config.ELASTICSEARCH_URL),
+    reason: 'ELASTICSEARCH_URL not set — log shipping to Elasticsearch disabled',
+  },
+];
+
+let _snapshot: IntegrationState[] | null = null;
+
+/**
+ * Evaluate all integrations, emit warn logs for disabled ones, enforce
+ * REQUIRE_INTEGRATIONS policy, and cache the result for the readiness endpoint.
+ *
+ * Call once during bootstrap.
+ */
+export function checkIntegrations(): IntegrationState[] {
+  const required = new Set(
+    (config.REQUIRE_INTEGRATIONS ?? '')
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  const states: IntegrationState[] = INTEGRATIONS.map(({ name, check, reason }) => {
+    const enabled = check();
+    if (!enabled) {
+      logger.warn(`Integration disabled: ${name}`, { reason });
+    }
+    return { name, enabled, reason: enabled ? undefined : reason };
+  });
+
+  _snapshot = states;
+
+  const missing = states.filter((s) => !s.enabled && required.has(s.name));
+  if (missing.length > 0) {
+    const names = missing.map((s) => s.name).join(', ');
+    throw new Error(
+      `Required integrations are not configured: ${names}. ` +
+        `Set the necessary environment variables or remove them from REQUIRE_INTEGRATIONS.`,
+    );
+  }
+
+  return states;
+}
+
+/** Returns the last computed snapshot (null before checkIntegrations() is called). */
+export function getIntegrationSnapshot(): IntegrationState[] | null {
+  return _snapshot;
+}
+
+/** Reset snapshot — for testing only. */
+export const _resetSnapshot = (): void => { _snapshot = null; };

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -5,8 +5,32 @@ import {
   getHealthMonitor,
   getAlertConfigService,
 } from '../services/serviceFactory';
+import { getIntegrationSnapshot } from '../lib/integrationStatus';
 
 const router = Router();
+
+/**
+ * @openapi
+ * /health/readiness:
+ *   get:
+ *     tags: [Health]
+ *     summary: Readiness probe — reports integration enabled/disabled state
+ *     security: []
+ *     responses:
+ *       200:
+ *         description: All required integrations are configured
+ *       503:
+ *         description: One or more integrations are disabled
+ */
+router.get('/readiness', (req, res) => {
+  const integrations = getIntegrationSnapshot();
+  if (!integrations) {
+    return res.status(503).json({ status: 'starting', integrations: [] });
+  }
+  const disabled = integrations.filter((i) => !i.enabled);
+  const status = disabled.length === 0 ? 'ready' : 'degraded';
+  return res.status(disabled.length === 0 ? 200 : 503).json({ status, integrations });
+});
 
 /**
  * @openapi

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,7 @@ import { startHealthMonitoringJob, stopHealthMonitoringJob } from './jobs/health
 import { initializeHealthMonitoring } from './monitoring/healthMonitoringInstance';
 import { createLogger } from './lib/logger';
 import { prisma } from './lib/prisma';
+import { checkIntegrations } from './lib/integrationStatus';
 import { Worker } from 'bullmq';
 import { Server } from 'http';
 import { initSearchIndex } from './services/SearchService';
@@ -229,6 +230,9 @@ process.on('SIGTERM', () => {
  */
 const bootstrap = async (): Promise<void> => {
   try {
+    // Check optional integrations — warns for disabled ones, throws if REQUIRE_INTEGRATIONS policy is violated
+    checkIntegrations();
+
     // Initialize job queue workers
     logger.info('Initializing job queue workers...');
     initializeWorkers();


### PR DESCRIPTION
…tions

- Add REQUIRE_INTEGRATIONS env policy — comma-separated list of integrations that must be configured; startup fails if any are absent
- Add lib/integrationStatus.ts: evaluates all optional integrations, emits one-time warn log per disabled one, caches snapshot
- Wire checkIntegrations() into bootstrap() before workers start
- Add GET /health/readiness: returns ready/degraded/starting with per-integration enabled state and disable reason
- Add tests: integrationStatus unit tests, readiness route tests

closes #474 