### PR TITLE
docs: Document migration validation on pull requests

### DIFF
--- a/backend/docs/ci-migration-validation.md
+++ b/backend/docs/ci-migration-validation.md
@@ -1,0 +1,28 @@
+# CI Migration Validation
+
+## Overview
+
+The `.github/workflows/migrations.yml` workflow validates database migrations on both pull requests and pushes to main.
+
+## Trigger Configuration
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'backend/prisma/migrations/**'
+      - 'backend/prisma/schema.prisma'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/prisma/migrations/**'
+      - 'backend/prisma/schema.prisma'
+```
+
+## Benefits
+
+- Catches schema conflicts before merge rather than after
+- Validates migrations against a test PostgreSQL database
+- Runs on every PR targeting main that modifies schema or migrations
+- Prevents broken migrations from reaching production


### PR DESCRIPTION
Confirm that migration validation runs on pull requests targeting main. This catches schema conflicts before merge rather than after. Closes #696