### PR TITLE
fix: Add explicit egress rules to NetworkPolicy

### DIFF
--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -18,19 +18,42 @@ spec:
         - protocol: TCP
           port: 3001
   egress:
-    # DNS
-    - ports:
+    # DNS - required for all name resolution
+    - to:
+        - namespaceSelector: {}
+      ports:
         - protocol: UDP
           port: 53
-    # Redis
-    - ports:
+    # Redis (ElastiCache) - session and queue storage
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
         - protocol: TCP
           port: 6379
-    # PostgreSQL
-    - ports:
+    # PostgreSQL (RDS) - primary database
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgres
+      ports:
         - protocol: TCP
           port: 5432
-    # OTLP collector
-    - ports:
+    # OTLP collector - observability telemetry
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app: opentelemetry-collector
+      ports:
         - protocol: TCP
           port: 4318
+    # External platform APIs - HTTPS only
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
- Added podSelector and namespaceSelector to egress rules
- DNS: Allow to all namespaces for name resolution
- Redis: Restrict to pods with app=redis label
- PostgreSQL: Restrict to pods with app=postgres label
- OTLP: Restrict to monitoring namespace collector pods
- External APIs: Allow HTTPS (443) for platform API calls
- Limits blast radius by restricting pod egress to required endpoints

Closes #690