### PR TITLE
feat: grafana provisioning, CI caching, migration rollback tests, AI …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: package-lock.json
 
+      - name: Cache backend dependencies
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-
+
       - name: Install dependencies
         run: npm ci
 

--- a/backend/elk/docker-compose.yml
+++ b/backend/elk/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
 
 volumes:
   es_data:

--- a/backend/elk/grafana/provisioning/dashboards.yml
+++ b/backend/elk/grafana/provisioning/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: SocialFlow Dashboards
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/backend/src/__tests__/migrations.rollback.test.ts
+++ b/backend/src/__tests__/migrations.rollback.test.ts
@@ -1,0 +1,118 @@
+import Redis from 'ioredis';
+import { Logger } from '../lib/logger';
+import { runMigrations, rollbackMigration, listMigrations } from '../admin/migrationService';
+import {
+  ADMIN_MIGRATIONS_SET_KEY,
+  ADMIN_MIGRATIONS_LOCK_KEY,
+  ADMIN_MIGRATIONS_METADATA_KEY,
+  KNOWN_QUEUES_SET_KEY,
+} from '../admin/constants';
+import { getRedisConnection } from '../config/runtime';
+
+describe('Migration Rollback', () => {
+  let redis: Redis;
+  let mockLogger: Logger;
+
+  beforeEach(() => {
+    redis = new Redis(getRedisConnection());
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as Logger;
+  });
+
+  afterEach(async () => {
+    await redis.del(
+      ADMIN_MIGRATIONS_SET_KEY,
+      ADMIN_MIGRATIONS_LOCK_KEY,
+      ADMIN_MIGRATIONS_METADATA_KEY,
+      KNOWN_QUEUES_SET_KEY,
+    );
+    redis.disconnect();
+  });
+
+  describe('sync_configured_queues rollback', () => {
+    const MIGRATION = '20260324_sync_configured_queues';
+
+    it('up → down restores pre-migration state (queues set removed)', async () => {
+      // Verify queues set does not exist before migration
+      expect(await redis.exists(KNOWN_QUEUES_SET_KEY)).toBe(0);
+
+      // UP: run migration
+      const upResult = await runMigrations({ dryRun: false }, mockLogger);
+      expect(upResult.lockAcquired).toBe(true);
+
+      // Confirm migration is marked applied
+      const appliedAfterUp = await redis.sismember(ADMIN_MIGRATIONS_SET_KEY, MIGRATION);
+      expect(appliedAfterUp).toBe(1);
+
+      // DOWN: rollback
+      const downResult = await rollbackMigration(MIGRATION, mockLogger);
+      expect(downResult.success).toBe(true);
+
+      // Verify schema matches pre-migration state: queues set is gone
+      expect(await redis.exists(KNOWN_QUEUES_SET_KEY)).toBe(0);
+    });
+
+    it('up → down removes migration from applied set', async () => {
+      await runMigrations({ dryRun: false }, mockLogger);
+      expect(await redis.sismember(ADMIN_MIGRATIONS_SET_KEY, MIGRATION)).toBe(1);
+
+      await rollbackMigration(MIGRATION, mockLogger);
+
+      expect(await redis.sismember(ADMIN_MIGRATIONS_SET_KEY, MIGRATION)).toBe(0);
+    });
+
+    it('up → down removes migration metadata', async () => {
+      await runMigrations({ dryRun: false }, mockLogger);
+      expect(await redis.hexists(ADMIN_MIGRATIONS_METADATA_KEY, MIGRATION)).toBe(1);
+
+      await rollbackMigration(MIGRATION, mockLogger);
+
+      expect(await redis.hexists(ADMIN_MIGRATIONS_METADATA_KEY, MIGRATION)).toBe(0);
+    });
+
+    it('up → down → up re-applies migration cleanly', async () => {
+      // UP
+      const up1 = await runMigrations({ dryRun: false }, mockLogger);
+      expect(up1.executed).toContain(MIGRATION);
+
+      // DOWN
+      const down = await rollbackMigration(MIGRATION, mockLogger);
+      expect(down.success).toBe(true);
+
+      // UP again — migration should re-execute, not be skipped
+      const up2 = await runMigrations({ dryRun: false }, mockLogger);
+      expect(up2.executed).toContain(MIGRATION);
+      expect(up2.skipped).not.toContain(MIGRATION);
+    });
+
+    it('listMigrations reflects unapplied state after rollback', async () => {
+      await runMigrations({ dryRun: false }, mockLogger);
+
+      let statuses = await listMigrations();
+      expect(statuses.find((s) => s.name === MIGRATION)?.applied).toBe(true);
+
+      await rollbackMigration(MIGRATION, mockLogger);
+
+      statuses = await listMigrations();
+      expect(statuses.find((s) => s.name === MIGRATION)?.applied).toBe(false);
+    });
+  });
+
+  describe('rollback error handling', () => {
+    it('returns error when migration name does not exist', async () => {
+      const result = await rollbackMigration('nonexistent_migration', mockLogger);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not found/i);
+    });
+
+    it('returns error when migration was never applied', async () => {
+      const result = await rollbackMigration('20260324_sync_configured_queues', mockLogger);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not applied/i);
+    });
+  });
+});

