### PR TITLE
fix(graphql): enforce blacklist check in requireAuth for logged-out t…

### DIFF
--- a/backend/src/graphql/__tests__/resolvers.test.ts
+++ b/backend/src/graphql/__tests__/resolvers.test.ts
@@ -1,0 +1,59 @@
+import { AuthBlacklistService } from '../../services/AuthBlacklistService';
+
+jest.mock('../../services/AuthBlacklistService', () => ({
+  AuthBlacklistService: {
+    isBlacklisted: jest.fn(),
+    keyFromPayload: jest.fn((p: any) => p.jti ?? `${p.sub}:${p.iat}`),
+    blacklistToken: jest.fn(),
+    accessTokenTTL: jest.fn(() => 900),
+  },
+}));
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    post: { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() },
+  },
+}));
+
+// Import resolvers AFTER mocks are set up
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolvers } = require('../resolvers');
+
+const mockIsBlacklisted = AuthBlacklistService.isBlacklisted as jest.Mock;
+
+describe('GraphQL requireAuth – blacklist enforcement', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('throws UNAUTHENTICATED when userId is missing', async () => {
+    await expect(resolvers.Query.me({}, {}, {})).rejects.toThrow('UNAUTHENTICATED');
+  });
+
+  it('throws UNAUTHENTICATED when token is blacklisted', async () => {
+    mockIsBlacklisted.mockResolvedValue(true);
+    const ctx = { userId: 'user-1', tokenKey: 'jti-abc' };
+    await expect(resolvers.Query.me({}, {}, ctx)).rejects.toThrow('UNAUTHENTICATED');
+    expect(mockIsBlacklisted).toHaveBeenCalledWith('jti-abc');
+  });
+
+  it('allows the query when token is valid and not blacklisted', async () => {
+    mockIsBlacklisted.mockResolvedValue(false);
+    const { prisma } = require('../../lib/prisma');
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-1' });
+
+    const ctx = { userId: 'user-1', tokenKey: 'jti-abc' };
+    const result = await resolvers.Query.me({}, {}, ctx);
+    expect(result).toEqual({ id: 'user-1' });
+    expect(mockIsBlacklisted).toHaveBeenCalledWith('jti-abc');
+  });
+
+  it('skips blacklist check when no tokenKey is present (legacy context)', async () => {
+    const { prisma } = require('../../lib/prisma');
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2' });
+
+    const ctx = { userId: 'user-2' }; // no tokenKey
+    const result = await resolvers.Query.me({}, {}, ctx);
+    expect(result).toEqual({ id: 'user-2' });
+    expect(mockIsBlacklisted).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/graphql/context.ts
+++ b/backend/src/graphql/context.ts
@@ -5,6 +5,13 @@ import { AuthBlacklistService } from '../services/AuthBlacklistService';
 export interface GraphQLContext {
   /** Authenticated user ID, or undefined for unauthenticated requests. */
   userId?: string;
+  /**
+   * Stable token key derived from the JWT payload (jti or sub:iat).
+   * Present whenever a valid (signature-verified) Bearer token was supplied,
+   * even if the token has been blacklisted. Used by requireAuth to enforce
+   * the blacklist check at the resolver layer.
+   */
+  tokenKey?: string;
 }
 
 const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
@@ -32,5 +39,5 @@ export async function buildContext({ req }: { req: Request }): Promise<GraphQLCo
   const tokenKey = AuthBlacklistService.keyFromPayload(payload);
   if (await AuthBlacklistService.isBlacklisted(tokenKey)) return {};
 
-  return { userId: payload.sub as string };
+  return { userId: payload.sub as string, tokenKey };
 }

--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -1,6 +1,7 @@
 import { GraphQLScalarType, Kind } from 'graphql';
 import { prisma } from '../lib/prisma';
 import { GraphQLContext } from './context';
+import { AuthBlacklistService } from '../services/AuthBlacklistService';
 
 const DateTimeScalar = new GraphQLScalarType({
   name: 'DateTime',
@@ -10,9 +11,18 @@ const DateTimeScalar = new GraphQLScalarType({
   parseLiteral: (ast) => (ast.kind === Kind.STRING ? new Date(ast.value) : null),
 });
 
-/** Throw a standard unauthenticated error when there is no user in context. */
-function requireAuth(ctx: GraphQLContext): string {
+/**
+ * Throw a standard unauthenticated error when there is no user in context,
+ * or when the token has been blacklisted (e.g. after logout).
+ */
+async function requireAuth(ctx: GraphQLContext): Promise<string> {
   if (!ctx.userId) throw new Error('UNAUTHENTICATED');
+
+  // Guard against valid-but-blacklisted tokens that somehow bypassed buildContext
+  if (ctx.tokenKey && await AuthBlacklistService.isBlacklisted(ctx.tokenKey)) {
+    throw new Error('UNAUTHENTICATED');
+  }
+
   return ctx.userId;
 }
 
@@ -22,13 +32,13 @@ export const resolvers = {
   Query: {
     /** Return the currently authenticated user. */
     me: async (_: unknown, __: unknown, ctx: GraphQLContext) => {
-      const userId = requireAuth(ctx);
+      const userId = await requireAuth(ctx);
       return prisma.user.findUnique({ where: { id: userId } });
     },
 
     /** Return a single user by ID. */
     user: async (_: unknown, { id }: { id: string }, ctx: GraphQLContext) => {
-      requireAuth(ctx);
+      await requireAuth(ctx);
       return prisma.user.findUnique({ where: { id } });
     },
 
@@ -38,7 +48,7 @@ export const resolvers = {
       { organizationId }: { organizationId: string },
       ctx: GraphQLContext,
     ) => {
-      requireAuth(ctx);
+      await requireAuth(ctx);
       return prisma.post.findMany({
         where: { organizationId },
         orderBy: { createdAt: 'desc' },
@@ -47,7 +57,7 @@ export const resolvers = {
 
     /** Return a single post by ID. */
     post: async (_: unknown, { id }: { id: string }, ctx: GraphQLContext) => {
-      requireAuth(ctx);
+      await requireAuth(ctx);
       return prisma.post.findUnique({ where: { id } });
     },
   },
@@ -59,7 +69,7 @@ export const resolvers = {
       { input }: { input: { organizationId: string; content: string; platform: string; scheduledAt?: Date } },
       ctx: GraphQLContext,
     ) => {
-      requireAuth(ctx);
+      await requireAuth(ctx);
       return prisma.post.create({ data: input });
     },
 
@@ -69,13 +79,13 @@ export const resolvers = {
       { id, input }: { id: string; input: { content?: string; platform?: string; scheduledAt?: Date } },
       ctx: GraphQLContext,
     ) => {
-      requireAuth(ctx);
+      await requireAuth(ctx);
       return prisma.post.update({ where: { id }, data: input });
     },
 
     /** Delete a post. Returns true on success. */
     deletePost: async (_: unknown, { id }: { id: string }, ctx: GraphQLContext) => {
-      requireAuth(ctx);
+      await requireAuth(ctx);
       await prisma.post.delete({ where: { id } });
       return true;
     },


### PR DESCRIPTION
…okens (#720)

requireAuth only checked for a userId in context but never verified the token against the blacklist. A valid-but-blacklisted token (e.g. after logout) could still reach resolvers if buildContext was bypassed or extended without the check.

- Add tokenKey field to GraphQLContext (populated by buildContext)
- requireAuth now calls AuthBlacklistService.isBlacklisted(tokenKey) and throws UNAUTHENTICATED if the token has been revoked
- All resolver calls updated to await the now-async requireAuth
- Add tests asserting blacklisted tokens are rejected

Closes #720