### PR TITLE
fix: enforce CI coverage thresholds with non-zero exit code (#706)

### DIFF
--- a/.github/scripts/post-coverage-comment.mjs
+++ b/.github/scripts/post-coverage-comment.mjs
@@ -67,3 +67,21 @@ export function checkThresholds(metrics, thresholds = THRESHOLDS) {
   );
   return { passed: violations.length === 0, violations };
 }
+
+// When executed directly (node .github/scripts/post-coverage-comment.mjs <path>)
+// exit non-zero if any threshold is violated so CI fails on regression.
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  const summaryPath = process.argv[2] ?? 'backend/coverage/coverage-summary.json';
+  const summary = loadSummary(summaryPath);
+  if (!summary) {
+    console.error(`Coverage summary not found: ${summaryPath}`);
+    process.exit(1);
+  }
+  const { passed, violations } = checkThresholds(summary);
+  if (!passed) {
+    console.error(`Coverage thresholds not met: ${violations.join(', ')}`);
+    process.exit(1);
+  }
+  console.log('All coverage thresholds met.');
+  process.exit(0);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,6 @@ jobs:
               issue_number: context.issue.number,
               body,
             });
+
+      - name: Enforce coverage thresholds
+        run: node .github/scripts/post-coverage-comment.mjs backend/coverage/coverage-summary.json


### PR DESCRIPTION
- Add main-guard block to post-coverage-comment.mjs that calls checkThresholds() and exits 1 when any metric is below threshold
- Add 'Enforce coverage thresholds' step to ci.yml that runs the script directly so the coverage job fails on regression

Closes #706