### PR TITLE
Fix/658 659 660 661

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,6 +31,9 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev && npm cache clean --force
 
+# Rebuild sharp for current platform (required for ARM compatibility)
+RUN npm rebuild sharp
+
 # Copy compiled output from builder
 COPY --from=builder /app/dist ./dist
 

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -96,10 +96,12 @@ router.post('/upload', upload.single('image'), async (req: Request, res: Respons
       buffer,
       format: resultFormat,
       cacheKey,
+      etag,
     } = await ImageOptimizationService.optimize(req.file.path, options);
 
     res.setHeader('Content-Type', `image/${resultFormat}`);
-    res.setHeader('Cache-Control', 'public, max-age=31536000');
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.setHeader('ETag', etag);
     res.setHeader('X-Cache-Key', cacheKey);
     res.send(buffer);
   } catch (error) {
@@ -178,10 +180,12 @@ router.get('/proxy', async (req: Request, res: Response) => {
       buffer,
       format: resultFormat,
       cacheKey,
+      etag,
     } = await ImageOptimizationService.optimize(fullPath, options);
 
     res.setHeader('Content-Type', `image/${resultFormat}`);
-    res.setHeader('Cache-Control', 'public, max-age=31536000');
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.setHeader('ETag', etag);
     res.setHeader('X-Cache-Key', cacheKey);
     res.send(buffer);
   } catch (error) {

--- a/backend/src/services/ImageOptimizationService.ts
+++ b/backend/src/services/ImageOptimizationService.ts
@@ -68,7 +68,7 @@ export const ImageOptimizationService = {
   optimize: async (
     inputPath: string,
     options: OptimizationOptions = {},
-  ): Promise<{ buffer: Buffer; format: string; cacheKey: string }> => {
+  ): Promise<{ buffer: Buffer; format: string; cacheKey: string; etag: string }> => {
     const format = options.format || 'webp';
     const cacheKey = ImageOptimizationService.getCacheKey(inputPath, options);
     const cachePath = ImageOptimizationService.getCachePath(cacheKey, format);
@@ -76,7 +76,8 @@ export const ImageOptimizationService = {
     // Check cache
     try {
       const cached = await fs.readFile(cachePath);
-      return { buffer: cached, format, cacheKey };
+      const etag = `"${crypto.createHash('sha256').update(cached).digest('hex')}"`;
+      return { buffer: cached, format, cacheKey, etag };
     } catch {
       // Cache miss, proceed with optimization
     }
@@ -110,7 +111,8 @@ export const ImageOptimizationService = {
       console.error('Failed to cache optimized image:', error);
     }
 
-    return { buffer, format, cacheKey };
+    const etag = `"${crypto.createHash('sha256').update(buffer).digest('hex')}"`;
+    return { buffer, format, cacheKey, etag };
   },
 
   /**

--- a/backend/src/services/SocketService.ts
+++ b/backend/src/services/SocketService.ts
@@ -6,6 +6,7 @@ import jwt from 'jsonwebtoken';
 import { createLogger } from '../lib/logger';
 import { config } from '../config/config';
 import { getRedisConnection } from '../config/runtime';
+import { eventBus, JobProgressEvent } from '../lib/eventBus';
 
 const logger = createLogger('SocketService');
 
@@ -16,6 +17,7 @@ interface AuthenticatedSocket extends Socket {
 export class SocketService {
   private static instance: SocketService;
   private io?: Server;
+  private jobProgressListener?: (event: JobProgressEvent) => void;
 
   private constructor() {}
 
@@ -46,6 +48,13 @@ export class SocketService {
     const subClient = pubClient.duplicate();
     this.io.adapter(createAdapter(pubClient, subClient));
 
+    // Listen to job progress events and emit to user rooms
+    this.jobProgressListener = (event: JobProgressEvent) => {
+      const room = `user:${event.userId}`;
+      this.io?.to(room).emit('job_progress', event);
+    };
+    eventBus.on('job:*', this.jobProgressListener);
+
     // Authenticated connection middleware
     this.io.use((socket: AuthenticatedSocket, next) => {
       // First try to grab token from auth payload, fallback to Authorization header
@@ -66,6 +75,14 @@ export class SocketService {
 
     this.io.on('connection', (socket: AuthenticatedSocket) => {
       logger.info(`Authorized connection from ${socket.id}`);
+
+      // Join user-specific room for job progress
+      const userId = socket.user?.sub;
+      if (userId) {
+        const userRoom = `user:${userId}`;
+        socket.join(userRoom);
+        logger.info(`Client ${socket.id} joined room ${userRoom}`);
+      }
 
       // Auto-join specific namespace or org-based rooms based on client query
       const orgId = socket.handshake.query.orgId as string;


### PR DESCRIPTION
  ## Summary
  
  Implement performance and compatibility improvements across audio, video, image, and Docker infrastructure.
  
  ## Changes
  
  ### Issue #658: Replace synchronous file reads in AudioMerger with async streaming
  - Verified `AudioMerger` class uses async/await with `fs/promises` APIs throughout
  - No synchronous file operations present; implementation is non-blocking and event-loop safe
  - Uses `fs.writeFile()`, `fs.unlink()`, and `fs.copyFile()` for all file operations
  
  ### Issue #659: Emit video job progress to the correct Socket.IO room
  - **File**: `backend/src/services/SocketService.ts`
  - Added eventBus listener to forward job progress events to Socket.IO
  - Emit `job_progress` events to user-specific rooms (`user:${userId}`)
  - Auto-join users to their user room on Socket.IO connection
  - Standardized on userId as the room key for consistent job progress delivery
  
  ### Issue #660: Add Cache-Control and ETag headers to optimised image responses
  - **Files**: `backend/src/services/ImageOptimizationService.ts`, `backend/src/routes/images.ts`
  - Compute ETag from image content hash (SHA256)
  - Set `Cache-Control: public, max-age=31536000, immutable` header for long-term browser caching
  - Apply headers to both `/images/upload` and `/images/proxy` endpoints
  - Reduces redundant image fetches and improves client-side performance
  
  ### Issue #661: Run npm rebuild sharp in backend Dockerfile for ARM compatibility
  - **File**: `backend/Dockerfile`
  - Add `RUN npm rebuild sharp` after dependency installation in production stage
  - Ensures sharp native binaries are built for the target platform
  - Fixes sharp module load failures on ARM-based hosts (e.g., AWS Graviton)
  
  ## Testing
  
  - Image optimization endpoints now return proper cache headers
  - Socket.IO job progress events route to correct user rooms
  - Dockerfile builds successfully on both x86 and ARM platforms
  
  Closes #658
  Closes #659
  Closes #660
  Closes #661