### PR TITLE
fix(ecs): set stopTimeout=60 to allow full 30s graceful shutdown

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -59,8 +59,9 @@ resource "aws_ecs_task_definition" "app" {
   task_role_arn            = aws_iam_role.task.arn
 
   container_definitions = jsonencode([{
-    name  = "app"
-    image = var.image_uri
+    name        = "app"
+    image       = var.image_uri
+    stopTimeout = 60
     portMappings = [{ containerPort = var.container_port, protocol = "tcp" }]
     environment = [
       { name = "NODE_ENV",    value = var.env },


### PR DESCRIPTION
ECS default stopTimeout is 30s, which races with the app's own 30s shutdown sequence. Setting stopTimeout=60 gives the container enough time to drain HTTP connections, stop workers, flush queues, and close DB connections before SIGKILL is sent.
Problem

ECS defaults stopTimeout to 30 seconds. The app's graceful shutdown sequence (server.ts) also runs up to 30 seconds. This is a race — ECS sends SIGKILL at the exact moment the app's internal timeout fires, which can interrupt the shutdown mid-way and leave connections/queues in a dirty state.

Root cause

terraform/modules/ecs had no stopTimeout configured, so ECS was using its 30s default.

Fix

Set stopTimeout = 60 on the container definition. This gives ECS a 60-second kill window, ensuring the app's full 30-second shutdown sequence has room to complete cleanly:

stop accepting new HTTP connections
drain in-flight requests
stop background workers and jobs
close BullMQ queues
disconnect from the database
Changed files

main.tf
 — added stopTimeout = 60 to the container definition
Testing

No logic changes. Verified the container definition renders correctly. Shutdown sequence in server.ts is unchanged.

Closes #688 