### PR TITLE
feat(config): expose DYNAMIC_CONFIG_POLL_INTERVAL_MS env var (#717)

### DIFF
--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -116,6 +116,9 @@ const envSchema = z.object({
   // ── Webhooks ──────────────────────────────────────────────────────────────
   HMAC_TIMESTAMP_TOLERANCE_MS: z.coerce.number().default(300000),
 
+  // ── Dynamic Config ────────────────────────────────────────────────────────
+  DYNAMIC_CONFIG_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(60000),
+
   // ── Rate Limiting ─────────────────────────────────────────────────────────
   RATE_LIMIT_STORE: z.enum(['redis', 'memory']).default('redis'),
 

--- a/backend/src/services/DynamicConfigService.ts
+++ b/backend/src/services/DynamicConfigService.ts
@@ -1,4 +1,5 @@
 import { prisma } from '../lib/prisma';
+import { config } from '../config/config';
 
 export enum ConfigKey {
   RATE_LIMIT_MAX = 'RATE_LIMIT_MAX',
@@ -168,5 +169,7 @@ export class DynamicConfigService {
   }
 }
 
-// Export a singleton instance
-export const dynamicConfigService = new DynamicConfigService();
+// Export a singleton instance — interval read from env so no code change needed
+export const dynamicConfigService = new DynamicConfigService(
+  config.DYNAMIC_CONFIG_POLL_INTERVAL_MS,
+);

--- a/backend/src/services/__tests__/DynamicConfigService.test.ts
+++ b/backend/src/services/__tests__/DynamicConfigService.test.ts
@@ -1,0 +1,73 @@
+import { DynamicConfigService } from '../DynamicConfigService';
+
+// Prevent real DB calls
+jest.mock('../../lib/prisma', () => ({
+  prisma: { dynamicConfig: { findMany: jest.fn().mockResolvedValue([]) } },
+}));
+
+describe('DynamicConfigService – poll interval', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('uses the provided interval (default 60 000 ms)', () => {
+    const svc = new DynamicConfigService(60000);
+    const refreshSpy = jest.spyOn(svc as any, 'refreshCache').mockResolvedValue(undefined);
+
+    svc.stopPolling();
+    (svc as any).pollingInterval = null;
+    svc.startPolling();
+
+    jest.advanceTimersByTime(60000);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(60000);
+    expect(refreshSpy).toHaveBeenCalledTimes(2);
+
+    svc.stopPolling();
+  });
+
+  it('respects a custom interval passed to the constructor', () => {
+    const svc = new DynamicConfigService(5000);
+    const refreshSpy = jest.spyOn(svc as any, 'refreshCache').mockResolvedValue(undefined);
+
+    svc.stopPolling();
+    (svc as any).pollingInterval = null;
+    svc.startPolling();
+
+    jest.advanceTimersByTime(5000);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    // Should NOT fire again before the next 5 s window
+    jest.advanceTimersByTime(4999);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    svc.stopPolling();
+  });
+
+  it('reads DYNAMIC_CONFIG_POLL_INTERVAL_MS from env via config', () => {
+    // The singleton is constructed with config.DYNAMIC_CONFIG_POLL_INTERVAL_MS.
+    // We verify the env var is wired up by checking the schema default.
+    const originalEnv = process.env.DYNAMIC_CONFIG_POLL_INTERVAL_MS;
+    process.env.DYNAMIC_CONFIG_POLL_INTERVAL_MS = '15000';
+
+    // Re-import to pick up the new env value
+    jest.resetModules();
+    const { validateEnv } = require('../../config/config');
+    const cfg = validateEnv(process.env);
+    expect(cfg.DYNAMIC_CONFIG_POLL_INTERVAL_MS).toBe(15000);
+
+    process.env.DYNAMIC_CONFIG_POLL_INTERVAL_MS = originalEnv;
+  });
+
+  it('defaults to 60 000 ms when env var is not set', () => {
+    jest.resetModules();
+    const saved = process.env.DYNAMIC_CONFIG_POLL_INTERVAL_MS;
+    delete process.env.DYNAMIC_CONFIG_POLL_INTERVAL_MS;
+
+    const { validateEnv } = require('../../config/config');
+    const cfg = validateEnv(process.env);
+    expect(cfg.DYNAMIC_CONFIG_POLL_INTERVAL_MS).toBe(60000);
+
+    process.env.DYNAMIC_CONFIG_POLL_INTERVAL_MS = saved;
+  });
+});


### PR DESCRIPTION
DynamicConfigService hardcoded a 60-second poll interval, making it impossible to tune per-environment without a code change.

- Add DYNAMIC_CONFIG_POLL_INTERVAL_MS to the zod env schema (default 60000)
- Pass config.DYNAMIC_CONFIG_POLL_INTERVAL_MS to the singleton constructor
- Add tests asserting the configured interval drives the polling timer

Closes #717