### PR TITLE
feat: S3 health check performs PutObject + DeleteObject write probe (…

### DIFF
--- a/backend/src/__tests__/healthService.test.ts
+++ b/backend/src/__tests__/healthService.test.ts
@@ -163,15 +163,15 @@ describe('HealthService — real dependency probes', () => {
       }
     });
 
-    it('returns healthy when S3 bucket is accessible', async () => {
+    it('returns healthy when S3 write probe succeeds', async () => {
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
       process.env.AWS_S3_BUCKET = 'test-bucket';
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        status: 200,
-        ok: true,
-      });
+      // PUT succeeds, DELETE succeeds
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })
+        .mockResolvedValueOnce({ status: 204, ok: true });
 
       const svc = makeService();
       const result = await svc.checkS3();
@@ -179,7 +179,11 @@ describe('HealthService — real dependency probes', () => {
       expect(result.status).toBe('healthy');
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('test-bucket'),
-        expect.objectContaining({ method: 'HEAD' }),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('.health-check'),
+        expect.objectContaining({ method: 'DELETE' }),
       );
     });
 
@@ -195,22 +199,36 @@ describe('HealthService — real dependency probes', () => {
       expect(result.error).toContain('AWS_S3_BUCKET');
     });
 
-    it('accepts 403 and 404 as connectivity indicators', async () => {
+    it('returns degraded when PutObject is denied (write permission missing)', async () => {
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
       process.env.AWS_S3_BUCKET = 'test-bucket';
 
-      const svc = makeService();
-
-      // 403 Forbidden
+      // PUT returns 403 Forbidden — no write permission
       (global.fetch as jest.Mock).mockResolvedValueOnce({ status: 403, ok: false });
-      let result = await svc.checkS3();
-      expect(result.status).toBe('healthy');
 
-      // 404 Not Found
-      (global.fetch as jest.Mock).mockResolvedValueOnce({ status: 404, ok: false });
-      result = await svc.checkS3();
-      expect(result.status).toBe('healthy');
+      const svc = makeService();
+      const result = await svc.checkS3();
+
+      expect(result.status).toBe('degraded');
+      expect(result.error).toContain('PutObject returned 403');
+    });
+
+    it('returns degraded when DeleteObject fails after successful put', async () => {
+      process.env.AWS_ACCESS_KEY_ID = 'test-key';
+      process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
+      process.env.AWS_S3_BUCKET = 'test-bucket';
+
+      // PUT succeeds, DELETE returns unexpected error
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })
+        .mockResolvedValueOnce({ status: 500, ok: false });
+
+      const svc = makeService();
+      const result = await svc.checkS3();
+
+      expect(result.status).toBe('degraded');
+      expect(result.error).toContain('DeleteObject returned 500');
     });
 
     it('returns unhealthy after 3 S3 failures', async () => {
@@ -330,7 +348,11 @@ describe('HealthService — real dependency probes', () => {
     it('returns healthy when all dependencies are healthy', async () => {
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ '1': 1 }]);
       (redis.ping as jest.Mock).mockResolvedValue('PONG');
-      (global.fetch as jest.Mock).mockResolvedValue({ status: 200, ok: true });
+      // S3 write probe: PUT then DELETE
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })  // S3 PUT
+        .mockResolvedValueOnce({ status: 204, ok: true })  // S3 DELETE
+        .mockResolvedValue({ status: 200, ok: true });     // Twitter
 
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
@@ -350,7 +372,11 @@ describe('HealthService — real dependency probes', () => {
     it('returns degraded when one dependency is degraded', async () => {
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ '1': 1 }]);
       (redis.ping as jest.Mock).mockRejectedValue(new Error('Connection failed'));
-      (global.fetch as jest.Mock).mockResolvedValue({ status: 200, ok: true });
+      // S3 write probe: PUT then DELETE
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })  // S3 PUT
+        .mockResolvedValueOnce({ status: 204, ok: true })  // S3 DELETE
+        .mockResolvedValue({ status: 200, ok: true });     // Twitter
 
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
@@ -392,7 +418,11 @@ describe('HealthService — real dependency probes', () => {
 
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ '1': 1 }]);
       (redis.ping as jest.Mock).mockResolvedValue('PONG');
