### PR TITLE
fix: Replace minAvailable with maxUnavailable in PodDisruptionBudget

### DIFF
--- a/k8s/base/pdb.yaml
+++ b/k8s/base/pdb.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: socialflow-backend
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: socialflow-backend


### PR DESCRIPTION
- Changed from minAvailable: 1 to maxUnavailable: 1
- Prevents node drains from blocking on single-replica deployments
- Allows voluntary disruptions while maintaining availability
- maxUnavailable: 1 permits disruption when replicas > 1

Closes #692