### PR TITLE
Fix/elasticache tls

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -74,6 +74,8 @@ REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=0
+# Set to 'true' when connecting to ElastiCache with transit encryption enabled (rediss://)
+REDIS_TLS=false
 
 # ─── Rate Limiting ────────────────────────────────────────────────────────────
 # In production the rate-limit store is backed by Redis (above).

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -26,6 +26,11 @@ const envSchema = z.object({
   REDIS_PORT: z.coerce.number().int().positive().default(6379),
   REDIS_PASSWORD: z.string().optional(),
   REDIS_DB: z.coerce.number().int().min(0).default(0),
+  // Set to 'true' in production when ElastiCache transit encryption is enabled (rediss://)
+  REDIS_TLS: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
 
   // ── Social APIs ───────────────────────────────────────────────────────────
   TWITTER_API_KEY: z.string().min(1, 'TWITTER_API_KEY is required'),

--- a/backend/src/config/runtime.ts
+++ b/backend/src/config/runtime.ts
@@ -14,6 +14,8 @@ export const getRedisConnection = (): RedisOptions => ({
   password: config.REDIS_PASSWORD,
   db: config.REDIS_DB,
   maxRetriesPerRequest: null,
+  // Enable TLS when REDIS_TLS=true (required for ElastiCache with transit encryption)
+  tls: config.REDIS_TLS ? {} : undefined,
 });
 
 export const getConfiguredQueueNames = (): string[] =>

--- a/backend/src/queues/WebhookQueue.ts
+++ b/backend/src/queues/WebhookQueue.ts
@@ -1,13 +1,11 @@
 import { Queue, Worker, Job } from 'bullmq';
 import { createLogger } from '../lib/logger';
 import { attemptDelivery } from '../services/WebhookDispatcher';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('WebhookQueue');
 
-const connection = {
-  host: process.env.REDIS_HOST ?? 'localhost',
-  port: parseInt(process.env.REDIS_PORT ?? '6379', 10),
-};
+const connection = getRedisConnection();
 
 export interface WebhookJobData {
   deliveryId: string;

--- a/backend/src/queues/twitterWebhookQueue.ts
+++ b/backend/src/queues/twitterWebhookQueue.ts
@@ -1,15 +1,11 @@
 import { Queue, Worker, Job } from 'bullmq';
 import { createLogger } from '../lib/logger';
 import { WebhookEventType } from '../schemas/webhooks';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('twitter-webhook-queue');
 
-const connection = {
-  host: process.env.REDIS_HOST ?? 'localhost',
-  port: parseInt(process.env.REDIS_PORT ?? '6379', 10),
-  password: process.env.REDIS_PASSWORD,
-  maxRetriesPerRequest: null,
-};
+const connection = getRedisConnection();
 
 export interface TwitterWebhookJobData {
   eventType: WebhookEventType;

--- a/backend/src/services/SocketService.ts
+++ b/backend/src/services/SocketService.ts
@@ -5,6 +5,7 @@ import Redis from 'ioredis';
 import jwt from 'jsonwebtoken';
 import { createLogger } from '../lib/logger';
 import { config } from '../config/config';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('SocketService');
 
@@ -41,7 +42,7 @@ export class SocketService {
     });
 
     // Configure Redis Adapter
-    const pubClient = new Redis({ host: config.REDIS_HOST, port: config.REDIS_PORT });
+    const pubClient = new Redis(getRedisConnection());
     const subClient = pubClient.duplicate();
     this.io.adapter(createAdapter(pubClient, subClient));
 

--- a/backend/src/utils/LockService.ts
+++ b/backend/src/utils/LockService.ts
@@ -1,15 +1,11 @@
 import Redlock from 'redlock';
 import Redis from 'ioredis';
 import { createLogger } from '../lib/logger';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('lock-service');
 
-const redisClient = new Redis({
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT || '6379'),
-  password: process.env.REDIS_PASSWORD,
-  db: parseInt(process.env.REDIS_DB || '0'),
-});
+const redisClient = new Redis(getRedisConnection());
 
 const redlock = new Redlock([redisClient], {
   driftFactor: 0.01,

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -67,7 +67,8 @@ resource "aws_ecs_task_definition" "app" {
       { name = "NODE_ENV",    value = var.env },
       { name = "PORT",        value = tostring(var.container_port) },
       { name = "S3_BUCKET",   value = var.s3_bucket },
-      { name = "AWS_REGION",  value = var.aws_region }
+      { name = "AWS_REGION",  value = var.aws_region },
+      { name = "REDIS_TLS",   value = "true" }
     ]
     secrets = [
       { name = "DATABASE_URL", valueFrom = aws_ssm_parameter.database_url.arn },

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -59,8 +59,9 @@ resource "aws_ecs_task_definition" "app" {
   task_role_arn            = aws_iam_role.task.arn
 
   container_definitions = jsonencode([{
-    name  = "app"
-    image = var.image_uri
+    name        = "app"
+    image       = var.image_uri
+    stopTimeout = 60
     portMappings = [{ containerPort = var.container_port, protocol = "tcp" }]
     environment = [
       { name = "NODE_ENV",    value = var.env },


### PR DESCRIPTION
Problem

Four Redis clients were building their own connections directly from REDIS_HOST/REDIS_PORT env vars, completely bypassing TLS. This meant JWT blacklist data and BullMQ job payloads were flowing over plaintext even though ElastiCache had transit_encryption_enabled = true at the infrastructure level.

Affected clients:

LockService.ts (Redlock distributed locks)
SocketService.ts (Socket.io Redis adapter)
WebhookQueue.ts (webhook delivery jobs)
twitterWebhookQueue.ts (Twitter event jobs)
Fix

Centralised all Redis connection creation through getRedisConnection() in runtime.ts. Added a REDIS_TLS flag that passes tls: {} to ioredis when enabled. The ECS task definition injects REDIS_TLS=true at deploy time so production always uses TLS, while local dev remains unaffected.

Changes

runtime.ts — getRedisConnection() now includes tls: {} when REDIS_TLS=true
config.ts — added REDIS_TLS env var (boolean, defaults to false)
LockService.ts, SocketService.ts, WebhookQueue.ts, twitterWebhookQueue.ts — replaced inline host/port objects with getRedisConnection()
main.tf
 — inject REDIS_TLS=true into the container environment
.env.example — documented REDIS_TLS flag
Notes

transit_encryption_enabled = true was already set in the ElastiCache module and rediss:// was already used in the ECS REDIS_URL secret for queueManager. This PR closes the gap for the remaining clients that were not going through that path.
closes #689 