### PR TITLE
fix(auth-e2e): fix UserStore reset between tests by adding clear() method

### DIFF
--- a/backend/src/__tests__/integration/auth.e2e.test.ts
+++ b/backend/src/__tests__/integration/auth.e2e.test.ts
@@ -4,7 +4,7 @@ import app from '../../app';
 import { UserStore } from '../../models/User';
 
 afterEach(() => {
-  (UserStore as any).users = new Map();
+  UserStore.clear();
 });
 
 // ── Register ──────────────────────────────────────────────────────────────────

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -27,4 +27,7 @@ export const UserStore = {
     users.set(id, updated);
     return updated;
   },
+
+  /** Clear all users — intended for test teardown only. */
+  clear: (): void => users.clear(),
 };


### PR DESCRIPTION
closes #712 

(UserStore as any).users = new Map() assigns a property on the UserStore
object but never touches the module-scoped const map the closures close
over, causing state to leak between tests.

Add UserStore.clear() which calls users.clear() on the real map, and
update afterEach to use it.