-      (global.fetch as jest.Mock).mockResolvedValue({ status: 200, ok: true });
+      // S3 write probe: PUT then DELETE
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })  // S3 PUT
+        .mockResolvedValueOnce({ status: 204, ok: true })  // S3 DELETE
+        .mockResolvedValue({ status: 200, ok: true });     // Twitter
 
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
@@ -422,7 +452,11 @@ describe('HealthService — real dependency probes', () => {
     it('does not throw when no healthMonitor is set', async () => {
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ '1': 1 }]);
       (redis.ping as jest.Mock).mockResolvedValue('PONG');
-      (global.fetch as jest.Mock).mockResolvedValue({ status: 200, ok: true });
+      // S3 write probe: PUT then DELETE
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })  // S3 PUT
+        .mockResolvedValueOnce({ status: 204, ok: true })  // S3 DELETE
+        .mockResolvedValue({ status: 200, ok: true });     // Twitter
 
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
@@ -436,7 +470,11 @@ describe('HealthService — real dependency probes', () => {
     it('includes latency and error messages for all dependencies', async () => {
       (prisma.$queryRaw as jest.Mock).mockRejectedValue(new Error('Connection refused'));
       (redis.ping as jest.Mock).mockResolvedValue('PONG');
-      (global.fetch as jest.Mock).mockResolvedValue({ status: 200, ok: true });
+      // S3 write probe: PUT then DELETE
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, ok: true })  // S3 PUT
+        .mockResolvedValueOnce({ status: 204, ok: true })  // S3 DELETE
+        .mockResolvedValue({ status: 200, ok: true });     // Twitter
 
       process.env.AWS_ACCESS_KEY_ID = 'test-key';
       process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';

--- a/backend/src/services/healthService.ts
+++ b/backend/src/services/healthService.ts
@@ -10,6 +10,7 @@ const logger = createLogger('health-service');
 
 const MIN_TIMEOUT_MS = 100;
 const UNHEALTHY_THRESHOLD = 3;
+const S3_HEALTH_KEY = '.health-check';
 
 export interface DependencyStatus {
   status: 'healthy' | 'degraded' | 'unhealthy';
@@ -106,15 +107,32 @@ export class HealthService {
 
     try {
       const region = process.env.AWS_REGION ?? 'us-east-1';
-      const url = `https://${bucket}.s3.${region}.amazonaws.com/`;
-      const res = await withTimeout(fetch(url, { method: 'HEAD' }), timeout, 's3');
-      // 200, 403, 404 all indicate S3 is reachable
-      if (res.status === 200 || res.status === 403 || res.status === 404) {
-        this.resetFailure('s3');
-        return { status: 'healthy', latency: Date.now() - start, lastChecked: new Date().toISOString(), errorRate: 0 };
+
+      // PutObject — write a tiny health-check object
+      const putUrl = `https://${bucket}.s3.${region}.amazonaws.com/${S3_HEALTH_KEY}`;
+      const putRes = await withTimeout(
+        fetch(putUrl, { method: 'PUT', body: 'ok', headers: { 'Content-Type': 'text/plain', 'Content-Length': '2' } }),
+        timeout,
+        's3-put',
+      );
+      if (putRes.status !== 200 && putRes.status !== 204) {
+        const count = this.recordFailure('s3');
+        return { status: this.statusFromCount(count), latency: Date.now() - start, lastChecked: new Date().toISOString(), errorRate: 100, error: `S3 PutObject returned ${putRes.status}` };
       }
-      const count = this.recordFailure('s3');
-      return { status: this.statusFromCount(count), latency: Date.now() - start, lastChecked: new Date().toISOString(), errorRate: 100, error: `S3 returned ${res.status}` };
+
+      // DeleteObject — clean up immediately
+      const delRes = await withTimeout(
+        fetch(putUrl, { method: 'DELETE' }),
+        timeout,
+        's3-delete',
+      );
+      if (delRes.status !== 200 && delRes.status !== 204 && delRes.status !== 404) {
+        const count = this.recordFailure('s3');
+        return { status: this.statusFromCount(count), latency: Date.now() - start, lastChecked: new Date().toISOString(), errorRate: 100, error: `S3 DeleteObject returned ${delRes.status}` };
+      }
+
+      this.resetFailure('s3');
+      return { status: 'healthy', latency: Date.now() - start, lastChecked: new Date().toISOString(), errorRate: 0 };
     } catch (err) {
       const count = this.recordFailure('s3');
       const error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
…#707)

- Replace HeadBucket with a PUT + DELETE round-trip to s3://bucket/.health-check
- Failure on PutObject (e.g. 403) is reported as degraded/unhealthy, catching missing write permissions that HeadBucket would silently pass
- DeleteObject 404 is treated as success (object already gone)
- Update healthService tests: replace HEAD mock with PUT/DELETE mocks, add cases for write-permission denial and delete failure

Closes #707