### PR TITLE
fix: replace default Elasticsearch credentials with environment variable

### DIFF
--- a/backend/elk/docker-compose.yml
+++ b/backend/elk/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false
+      - xpack.security.enabled=true
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:?ELASTIC_PASSWORD must be set and not use default 'changeme'}
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     ports:
       - '9200:9200'


### PR DESCRIPTION
- Replace hardcoded ELASTIC_PASSWORD with
- Add validation that fails if password is not set
- Enable xpack.security for proper authentication

Closes #698