### PR TITLE
fix(otel): flush OTel spans in afterAll to prevent test-exit warnings

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -42,6 +42,7 @@ module.exports = {
         '^.*/utils/LockService$': '<rootDir>/src/__tests__/__mocks__/LockService.js',
       },
       setupFiles: ['<rootDir>/src/__tests__/unitSetup.ts'],
+      setupFilesAfterEnv: ['<rootDir>/src/__tests__/otelTeardown.ts'],
       transform: { '^.+\\.tsx?$': ['ts-jest', { diagnostics: false }] },
     },
     {

--- a/backend/src/__tests__/otelTeardown.ts
+++ b/backend/src/__tests__/otelTeardown.ts
@@ -1,0 +1,23 @@
+/**
+ * otelTeardown.ts
+ *
+ * Flushes buffered OTel spans after all tests in a suite complete.
+ * Prevents "span exporter" warnings caused by Jest calling process.exit()
+ * before the BatchSpanProcessor drains its queue (issue #710).
+ *
+ * Registered via setupFilesAfterFramework in jest.config.js so that
+ * afterAll is available.
+ */
+
+afterAll(async () => {
+  try {
+    // Dynamically import to avoid initialising the SDK during module load.
+    // tracing.ts is excluded from coverage so this import is safe in tests.
+    const tracing = await import('../tracing').catch(() => null);
+    if (tracing?.shutdownOtel) {
+      await tracing.shutdownOtel(3_000);
+    }
+  } catch {
+    // Swallow — a shutdown failure must never fail the test suite.
+  }
+});


### PR DESCRIPTION
Closes #710

- Add otelTeardown.ts with a global afterAll hook that calls shutdownOtel()
- Register it via setupFilesAfterEnv in the unit project of jest.config.js
- Dynamic import guards against SDK initialisation during module load
- Errors are swallowed so a shutdown failure never fails the test suite