### PR TITLE
fix(feature-flags): replace djb2 with FNV-1a hash to fix uneven bucket distribution 

### DIFF
--- a/backend/src/services/FeatureService.ts
+++ b/backend/src/services/FeatureService.ts
@@ -122,16 +122,21 @@ export class FeatureService {
   }
 
   /**
-   * Deterministic bucket assignment using djb2 hash.
+   * Deterministic bucket assignment using FNV-1a 32-bit hash.
+   * FNV-1a distributes sequential integer IDs evenly, avoiding the clustering
+   * that modulo on raw numeric IDs produces.
    * Returns a number 0–99 so we can compare against a percentage.
    */
   private hashBucket(flagName: string, userId: string): number {
     const input = `${flagName}:${userId}`;
-    let hash = 5381;
+    // FNV-1a 32-bit constants
+    let hash = 0x811c9dc5; // offset basis
     for (let i = 0; i < input.length; i++) {
-      hash = (hash * 33) ^ input.charCodeAt(i);
+      hash ^= input.charCodeAt(i);
+      // Multiply by FNV prime (0x01000193), keeping result in 32-bit range
+      hash = (hash * 0x01000193) >>> 0;
     }
-    return Math.abs(hash) % 100;
+    return hash % 100;
   }
 }
 

--- a/backend/src/services/__tests__/FeatureService.test.ts
+++ b/backend/src/services/__tests__/FeatureService.test.ts
@@ -1,0 +1,64 @@
+import { FeatureService } from '../FeatureService';
+import { dynamicConfigService } from '../DynamicConfigService';
+
+jest.mock('../DynamicConfigService', () => ({
+  dynamicConfigService: {
+    get: jest.fn(),
+    set: jest.fn(),
+    getStatus: jest.fn(() => ({ cachedKeys: [] })),
+  },
+}));
+
+const mockGet = dynamicConfigService.get as jest.Mock;
+
+describe('FeatureService.hashBucket – FNV-1a distribution', () => {
+  // Access private method via cast
+  const svc = new FeatureService() as any;
+
+  it('returns a value in [0, 99] for any input', () => {
+    for (let i = 0; i < 200; i++) {
+      const bucket = svc.hashBucket('flag', String(i));
+      expect(bucket).toBeGreaterThanOrEqual(0);
+      expect(bucket).toBeLessThan(100);
+    }
+  });
+
+  it('distributes 1000 sequential integer user IDs evenly across buckets', () => {
+    const counts = new Array(100).fill(0);
+    for (let i = 0; i < 1000; i++) {
+      counts[svc.hashBucket('rollout', String(i))]++;
+    }
+    // With 1000 users across 100 buckets the expected count is 10.
+    // Allow ±8 variance (80 % tolerance) to confirm no severe clustering.
+    for (const count of counts) {
+      expect(count).toBeGreaterThanOrEqual(2);
+      expect(count).toBeLessThanOrEqual(18);
+    }
+  });
+
+  it('is deterministic – same inputs always produce the same bucket', () => {
+    expect(svc.hashBucket('feat', '42')).toBe(svc.hashBucket('feat', '42'));
+    expect(svc.hashBucket('feat', '1')).toBe(svc.hashBucket('feat', '1'));
+  });
+
+  it('produces different buckets for different flag names with the same user ID', () => {
+    const b1 = svc.hashBucket('flag-a', '100');
+    const b2 = svc.hashBucket('flag-b', '100');
+    // Not guaranteed to differ for every pair, but these specific values do
+    expect(b1).not.toBe(b2);
+  });
+});
+
+describe('FeatureService.isEnabled – canary strategy', () => {
+  const svc = new FeatureService();
+
+  it('always returns true when percentage is 100', () => {
+    mockGet.mockReturnValue({ enabled: true, strategy: 'canary', percentage: 100 });
+    expect(svc.isEnabled('flag', { userId: '1' })).toBe(true);
+  });
+
+  it('always returns false when percentage is 0', () => {
+    mockGet.mockReturnValue({ enabled: true, strategy: 'canary', percentage: 0 });
+    expect(svc.isEnabled('flag', { userId: '1' })).toBe(false);
+  });
+});


### PR DESCRIPTION


Sequential integer user IDs fed into djb2 with modulo caused clustering because consecutive inputs produce correlated hash values. FNV-1a uses XOR-folding which spreads sequential IDs uniformly across the 0-99 range.

- Replace hashBucket implementation with FNV-1a 32-bit algorithm
- Use >>> 0 to keep arithmetic in unsigned 32-bit range
- Add tests asserting even distribution for 1000 sequential IDs

Closes #721