### PR TITLE
Fix/issues 676 677 678 679

### DIFF
--- a/src/components/PasswordRotationModal.tsx
+++ b/src/components/PasswordRotationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface PasswordRotationModalProps {
   isOpen: boolean;
@@ -19,6 +19,16 @@ export const PasswordRotationModal: React.FC<PasswordRotationModalProps> = ({
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [localError, setLocalError] = useState('');
+
+  // Clear sensitive fields on unmount
+  useEffect(() => {
+    return () => {
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setLocalError('');
+    };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/ReachScoreWidget.tsx
+++ b/src/components/ReachScoreWidget.tsx
@@ -13,7 +13,7 @@ export const ReachScoreWidget: React.FC<ReachScoreWidgetProps> = ({ postData, on
 
   useEffect(() => {
     analyzePrediction();
-  }, [postData.content, postData.platform, postData.scheduledTime]);
+  }, [postData.content, postData.platform, postData.scheduledTime, postData]);
 
   const analyzePrediction = async () => {
     if (!postData.content || postData.content.length < 3) {

--- a/src/components/TwoFactorSetup.tsx
+++ b/src/components/TwoFactorSetup.tsx
@@ -4,9 +4,10 @@ import QRCodeDisplay from './QRCodeDisplay';
 
 type SetupStep =
   | 'IDLE'
+  | 'GENERATING_CODES'
+  | 'SHOWING_CODES'
   | 'QR_DISPLAY'
   | 'CONFIRMING'
-  | 'SHOWING_CODES'
   | 'DISABLING'
   | 'DONE';
 
@@ -37,6 +38,25 @@ const TwoFactorSetup: React.FC<TwoFactorSetupProps> = ({
 
   const handleStartSetup = () => {
     setError(null);
+    setLoading(true);
+    try {
+      const codes = twoFactorService.generateRecoveryCodes();
+      setRecoveryCodes(codes.map(c => c.code));
+      setCodesAcknowledged(false);
+      setStep('SHOWING_CODES');
+    } catch (e) {
+      setError('Failed to generate recovery codes.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCodesAcknowledged = () => {
+    if (!codesAcknowledged) {
+      setError('Please confirm you have saved your recovery codes.');
+      return;
+    }
+    setError(null);
     const { secret: s, uri: u } = twoFactorService.generateSecret('SocialFlow');
     setSecret(s);
     setUri(u);
@@ -58,11 +78,9 @@ const TwoFactorSetup: React.FC<TwoFactorSetupProps> = ({
     setLoading(true);
     try {
       await twoFactorService.enable(secret);
-      const codes = twoFactorService.generateRecoveryCodes();
-      await twoFactorService.storeRecoveryCodes(codes);
-      setRecoveryCodes(codes.map(c => c.code));
-      setCodesAcknowledged(false);
-      setStep('SHOWING_CODES');
+      await twoFactorService.storeRecoveryCodes(recoveryCodes.map(code => ({ code })));
+      setStep('DONE');
+      onSetupComplete();
     } catch (e) {
       setError(e instanceof TwoFactorUnavailableError ? e.message : 'Failed to enable 2FA.');
     } finally {
@@ -214,11 +232,11 @@ const TwoFactorSetup: React.FC<TwoFactorSetupProps> = ({
           </label>
           {error && <p className="text-red-600 text-sm">{error}</p>}
           <button
-            onClick={handleFinishSetup}
-            disabled={!codesAcknowledged}
+            onClick={handleCodesAcknowledged}
+            disabled={!codesAcknowledged || loading}
             className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
           >
-            Done
+            {loading ? 'Generating QR Code…' : 'Continue to QR Code'}
           </button>
         </div>
       )}

--- a/src/components/WebhookManager.tsx
+++ b/src/components/WebhookManager.tsx
@@ -21,6 +21,8 @@ interface State {
   // deliveries keyed by webhook id
   deliveries: Record<string, WebhookDelivery[]>;
   expandedId: string | null;
+  // track in-flight replay requests: key is "webhookId:deliveryId"
+  replayingDeliveries: Set<string>;
 }
 
 type Action =
@@ -30,7 +32,9 @@ type Action =
   | { type: 'ADD'; webhook: WebhookSubscription }
   | { type: 'REMOVE'; id: string }
   | { type: 'DELIVERIES_OK'; id: string; deliveries: WebhookDelivery[] }
-  | { type: 'TOGGLE_EXPAND'; id: string };
+  | { type: 'TOGGLE_EXPAND'; id: string }
+  | { type: 'REPLAY_START'; webhookId: string; deliveryId: string }
+  | { type: 'REPLAY_END'; webhookId: string; deliveryId: string };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -43,6 +47,16 @@ function reducer(state: State, action: Action): State {
       return { ...state, deliveries: { ...state.deliveries, [action.id]: action.deliveries } };
     case 'TOGGLE_EXPAND':
       return { ...state, expandedId: state.expandedId === action.id ? null : action.id };
+    case 'REPLAY_START': {
+      const key = `${action.webhookId}:${action.deliveryId}`;
+      return { ...state, replayingDeliveries: new Set([...state.replayingDeliveries, key]) };
+    }
+    case 'REPLAY_END': {
+      const key = `${action.webhookId}:${action.deliveryId}`;
+      const next = new Set(state.replayingDeliveries);
+      next.delete(key);
+      return { ...state, replayingDeliveries: next };
+    }
     default: return state;
   }
 }
@@ -55,10 +69,11 @@ const DELIVERY_COLORS: Record<string, string> = {
   pending: 'bg-gray-100 text-gray-600',
 };
 
-function DeliveryRow({ d, webhookId, onReplay }: {
+function DeliveryRow({ d, webhookId, onReplay, isReplaying }: {
   d: WebhookDelivery;
   webhookId: string;
   onReplay: (webhookId: string, deliveryId: string) => void;
+  isReplaying: boolean;
 }) {
   return (
     <tr className="text-xs border-t">
@@ -75,17 +90,17 @@ function DeliveryRow({ d, webhookId, onReplay }: {
         <button
           onClick={() => onReplay(webhookId, d.id!)}
           className="text-blue-600 hover:underline disabled:opacity-40"
-          disabled={!d.id}
+          disabled={!d.id || isReplaying}
           aria-label="Replay delivery"
         >
-          Replay
+          {isReplaying ? 'Replaying…' : 'Replay'}
         </button>
       </td>
     </tr>
   );
 }
 
-function WebhookRow({ webhook, deliveries, expanded, onExpand, onDelete, onTest, onReplay }: {
+function WebhookRow({ webhook, deliveries, expanded, onExpand, onDelete, onTest, onReplay, replayingDeliveries }: {
   webhook: WebhookSubscription;
   deliveries: WebhookDelivery[];
   expanded: boolean;
@@ -93,6 +108,7 @@ function WebhookRow({ webhook, deliveries, expanded, onExpand, onDelete, onTest,
   onDelete: (id: string) => void;
   onTest: (id: string) => void;
   onReplay: (webhookId: string, deliveryId: string) => void;
+  replayingDeliveries: Set<string>;
 }) {
   const last = deliveries[0];
 
@@ -156,7 +172,13 @@ function WebhookRow({ webhook, deliveries, expanded, onExpand, onDelete, onTest,
               </thead>
               <tbody>
                 {deliveries.map(d => (
-                  <DeliveryRow key={d.id} d={d} webhookId={webhook.id!} onReplay={onReplay} />
+                  <DeliveryRow 
+                    key={d.id} 
+                    d={d} 
+                    webhookId={webhook.id!} 
+                    onReplay={onReplay}
+                    isReplaying={replayingDeliveries.has(`${webhook.id}:${d.id}`)}
+                  />
                 ))}
               </tbody>
             </table>
@@ -297,7 +319,7 @@ function TestModal({ webhookId, onClose }: { webhookId: string; onClose: () => v
 
 export default function WebhookManager() {
   const [state, dispatch] = useReducer(reducer, {
-    webhooks: [], loading: false, error: null, deliveries: {}, expandedId: null,
+    webhooks: [], loading: false, error: null, deliveries: {}, expandedId: null, replayingDeliveries: new Set(),
   });
   const [testingId, setTestingId] = useState<string | null>(null);
 
@@ -336,6 +358,7 @@ export default function WebhookManager() {
   }
 
   async function handleReplay(webhookId: string, deliveryId: string) {
+    dispatch({ type: 'REPLAY_START', webhookId, deliveryId });
     try {
       await WebhooksService.replayDelivery(webhookId, deliveryId);
       // Refresh deliveries for this webhook
@@ -343,6 +366,8 @@ export default function WebhookManager() {
       dispatch({ type: 'DELIVERIES_OK', id: webhookId, deliveries });
     } catch (e: any) {
       alert(e?.message ?? 'Replay failed.');
+    } finally {
+      dispatch({ type: 'REPLAY_END', webhookId, deliveryId });
     }
   }
 
@@ -375,6 +400,7 @@ export default function WebhookManager() {
             onDelete={handleDelete}
             onTest={id => setTestingId(id)}
             onReplay={handleReplay}
+            replayingDeliveries={state.replayingDeliveries}
           />
         ))}
       </div>


### PR DESCRIPTION
 ## Summary
  
  This PR implements fixes for four critical UI/UX and security issues across the dashboard components.
  
  ## Changes
  
  ### Issue #676: Disable WebhookManager replay button during in-flight request
  - Added `replayingDeliveries` Set to track in-flight replay requests by `webhookId:deliveryId` key
  - Introduced `REPLAY_START` and `REPLAY_END` reducer actions to manage loading state
  - Replay button is now disabled and displays "Replaying..." text during API requests
  - Prevents duplicate replay requests caused by rapid button clicks
  
  **Files modified:** `src/components/WebhookManager.tsx`
  
  ### Issue #677: Re-fetch predictive reach score when post content changes
  - Added `postData` to the useEffect dependency array in ReachScoreWidget
  - Ensures reach score is recalculated whenever any post property changes
  - Keeps displayed score in sync with current post content
  
  **Files modified:** `src/components/ReachScoreWidget.tsx`
  
  ### Issue #678: Show 2FA QR code only after user acknowledges backup codes
  - Reordered 2FA setup flow to display backup codes before QR code
  - Added `GENERATING_CODES` step to the setup flow
  - Users must acknowledge backup codes before proceeding to QR code display
  - Ensures users record recovery codes before setting up authenticator app
  - Backup codes are generated upfront and stored after TOTP verification
  
  **Files modified:** `src/components/TwoFactorSetup.tsx`
  
  ### Issue #679: Clear sensitive password fields from state on PasswordRotationModal unmount
  - Added useEffect cleanup function to clear all password fields on component unmount
  - Prevents password values from lingering in React state after modal closes
  - Clears `currentPassword`, `newPassword`, `confirmPassword`, and `localError` fields
  - Improves security by removing sensitive data from memory
  
  **Files modified:** `src/components/PasswordRotationModal.tsx`
  
  ## Testing
  
  - WebhookManager: Verify replay button disables during request and re-enables after completion
  - ReachScoreWidget: Verify reach score updates when post content is edited
  - TwoFactorSetup: Verify backup codes display first and QR code only shows after acknowledgement
  - PasswordRotationModal: Verify password fields are cleared when modal closes
  
  ## Closes
  
  Closes #676
  Closes #677
  Closes #678
  Closes #679