--- a/backend/src/admin/migrationService.ts
+++ b/backend/src/admin/migrationService.ts
@@ -21,6 +21,7 @@ interface MigrationDefinition {
   name: string;
   description: string;
   run: (context: MigrationContext) => Promise<Record<string, unknown>>;
+  rollback?: (context: MigrationContext) => Promise<void>;
 }
 
 export interface MigrationStatus {
@@ -85,6 +86,12 @@ const migrations: MigrationDefinition[] = [
       });
 
       return { syncedQueues };
+    },
+    rollback: async ({ redis, logger }) => {
+      await redis.del(KNOWN_QUEUES_SET_KEY);
+      logger.info('Rolled back migration: removed known-queues set', {
+        migration: '20260324_sync_configured_queues',
+      });
     },
   },
 ];
@@ -362,6 +369,42 @@ export const runMigrations = async (
         await releaseMigrationLock(redis, logger);
       }
     }
+  } finally {
+    redis.disconnect();
+  }
+};
+
+export const rollbackMigration = async (
+  migrationName: string,
+  logger: Logger,
+): Promise<{ success: boolean; error?: string }> => {
+  const redis = new Redis(getRedisConnection());
+
+  try {
+    const migration = migrations.find((m) => m.name === migrationName);
+    if (!migration) {
+      return { success: false, error: 'Migration not found' };
+    }
+
+    if (!migration.rollback) {
+      return { success: false, error: 'Migration does not support rollback' };
+    }
+
+    const applied = await redis.sismember(ADMIN_MIGRATIONS_SET_KEY, migrationName);
+    if (!applied) {
+      return { success: false, error: 'Migration not applied' };
+    }
+
+    await migration.rollback({ redis, logger });
+    await redis.srem(ADMIN_MIGRATIONS_SET_KEY, migrationName);
+    await redis.hdel(ADMIN_MIGRATIONS_METADATA_KEY, migrationName);
+
+    logger.info('Migration rolled back successfully', { migration: migrationName });
+    return { success: true };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    logger.error('Rollback failed', { migration: migrationName, error: errorMsg });
+    return { success: false, error: errorMsg };
   } finally {
     redis.disconnect();
   }

--- a/perf-tests/load-test.js
+++ b/perf-tests/load-test.js
@@ -32,11 +32,25 @@ export const options = {
       env: { SCENARIO: 'load' },
       startTime: '35s', // starts after smoke finishes
     },
+    ai_concurrency: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '60s', target: 50 },
+        { duration: '30s', target: 50 },
+        { duration: '10s', target: 0 },
+      ],
+      tags: { scenario: 'ai_concurrency' },
+      env: { SCENARIO: 'ai_concurrency' },
+      startTime: '35s',
+      exec: 'aiConcurrencyScenario',
+    },
   },
   thresholds: {
     http_req_failed: ['rate<0.01'],           // <1% errors
     http_req_duration: ['p(95)<2000'],        // 95th percentile under 2s
     'http_req_duration{endpoint:ai}': ['p(95)<5000'], // AI endpoints get 5s budget
+    'http_req_duration{scenario:ai_concurrency}': ['p(95)<5000'],
   },
 };
 
@@ -84,5 +98,12 @@ export default function () {
   sleep(1);
 
   testPostPublishing();
+  sleep(0.5);
+}
+
+// ── AI concurrency scenario (ramp 1→50 VUs over 60s, p95 < 5s) ───────────────
+
+export function aiConcurrencyScenario() {
+  testAIGeneration();
   sleep(0.5);
 }


### PR DESCRIPTION
closes #699 
closes #695 
closes #702 
closes #703 



…load test

- Add Grafana dashboard provisioning config and explicit dashboards mount in docker-compose so dashboards are auto-loaded on container startup

- Cache backend/node_modules in CI keyed on backend/package-lock.json hash to avoid redundant npm ci on every push

- Add rollback() to migration service and export rollbackMigration(); add migrations.rollback.test.ts covering up→down→verify for all migrations

- Add ai_concurrency k6 scenario ramping 1→50 VUs over 60s with p95 < 5s SLO threshold on the AI endpoint