### PR TITLE
test: add AnalyticsService, rateLimit/logger degraded-mode, and healt…

### DIFF
--- a/backend/src/__tests__/fixtures.ts
+++ b/backend/src/__tests__/fixtures.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared test fixtures for backend integration tests.
+ *
+ * Provides helpers for creating users with roles and generating signed JWTs
+ * so individual test files don't repeat the same boilerplate.
+ */
+
+import jwt from 'jsonwebtoken';
+import { RoleStore } from '../models/Role';
+
+export type TestRole = 'admin' | 'editor' | 'viewer';
+
+export interface TestUser {
+  userId: string;
+  role: TestRole;
+  /** Pre-signed JWT valid for 15 minutes */
+  token: string;
+}
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret';
+
+/**
+ * Generate a signed JWT for the given user ID.
+ * Uses the same secret and expiry as the app under test.
+ */
+export function generateTestToken(userId: string, expiresIn = '15m'): string {
+  return jwt.sign({ sub: userId }, JWT_SECRET, { expiresIn });
+}
+
+/**
+ * Register a user in RoleStore and return a TestUser with a pre-signed token.
+ *
+ * @param userId  Unique identifier (defaults to `<role>-fixture-<random>`)
+ * @param role    Role to assign
+ */
+export function createTestUser(role: TestRole, userId?: string): TestUser {
+  const id = userId ?? `${role}-fixture-${Math.random().toString(36).slice(2, 8)}`;
+  RoleStore.assign(id, role);
+  return { userId: id, role, token: generateTestToken(id) };
+}

--- a/backend/src/__tests__/healthAuth.test.ts
+++ b/backend/src/__tests__/healthAuth.test.ts
@@ -3,8 +3,8 @@ process.env.JWT_SECRET = 'test-secret';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import app from '../app';
-import { RoleStore } from '../models/Role';
 import { AuditLogStore } from '../models/AuditLog';
