### PR TITLE
feat: add worker alert context

### DIFF
--- a/backend/src/__tests__/notificationProvider.test.ts
+++ b/backend/src/__tests__/notificationProvider.test.ts
@@ -1,0 +1,72 @@
+import { createNotificationManager } from '../services/notificationProvider';
+
+describe('notificationProvider worker alert context', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('includes queue name and last error in Slack alert text', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as typeof fetch;
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.test/services/example';
+
+    const manager = createNotificationManager();
+
+    await manager.sendAlert({
+      severity: 'critical',
+      service: 'worker-monitor',
+      message: 'Worker image-sync emitted an error',
+      details: {
+        queueName: 'image-processing',
+        lastErrorMessage: 'connection reset by peer',
+      },
+      timestamp: '2026-04-23T12:00:00.000Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://hooks.slack.test/services/example',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining(
+          'Worker image-sync emitted an error (queue=image-processing, lastError=connection reset by peer)',
+        ),
+      }),
+    );
+  });
+
+  it('includes queue name and last error in PagerDuty summary', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as typeof fetch;
+    process.env.PAGERDUTY_INTEGRATION_KEY = 'pagerduty-key';
+
+    const manager = createNotificationManager();
+
+    await manager.sendAlert({
+      severity: 'critical',
+      service: 'worker-monitor',
+      message: 'Worker image-sync restarted',
+      details: {
+        queueName: 'image-processing',
+        lastErrorMessage: 'connection reset by peer',
+      },
+      timestamp: '2026-04-23T12:00:00.000Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://events.pagerduty.com/v2/enqueue',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining(
+          'worker-monitor: Worker image-sync restarted (queue=image-processing, lastError=connection reset by peer)',
+        ),
+      }),
+    );
+  });
+});

--- a/backend/src/modules/health/services/notificationProvider.ts
+++ b/backend/src/modules/health/services/notificationProvider.ts
@@ -16,6 +16,31 @@ export interface NotificationProvider {
   send(alert: AlertPayload): Promise<void>;
 }
 
