### PR TITLE
fix(lock-service): extend lock TTL periodically to prevent mid-operation expiry

### DIFF
--- a/backend/src/__tests__/LockService.test.ts
+++ b/backend/src/__tests__/LockService.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for LockService TTL extension (issue #718).
+ *
+ * Verifies that withLock keeps the lock alive for the full operation duration
+ * even when the operation runs longer than the initial TTL.
+ */
+
+jest.mock('ioredis');
+jest.mock('redlock');
+
+import Redlock from 'redlock';
+
+const mockExtend = jest.fn();
+const mockUnlock = jest.fn().mockResolvedValue(undefined);
+const mockLock = jest.fn();
+
+// Build a fake lock object factory
+const makeFakeLock = () => ({
+  extend: mockExtend,
+  unlock: mockUnlock,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+
+  // extend returns a new lock-like object each time
+  mockExtend.mockImplementation(() => Promise.resolve(makeFakeLock()));
+
+  // redlock.lock resolves immediately with a fake lock
+  (Redlock as unknown as jest.Mock).mockImplementation(() => ({
+    lock: mockLock.mockResolvedValue(makeFakeLock()),
+  }));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// Re-require after mocks are set up so the module picks up the mocked Redlock
+function getLockService() {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('../utils/LockService').LockService as typeof import('../utils/LockService').LockService;
+}
+
+describe('LockService.withLock – TTL extension', () => {
+  it('acquires the lock and releases it on success', async () => {
+    const LockService = getLockService();
+    const result = await LockService.withLock('test-key', async () => 'ok', { duration: 1000 });
+    expect(result).toBe('ok');
+    expect(mockLock).toHaveBeenCalledTimes(1);
+    expect(mockUnlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('extends the lock at TTL/2 intervals while the operation runs', async () => {
+    const LockService = getLockService();
+    const duration = 1000;
+
+    // Start a long-running operation that we control manually
+    let resolveOp!: () => void;
+    const opPromise = LockService.withLock(
+      'extend-key',
+      () => new Promise<void>((res) => { resolveOp = res; }),
+      { duration },
+    );
+
+    // Advance time by TTL/2 — one extend should fire
+    await jest.advanceTimersByTimeAsync(duration / 2);
+    expect(mockExtend).toHaveBeenCalledTimes(1);
+
+    // Advance another TTL/2 — second extend
+    await jest.advanceTimersByTimeAsync(duration / 2);
+    expect(mockExtend).toHaveBeenCalledTimes(2);
+
+    // Finish the operation
+    resolveOp();
+    await opPromise;
+
+    // Lock must be released after the operation completes
+    expect(mockUnlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops extending after the operation finishes', async () => {
+    const LockService = getLockService();
+    const duration = 1000;
+
+    await LockService.withLock('stop-extend-key', async () => 'done', { duration });
+
+    const callsAfterFinish = mockExtend.mock.calls.length;
+
+    // Advance time well past TTL — no more extends should happen
+    await jest.advanceTimersByTimeAsync(duration * 3);
+    expect(mockExtend.mock.calls.length).toBe(callsAfterFinish);
+  });
+
+  it('releases the lock even when the operation throws', async () => {
+    const LockService = getLockService();
+
+    await expect(
+      LockService.withLock('error-key', async () => { throw new Error('boom'); }, { duration: 500 }),
+    ).rejects.toThrow('boom');
+
+    expect(mockUnlock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/utils/LockService.ts
+++ b/backend/src/utils/LockService.ts
@@ -25,7 +25,10 @@ export interface LockOptions {
 
 export const LockService = {
   /**
-   * Acquire a lock and execute a function
+   * Acquire a lock and execute a function.
+   * A background interval extends the lock TTL every TTL/2 ms so the lock
+   * is held for the full duration of the operation even when it exceeds the
+   * initial TTL.
    */
   async withLock<T>(key: string, fn: () => Promise<T>, options: LockOptions = {}): Promise<T> {
     const duration = options.duration || 30000; // 30 seconds default
@@ -36,10 +39,24 @@ export const LockService = {
       lock = await redlock.lock(lockKey, duration);
       logger.info(`Lock acquired: ${lockKey}`);
 
+      // Extend the lock TTL every TTL/2 ms while the operation is running.
+      let currentLock = lock;
+      const extendInterval = setInterval(async () => {
+        try {
+          currentLock = await currentLock.extend(duration);
+          logger.debug(`Lock extended: ${lockKey}`);
+        } catch (extErr) {
+          logger.warn(`Failed to extend lock: ${lockKey}`, {
+            error: extErr instanceof Error ? extErr.message : String(extErr),
+          });
+        }
+      }, Math.floor(duration / 2));
+
       try {
         return await fn();
       } finally {
-        await lock.unlock().catch((err) => {
+        clearInterval(extendInterval);
+        await currentLock.unlock().catch((err) => {
           logger.error(`Failed to unlock ${lockKey}`, { error: err.message });
         });
         logger.info(`Lock released: ${lockKey}`);


### PR DESCRIPTION


Closes #718

- Start a setInterval at TTL/2 ms inside withLock that calls lock.extend() so mutual exclusion is maintained for operations longer than the initial TTL
- Clear the interval in the finally block before unlocking
- Track the latest lock reference returned by extend() for correct unlock
- Add LockService.test.ts asserting extension fires at TTL/2 intervals and stops after the operation completes