### PR TITLE
feat(metrics): warn on unmapped route prefix in resolveCategory

### DIFF
--- a/backend/src/lib/metrics.ts
+++ b/backend/src/lib/metrics.ts
@@ -1,4 +1,7 @@
 import { Registry, Histogram, Counter, Gauge, collectDefaultMetrics } from 'prom-client';
+import { createLogger } from './logger';
+
+const logger = createLogger('metrics');
 
 export const register = new Registry();
 
@@ -84,5 +87,6 @@ export function resolveCategory(path: string): string {
   if (/^\/(health|status)/.test(path) || /\/health/.test(path)) return 'health';
   if (/\/auth/.test(path)) return 'auth';
   if (/\/(ai|tts|translation)/.test(path)) return 'ai';
+  logger.warn(`resolveCategory: unmapped route prefix — falling back to "general"`, { path });
   return 'general';
 }


### PR DESCRIPTION
Closes #711

- Import logger into metrics.ts
- Add logger.warn() in the default case of resolveCategory with the unmapped path so developers are alerted when a new route is added without updating the category map