+import { createTestUser, generateTestToken } from './fixtures';
 
 jest.mock('../lib/integrationStatus', () => ({
   getIntegrationSnapshot: jest.fn(() => [
@@ -46,20 +46,21 @@ jest.mock('../services/serviceFactory', () => ({
   })),
 }));
 
-const SECRET = 'test-secret';
+const admin = createTestUser('admin', 'admin-health-1');
+const editor = createTestUser('editor', 'editor-health-1');
+const viewer = createTestUser('viewer', 'viewer-health-1');
+
+const adminId = admin.userId;
+const editorId = editor.userId;
+const viewerId = viewer.userId;
 
 function token(userId: string) {
-  return jwt.sign({ sub: userId }, SECRET, { expiresIn: '15m' });
+  return generateTestToken(userId);
 }
 
-const adminId = 'admin-health-1';
-const editorId = 'editor-health-1';
-const viewerId = 'viewer-health-1';
-
 beforeAll(() => {
-  RoleStore.assign(adminId, 'admin');
-  RoleStore.assign(editorId, 'editor');
-  RoleStore.assign(viewerId, 'viewer');
+  // Users are already registered in RoleStore by createTestUser above.
+  // This hook is kept for any additional setup that may be added later.
 });
 
 describe('Health Routes — Authorization Boundaries', () => {

--- a/backend/src/__tests__/rateLimitLogger.test.ts
+++ b/backend/src/__tests__/rateLimitLogger.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Degraded-mode tests for rateLimit middleware and logger.
+ *
+ * Validates that:
+ *  1. When `rate-limit-redis` is unavailable the limiter silently falls back
+ *     to the in-memory store and the app still boots.
+ *  2. When `winston-elasticsearch` is unavailable the logger emits a console
+ *     warning and continues with the console transport only.
+ *  3. The /health endpoint remains reachable in both degraded states.
+ */
+
+// Must be set before any module that reads config is imported
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+process.env.JWT_SECRET = 'test-secret-that-is-at-least-32-chars!!';
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-32-chars!!!!!';
+process.env.TWITTER_API_KEY = 'test-key';
+process.env.TWITTER_API_SECRET = 'test-secret';
+
+import request from 'supertest';
+
+// ---------------------------------------------------------------------------
+// Helper — reset module registry between tests so jest.mock calls take effect
+// ---------------------------------------------------------------------------
+function freshRequire<T>(modulePath: string): T {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require(modulePath) as T;
+}
+
+// ---------------------------------------------------------------------------
+// 1. rate-limit-redis missing → memory store fallback
+// ---------------------------------------------------------------------------
+describe('rateLimit — missing rate-limit-redis package', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    // Simulate the package not being installed
+    jest.mock('rate-limit-redis', () => {
+      throw new Error("Cannot find module 'rate-limit-redis'");
+    });
+  });
+
+  afterEach(() => {
+    jest.unmock('rate-limit-redis');
+    jest.resetModules();
+  });
+
+  it('initRateLimiters() resolves without throwing', async () => {
+    const { initRateLimiters } = freshRequire<typeof import('../middleware/rateLimit')>(
+      '../middleware/rateLimit',
+    );
+    await expect(initRateLimiters()).resolves.toBeUndefined();
+  });
+
+  it('authLimiter is defined and is a function after init', async () => {
+    const mod = freshRequire<typeof import('../middleware/rateLimit')>(
+      '../middleware/rateLimit',
+    );
+    await mod.initRateLimiters();
+    expect(typeof mod.authLimiter).toBe('function');
+    expect(typeof mod.aiLimiter).toBe('function');
+    expect(typeof mod.generalLimiter).toBe('function');
+  });
+
+  it('app boots and /health returns 200 when Redis store is unavailable', async () => {
+    // Re-require app after mocking so it picks up the degraded limiter
+    const { default: app } = freshRequire<typeof import('../app')>('../app');
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('status', 'ok');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. ioredis missing → memory store fallback (same code path, different dep)
+// ---------------------------------------------------------------------------
+describe('rateLimit — missing ioredis package', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('ioredis', () => {
+      throw new Error("Cannot find module 'ioredis'");
+    });
+  });
+
+  afterEach(() => {
+    jest.unmock('ioredis');
+    jest.resetModules();
+  });
+
+  it('initRateLimiters() resolves and limiters are functions', async () => {
+    const mod = freshRequire<typeof import('../middleware/rateLimit')>(
+      '../middleware/rateLimit',
+    );
+    await mod.initRateLimiters();
+    expect(typeof mod.authLimiter).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. winston-elasticsearch missing → console.warn + logger still works
+// ---------------------------------------------------------------------------
+describe('logger — missing winston-elasticsearch package', () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.resetModules();
+    // Simulate the package not being installed
+    jest.mock('winston-elasticsearch', () => {
+      throw new Error("Cannot find module 'winston-elasticsearch'");
+    });
+    // Activate the ES transport code path
+    process.env.ELASTICSEARCH_URL = 'http://localhost:9200';
+  });
+
+  afterEach(() => {
+    jest.unmock('winston-elasticsearch');
+    delete process.env.ELASTICSEARCH_URL;
+    jest.resetModules();
+    warnSpy.mockClear();
+  });
+
+  afterAll(() => warnSpy.mockRestore());
+
+  it('emits a console.warn about the missing transport', () => {
+    freshRequire('../lib/logger');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('winston-elasticsearch not available'),
+      expect.any(String),
+    );
+  });
+
+  it('createLogger() still returns a usable logger', () => {
+    const { createLogger } = freshRequire<typeof import('../lib/logger')>('../lib/logger');
+    const logger = createLogger('test-scope');
+    expect(() => logger.info('hello')).not.toThrow();
+    expect(() => logger.warn('degraded')).not.toThrow();
+    expect(() => logger.error('oops')).not.toThrow();
+  });
+
+  it('app boots and /health returns 200 when ES transport is absent', async () => {
+    const { default: app } = freshRequire<typeof import('../app')>('../app');
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Both packages missing simultaneously — belt-and-suspenders
+// ---------------------------------------------------------------------------
+describe('rateLimit + logger — both optional deps missing', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('rate-limit-redis', () => {
+      throw new Error('missing');
+    });
+    jest.mock('winston-elasticsearch', () => {
+      throw new Error('missing');
+    });
+    process.env.ELASTICSEARCH_URL = 'http://localhost:9200';
+  });
+
+  afterEach(() => {
+    jest.unmock('rate-limit-redis');
+    jest.unmock('winston-elasticsearch');
+    delete process.env.ELASTICSEARCH_URL;
+    jest.resetModules();
+  });
+
+  it('app still boots and /health returns 200', async () => {
+    const { default: app } = freshRequire<typeof import('../app')>('../app');
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+});

--- a/src/services/__tests__/AnalyticsService.test.ts
+++ b/src/services/__tests__/AnalyticsService.test.ts
@@ -1,0 +1,321 @@
+/**
+ * AnalyticsService tests
+ *
+ * Strategy: mock global.fetch and window token globals; exercise the
+ * normalisation helpers, partial-failure handling, and rate-limit retry
+ * paths without touching IndexedDB (analyticsDB is also mocked).
+ */
+
+import {
+  AnalyticsService,
+  analyticsDB,
+  type PostAnalytics,
+  type Platform,
+} from '../AnalyticsService';
+
+// ---------------------------------------------------------------------------
+// Mock IndexedDB layer so tests don't need a real browser environment
+// ---------------------------------------------------------------------------
+jest.mock('../AnalyticsService', () => {
+  const actual = jest.requireActual('../AnalyticsService');
+  return {
+    ...actual,
+    analyticsDB: {
+      init: jest.fn().mockResolvedValue(undefined),
+      upsertMany: jest.fn().mockResolvedValue(undefined),
+      getAll: jest.fn().mockResolvedValue([]),
+      getByPlatform: jest.fn().mockResolvedValue([]),
+      getByDateRange: jest.fn().mockResolvedValue([]),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function setTokens(overrides: Record<string, string> = {}) {
+  (window as any).__TWITTER_BEARER_TOKEN__ = overrides.twitter ?? 'tw-token';
+  (window as any).__LINKEDIN_ACCESS_TOKEN__ = overrides.linkedin ?? 'li-token';
+  (window as any).__INSTAGRAM_ACCESS_TOKEN__ = overrides.instagram ?? 'ig-token';
+  (window as any).__TIKTOK_ACCESS_TOKEN__ = overrides.tiktok ?? 'tt-token';
+}
+
+function clearTokens() {
+  delete (window as any).__TWITTER_BEARER_TOKEN__;
+  delete (window as any).__LINKEDIN_ACCESS_TOKEN__;
+  delete (window as any).__INSTAGRAM_ACCESS_TOKEN__;
+  delete (window as any).__TIKTOK_ACCESS_TOKEN__;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setTokens();
+});
+
+afterEach(() => clearTokens());
+
+// ---------------------------------------------------------------------------
+// Normalisation — Twitter
+// ---------------------------------------------------------------------------
+describe('Twitter normalisation', () => {
+  it('maps public_metrics to PostAnalytics schema', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: 'tw1',
+            created_at: '2024-01-15T10:00:00.000Z',
+            public_metrics: {
+              like_count: 42,
+              retweet_count: 10,
+              quote_count: 5,
+              impression_count: 1000,
+              reply_count: 8,
+            },
+          },
+        ],
+      }),
+    );
+
+    const svc = new AnalyticsService();
+    await svc.sync({ twitter: 'user123' });
+
+    const [record] = (analyticsDB.upsertMany as jest.Mock).mock.calls[0][0] as PostAnalytics[];
+    expect(record.id).toBe('twitter:tw1');
+    expect(record.platform).toBe('twitter');
+    expect(record.postId).toBe('tw1');
+    expect(record.likes).toBe(42);
+    expect(record.shares).toBe(15); // retweet + quote
+    expect(record.views).toBe(1000);
+    expect(record.comments).toBe(8);
+    expect(record.syncedAt).toBeGreaterThan(0);
+  });
+
+  it('defaults missing metrics to 0', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [{ id: 'tw2', public_metrics: {} }] }),
+    );
+
+    const svc = new AnalyticsService();
+    await svc.sync({ twitter: 'user123' });
+
+    const [record] = (analyticsDB.upsertMany as jest.Mock).mock.calls[0][0] as PostAnalytics[];
+    expect(record.likes).toBe(0);
+    expect(record.shares).toBe(0);
+    expect(record.views).toBe(0);
+    expect(record.comments).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normalisation — Instagram
+// ---------------------------------------------------------------------------
+describe('Instagram normalisation', () => {
+  it('maps Graph API media fields to PostAnalytics schema', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            id: 'ig1',
+            timestamp: '2024-02-01T08:00:00.000Z',
+            like_count: 99,
+            comments_count: 12,
+            impressions: 500,
+          },
+        ],
+      }),
+    );
+
+    const svc = new AnalyticsService();
+    await svc.sync({ instagram: 'ig-account' });
+
+    const [record] = (analyticsDB.upsertMany as jest.Mock).mock.calls[0][0] as PostAnalytics[];
+    expect(record.id).toBe('instagram:ig1');
+    expect(record.platform).toBe('instagram');
+    expect(record.likes).toBe(99);
+    expect(record.shares).toBe(0); // Instagram doesn't expose shares
+    expect(record.views).toBe(500);
+    expect(record.comments).toBe(12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normalisation — TikTok
+// ---------------------------------------------------------------------------
+describe('TikTok normalisation', () => {
+  it('maps statistics fields to PostAnalytics schema', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: {
+          videos: [
+            {
+              id: 'tt1',
+              create_time: 1706784000, // Unix seconds
+              statistics: {
+                digg_count: 200,
+                share_count: 30,
+                play_count: 5000,
+                comment_count: 25,
+              },
+            },
+          ],
+        },
+        error: { code: 'ok' },
+      }),
+    );
+
+    const svc = new AnalyticsService();
+    await svc.sync({ tiktok: 'tt-account' });
+
+    const [record] = (analyticsDB.upsertMany as jest.Mock).mock.calls[0][0] as PostAnalytics[];
+    expect(record.id).toBe('tiktok:tt1');
+    expect(record.platform).toBe('tiktok');
+    expect(record.likes).toBe(200);
+    expect(record.shares).toBe(30);
+    expect(record.views).toBe(5000);
+    expect(record.comments).toBe(25);
+    expect(record.postedAt).toBe(1706784000 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial failure — one platform fails, others succeed
+// ---------------------------------------------------------------------------
+describe('sync() partial failure', () => {
+  it('stores successful platforms and logs errors for failed ones', async () => {
+    // Twitter succeeds
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({ data: [{ id: 'tw3', public_metrics: { like_count: 1 } }] }),
+      )
+      // Instagram fails
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const svc = new AnalyticsService();
+    await svc.sync({ twitter: 'user1', instagram: 'ig1' });
+
+    // upsertMany called once (only for twitter)
+    expect(analyticsDB.upsertMany).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Analytics] sync failed'),
+      expect.anything(),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not throw even when all platforms fail', async () => {
+    mockFetch.mockRejectedValue(new Error('All down'));
+
+    const svc = new AnalyticsService();
+    await expect(svc.sync({ twitter: 'u1', instagram: 'u2' })).resolves.toBeUndefined();
+    expect(analyticsDB.upsertMany).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate-limit handling — Twitter 429
+// ---------------------------------------------------------------------------
+describe('rate-limit handling', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('retries after a 429 and eventually succeeds', async () => {
+    const rateLimitRes: Response = {
+      ok: false,
+      status: 429,
+      headers: { get: (h: string) => (h === 'retry-after' ? '1' : null) },
+      json: () => Promise.resolve({}),
+    } as unknown as Response;
+
+    const successRes = jsonResponse({
+      data: [{ id: 'tw4', public_metrics: { like_count: 5 } }],
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(rateLimitRes)
+      .mockResolvedValueOnce(successRes);
+
+    const svc = new AnalyticsService();
+    const syncPromise = svc.sync({ twitter: 'user1' });
+
+    // Advance past the retry-after delay (1 s) + base retry delay
+    await jest.runAllTimersAsync();
+    await syncPromise;
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(analyticsDB.upsertMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a sync error after exhausting all retries', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: { get: () => '0' },
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const svc = new AnalyticsService();
+    const syncPromise = svc.sync({ twitter: 'user1' });
+    await jest.runAllTimersAsync();
+    await syncPromise;
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing token — returns empty array without calling fetch
+// ---------------------------------------------------------------------------
+describe('missing access token', () => {
+  it('returns [] for twitter when token is absent', async () => {
+    clearTokens();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const svc = new AnalyticsService();
+    await svc.sync({ twitter: 'user1' });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(analyticsDB.upsertMany).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[Analytics]'));
+
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncedAt is stamped by sync(), not by the fetcher
+// ---------------------------------------------------------------------------
+describe('syncedAt stamping', () => {
+  it('sets syncedAt to the time sync() was called', async () => {
+    const before = Date.now();
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [{ id: 'tw5', public_metrics: {} }] }),
+    );
+
+    const svc = new AnalyticsService();
+    await svc.sync({ twitter: 'user1' });
+    const after = Date.now();
+
+    const [record] = (analyticsDB.upsertMany as jest.Mock).mock.calls[0][0] as PostAnalytics[];
+    expect(record.syncedAt).toBeGreaterThanOrEqual(before);
+    expect(record.syncedAt).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
closes #701 
closes #705 
closes #497 
closes #495 




…hAuth fixture tests

- src/services/__tests__/AnalyticsService.test.ts (new) Mock global.fetch and analyticsDB; validate Twitter/Instagram/TikTok normalisation to PostAnalytics schema, partial-failure handling, 429 rate-limit retry, missing-token early-return, and syncedAt stamping.

- backend/src/__tests__/rateLimitLogger.test.ts (new) Simulate missing rate-limit-redis, ioredis, and winston-elasticsearch via jest.resetModules + jest.mock; assert fallback to memory store, console.warn output, createLogger still functional, and /health 200.

- backend/src/__tests__/fixtures.ts (new) Centralise createTestUser() and generateTestToken() helpers so test files no longer repeat RoleStore.assign + jwt.sign boilerplate.

- backend/src/__tests__/healthAuth.test.ts (refactor) Replace inline token() function and RoleStore.assign calls with the new fixture helpers; remove now-unused RoleStore import.