+function formatAlertSummary(alert: AlertPayload): string {
+  const queueName =
+    typeof alert.details?.queueName === 'string' ? alert.details.queueName : undefined;
+  const lastErrorMessage =
+    typeof alert.details?.lastErrorMessage === 'string'
+      ? alert.details.lastErrorMessage
+      : typeof alert.details?.error === 'string'
+      ? alert.details.error
+      : typeof alert.details?.failedReason === 'string'
+      ? alert.details.failedReason
+      : undefined;
+
+  const context: string[] = [];
+
+  if (queueName) {
+    context.push(`queue=${queueName}`);
+  }
+
+  if (lastErrorMessage) {
+    context.push(`lastError=${lastErrorMessage}`);
+  }
+
+  return context.length > 0 ? `${alert.message} (${context.join(', ')})` : alert.message;
+}
+
 @injectable()
 class SlackNotificationProvider implements NotificationProvider {
   private webhookUrl: string;
@@ -27,12 +52,13 @@ class SlackNotificationProvider implements NotificationProvider {
   async send(alert: AlertPayload): Promise<void> {
     try {
       const color = alert.severity === 'critical' ? 'danger' : 'warning';
+      const summary = formatAlertSummary(alert);
       const payload = {
         attachments: [
           {
             color,
             title: `${alert.severity.toUpperCase()}: ${alert.service}`,
-            text: alert.message,
+            text: summary,
             fields: alert.details
               ? Object.entries(alert.details).map(([key, value]) => ({
                   title: key,
@@ -75,12 +101,13 @@ class PagerDutyNotificationProvider implements NotificationProvider {
 
   async send(alert: AlertPayload): Promise<void> {
     try {
+      const summary = formatAlertSummary(alert);
       const payload = {
         routing_key: this.integrationKey,
         event_action: alert.severity === 'critical' ? 'trigger' : 'resolve',
         dedup_key: `${alert.service}-${alert.timestamp}`,
         payload: {
-          summary: `${alert.service}: ${alert.message}`,
+          summary: `${alert.service}: ${summary}`,
           severity: alert.severity === 'critical' ? 'critical' : 'warning',
           source: 'SocialFlow Health Monitor',
           custom_details: alert.details || {},

--- a/backend/src/monitoring/workerMonitor.ts
+++ b/backend/src/monitoring/workerMonitor.ts
@@ -61,6 +61,7 @@ interface RegisteredWorker {
   restartCount: number;
   lastRestartAt?: string;
   listenerAttached: boolean;
+  lastErrorMessage?: string;
 }
 
 interface MonitoredQueue {
@@ -138,7 +139,9 @@ export class WorkerMonitor {
         metadata: { queueName, jobId },
       });
 
-      await this.restartWorkersForQueue(queueName, `stalled job detected: ${String(jobId)}`);
+      await this.restartWorkersForQueue(queueName, {
+        reason: `stalled job detected: ${String(jobId)}`,
+      });
     });
 
     monitoredQueue.events.on('failed', async ({ jobId, failedReason, prev }) => {
@@ -331,7 +334,12 @@ export class WorkerMonitor {
         },
       });
 
-      await this.restartWorker(worker.workerName, `worker error: ${error.message}`);
+      worker.lastErrorMessage = error.message;
+
+      await this.restartWorker(worker.workerName, {
+        reason: `worker error: ${error.message}`,
+        lastErrorMessage: error.message,
+      });
     };
 
     worker.worker.on('error', errorListener);
@@ -397,7 +405,9 @@ export class WorkerMonitor {
             },
           });
 
-          await this.restartWorkersForQueue(queue.queueName, 'stuck active jobs detected');
+          await this.restartWorkersForQueue(queue.queueName, {
+            reason: 'stuck active jobs detected',
+          });
         }
       } catch (error) {
         await this.sendAlert({
@@ -413,21 +423,29 @@ export class WorkerMonitor {
     }
   }
 
-  private async restartWorkersForQueue(queueName: string, reason: string): Promise<void> {
+  private async restartWorkersForQueue(
+    queueName: string,
+    context: { reason: string; lastErrorMessage?: string },
+  ): Promise<void> {
     const workerNames = Array.from(this.workers.values())
       .filter((worker) => worker.queueName === queueName)
       .map((worker) => worker.workerName);
 
     for (const workerName of workerNames) {
-      await this.restartWorker(workerName, reason);
+      await this.restartWorker(workerName, context);
     }
   }
 
-  private async restartWorker(workerName: string, reason: string): Promise<void> {
+  private async restartWorker(
+    workerName: string,
+    context: { reason: string; lastErrorMessage?: string },
+  ): Promise<void> {
     const worker = this.workers.get(workerName);
     if (!worker) {
       return;
     }
+
+    const lastErrorMessage = context.lastErrorMessage ?? worker.lastErrorMessage;
 
     const now = Date.now();
     worker.restartHistory = worker.restartHistory.filter((timestamp) => now - timestamp <= HOUR_MS);
@@ -441,7 +459,8 @@ export class WorkerMonitor {
         metadata: {
           workerName,
           queueName: worker.queueName,
-          reason,
+          reason: context.reason,
+          lastErrorMessage,
           maxRestartsPerHour: this.options.maxRestartsPerHour,
         },
       });
@@ -476,7 +495,8 @@ export class WorkerMonitor {
       metadata: {
         workerName,
         queueName: worker.queueName,
-        reason,
+        reason: context.reason,
+        lastErrorMessage,
         restartCount: worker.restartCount,
       },
     });
@@ -492,7 +512,9 @@ export class WorkerMonitor {
       await this.options.alertHandler(payload);
     } catch (error) {
       this.options.logger.error(
-        `[worker-monitor] Alert handler failed: ${error instanceof Error ? error.message : String(error)}`,
+        `[worker-monitor] Alert handler failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
     }
 

--- a/backend/src/monitoring/workerMonitorInstance.ts
+++ b/backend/src/monitoring/workerMonitorInstance.ts
@@ -2,9 +2,11 @@ import { Worker } from 'bullmq';
 import { getConfiguredQueueNames, getNumber, getRedisConnection } from '../config/runtime';
 import { WorkerMonitor } from './workerMonitor';
 import { createLogger } from '../lib/logger';
+import { createNotificationManager } from '../services/notificationProvider';
 
 const logger = createLogger('worker-monitor');
 const redisConnection = getRedisConnection();
+const notificationManager = createNotificationManager();
 
 const queueNames = getConfiguredQueueNames();
 
@@ -16,7 +18,19 @@ const workerMonitor = new WorkerMonitor({
   maxRestartsPerHour: getNumber(process.env.WORKER_MONITOR_MAX_RESTARTS_PER_HOUR, 3),
   maxRecoveryAttempts: getNumber(process.env.WORKER_MONITOR_MAX_RECOVERY_ATTEMPTS, 5),
   alertHandler: async (alert) => {
-    // Replace this callback with PagerDuty/Slack/email integration in production.
+    const details = {
+      code: alert.code,
+      ...(alert.metadata ?? {}),
+    };
+
+    await notificationManager.sendAlert({
+      severity: alert.severity,
+      service: 'worker-monitor',
+      message: alert.message,
+      details,
+      timestamp: alert.timestamp,
+    });
+
     logger.warn('Worker monitor alert', { alert });
   },
 });

--- a/backend/src/services/notificationProvider.ts
+++ b/backend/src/services/notificationProvider.ts
@@ -16,6 +16,31 @@ export interface NotificationProvider {
   send(alert: AlertPayload): Promise<void>;
 }
 
+function formatAlertSummary(alert: AlertPayload): string {
+  const queueName =
+    typeof alert.details?.queueName === 'string' ? alert.details.queueName : undefined;
+  const lastErrorMessage =
+    typeof alert.details?.lastErrorMessage === 'string'
+      ? alert.details.lastErrorMessage
+      : typeof alert.details?.error === 'string'
+      ? alert.details.error
+      : typeof alert.details?.failedReason === 'string'
+      ? alert.details.failedReason
+      : undefined;
+
+  const context: string[] = [];
+
+  if (queueName) {
+    context.push(`queue=${queueName}`);
+  }
+
+  if (lastErrorMessage) {
+    context.push(`lastError=${lastErrorMessage}`);
+  }
+
+  return context.length > 0 ? `${alert.message} (${context.join(', ')})` : alert.message;
+}
+
 @injectable()
 class SlackNotificationProvider implements NotificationProvider {
   private webhookUrl: string;
@@ -27,12 +52,13 @@ class SlackNotificationProvider implements NotificationProvider {
   async send(alert: AlertPayload): Promise<void> {
     try {
       const color = alert.severity === 'critical' ? 'danger' : 'warning';
+      const summary = formatAlertSummary(alert);
       const payload = {
         attachments: [
           {
             color,
             title: `${alert.severity.toUpperCase()}: ${alert.service}`,
-            text: alert.message,
+            text: summary,
             fields: alert.details
               ? Object.entries(alert.details).map(([key, value]) => ({
                   title: key,
@@ -75,12 +101,13 @@ class PagerDutyNotificationProvider implements NotificationProvider {
 
   async send(alert: AlertPayload): Promise<void> {
     try {
+      const summary = formatAlertSummary(alert);
       const payload = {
         routing_key: this.integrationKey,
         event_action: alert.severity === 'critical' ? 'trigger' : 'resolve',
         dedup_key: `${alert.service}-${alert.timestamp}`,
         payload: {
-          summary: `${alert.service}: ${alert.message}`,
+          summary: `${alert.service}: ${summary}`,
           severity: alert.severity === 'critical' ? 'critical' : 'warning',
           source: 'SocialFlow Health Monitor',
           custom_details: alert.details || {},


### PR DESCRIPTION
## Summary
- send worker monitor alerts through the shared notification providers
- include queue name and last error message in worker alert details
- surface queue and last error in Slack and PagerDuty alert summaries
- add focused notification provider tests for worker alert context

Closes #708