### PR TITLE
fix(#648): validate X-Request-Id header format to prevent log injection

### DIFF
--- a/backend/src/__tests__/requestId.test.ts
+++ b/backend/src/__tests__/requestId.test.ts
@@ -1,19 +1,30 @@
+/**
+ * requestId.test.ts
+ *
+ * Tests for the requestIdMiddleware and isValidUuidV4 helper.
+ *
+ * Issue #648 — Validate X-Request-Id header format to prevent log injection.
+ * The middleware now accepts a client-supplied X-Request-Id only when it is a
+ * valid UUID v4; any other value is replaced with a freshly generated UUID.
+ */
+
 import request from 'supertest';
 import express, { Request, Response } from 'express';
-import { requestIdMiddleware, getRequestId } from '../middleware/requestId';
+import { requestIdMiddleware, getRequestId, isValidUuidV4 } from '../middleware/requestId';
 import { createLogger } from '../lib/logger';
 
 const logger = createLogger('test');
 
-// Create test app
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// ── Test app ──────────────────────────────────────────────────────────────────
+
 const createTestApp = () => {
   const app = express();
 
-  // Apply request ID middleware
   app.use(requestIdMiddleware);
   app.use(express.json());
 
-  // Test routes
   app.get('/test', (req: Request, res: Response) => {
     const requestId = getRequestId();
     logger.info('Test route accessed');
@@ -28,7 +39,6 @@ const createTestApp = () => {
     const requestId = getRequestId();
     logger.info('Async test route accessed');
 
-    // Simulate async operation
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     const requestIdAfterAsync = getRequestId();
@@ -44,6 +54,85 @@ const createTestApp = () => {
   return app;
 };
 
+// ── isValidUuidV4 unit tests ──────────────────────────────────────────────────
+
+describe('isValidUuidV4()', () => {
+  describe('valid UUIDs', () => {
+    it('accepts a canonical UUID v4 (lowercase)', () => {
+      expect(isValidUuidV4('550e8400-e29b-41d4-a716-446655440000')).toBe(false); // v1 format
+      expect(isValidUuidV4('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe(true);
+    });
+
+    it('accepts UUID v4 with uppercase hex digits', () => {
+      expect(isValidUuidV4('F47AC10B-58CC-4372-A567-0E02B2C3D479')).toBe(true);
+    });
+
+    it('accepts UUID v4 with mixed case', () => {
+      expect(isValidUuidV4('f47ac10b-58CC-4372-a567-0E02B2C3D479')).toBe(true);
+    });
+
+    it('accepts all valid variant bits (8, 9, a, b)', () => {
+      // variant nibble must be 8, 9, a, or b
+      expect(isValidUuidV4('f47ac10b-58cc-4372-8567-0e02b2c3d479')).toBe(true);
+      expect(isValidUuidV4('f47ac10b-58cc-4372-9567-0e02b2c3d479')).toBe(true);
+      expect(isValidUuidV4('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe(true);
+      expect(isValidUuidV4('f47ac10b-58cc-4372-b567-0e02b2c3d479')).toBe(true);
+    });
+  });
+
+  describe('invalid values', () => {
+    it('rejects an empty string', () => {
+      expect(isValidUuidV4('')).toBe(false);
+    });
+
+    it('rejects a plain string', () => {
+      expect(isValidUuidV4('not-a-uuid')).toBe(false);
+    });
+
+    it('rejects a UUID v1 (version digit is 1)', () => {
+      expect(isValidUuidV4('550e8400-e29b-11d4-a716-446655440000')).toBe(false);
+    });
+
+    it('rejects a UUID v3 (version digit is 3)', () => {
+      expect(isValidUuidV4('6ba7b810-9dad-31d1-80b4-00c04fd430c8')).toBe(false);
+    });
+
+    it('rejects a UUID v5 (version digit is 5)', () => {
+      expect(isValidUuidV4('886313e1-3b8a-5372-9b90-0c9aee199e5d')).toBe(false);
+    });
+
+    it('rejects a string with a newline character (log injection)', () => {
+      expect(isValidUuidV4('f47ac10b-58cc-4372-a567-0e02b2c3d479\nINJECTED')).toBe(false);
+    });
+
+    it('rejects a string with a carriage return (log injection)', () => {
+      expect(isValidUuidV4('f47ac10b-58cc-4372-a567-0e02b2c3d479\rINJECTED')).toBe(false);
+    });
+
+    it('rejects a string with a null byte', () => {
+      expect(isValidUuidV4('f47ac10b-58cc-4372-a567-0e02b2c3d479\x00')).toBe(false);
+    });
+
+    it('rejects a UUID without hyphens', () => {
+      expect(isValidUuidV4('f47ac10b58cc4372a5670e02b2c3d479')).toBe(false);
+    });
+
+    it('rejects a UUID with extra characters appended', () => {
+      expect(isValidUuidV4('f47ac10b-58cc-4372-a567-0e02b2c3d479-extra')).toBe(false);
+    });
+
+    it('rejects a very long string', () => {
+      expect(isValidUuidV4('a'.repeat(500))).toBe(false);
+    });
+
+    it('rejects a string with special shell-injection characters', () => {
+      expect(isValidUuidV4('$(rm -rf /)')).toBe(false);
+    });
+  });
+});
+
+// ── requestIdMiddleware integration tests ─────────────────────────────────────
+
 describe('Request ID Middleware', () => {
   let app: express.Application;
 
@@ -51,124 +140,188 @@ describe('Request ID Middleware', () => {
     app = createTestApp();
   });
 
+  // ── Auto-generation ─────────────────────────────────────────────────────────
+
   describe('Request ID Generation', () => {
-    it('should generate a UUID v4 request ID if not provided', async () => {
+    it('generates a UUID v4 when no X-Request-Id header is provided', async () => {
       const response = await request(app).get('/test');
 
       expect(response.status).toBe(200);
-      expect(response.headers['x-request-id']).toBeDefined();
-
-      // Verify it's a valid UUID v4
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-      expect(response.headers['x-request-id']).toMatch(uuidRegex);
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
     });
 
-    it('should use client-provided request ID', async () => {
-      const customId = 'my-custom-request-id-123';
+    it('generates different IDs for different requests', async () => {
+      const r1 = await request(app).get('/test');
+      const r2 = await request(app).get('/test');
 
-      const response = await request(app).get('/test').set('X-Request-Id', customId);
-
-      expect(response.status).toBe(200);
-      expect(response.headers['x-request-id']).toBe(customId);
-      expect(response.body.requestId).toBe(customId);
-    });
-
-    it('should generate different IDs for different requests', async () => {
-      const response1 = await request(app).get('/test');
-      const response2 = await request(app).get('/test');
-
-      expect(response1.headers['x-request-id']).toBeDefined();
-      expect(response2.headers['x-request-id']).toBeDefined();
-      expect(response1.headers['x-request-id']).not.toBe(response2.headers['x-request-id']);
+      expect(r1.headers['x-request-id']).not.toBe(r2.headers['x-request-id']);
     });
   });
+
+  // ── Valid UUID v4 passthrough ───────────────────────────────────────────────
+
+  describe('Valid UUID v4 passthrough', () => {
+    it('accepts and echoes a valid UUID v4 supplied by the client', async () => {
+      const validId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+
+      const response = await request(app).get('/test').set('X-Request-Id', validId);
+
+      expect(response.status).toBe(200);
+      expect(response.headers['x-request-id']).toBe(validId);
+      expect(response.body.requestId).toBe(validId);
+    });
+
+    it('accepts a valid UUID v4 with uppercase hex digits', async () => {
+      const validId = 'F47AC10B-58CC-4372-A567-0E02B2C3D479';
+
+      const response = await request(app).get('/test').set('X-Request-Id', validId);
+
+      expect(response.headers['x-request-id']).toBe(validId);
+    });
+  });
+
+  // ── Invalid value rejection ─────────────────────────────────────────────────
+
+  describe('Invalid X-Request-Id rejection', () => {
+    it('replaces an empty X-Request-Id with a generated UUID', async () => {
+      const response = await request(app).get('/test').set('X-Request-Id', '');
+
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+    });
+
+    it('replaces an arbitrary string with a generated UUID', async () => {
+      const response = await request(app)
+        .get('/test')
+        .set('X-Request-Id', 'my-custom-request-id-123');
+
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+      expect(response.headers['x-request-id']).not.toBe('my-custom-request-id-123');
+    });
+
+    it('replaces a newline-injection attempt with a generated UUID', async () => {
+      const injected = 'f47ac10b-58cc-4372-a567-0e02b2c3d479\nX-Injected-Header: evil';
+
+      const response = await request(app).get('/test').set('X-Request-Id', injected);
+
+      // The response ID must be a clean UUID — not the injected string
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+      expect(response.headers['x-request-id']).not.toContain('\n');
+    });
+
+    it('replaces a carriage-return injection attempt with a generated UUID', async () => {
+      const injected = 'f47ac10b-58cc-4372-a567-0e02b2c3d479\rINJECTED';
+
+      const response = await request(app).get('/test').set('X-Request-Id', injected);
+
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+      expect(response.headers['x-request-id']).not.toContain('\r');
+    });
+
+    it('replaces a very long string with a generated UUID', async () => {
+      const longId = 'a'.repeat(500);
+
+      const response = await request(app).get('/test').set('X-Request-Id', longId);
+
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+    });
+
+    it('replaces a UUID v1 (non-v4) with a generated UUID', async () => {
+      const uuidV1 = '550e8400-e29b-11d4-a716-446655440000';
+
+      const response = await request(app).get('/test').set('X-Request-Id', uuidV1);
+
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+      expect(response.headers['x-request-id']).not.toBe(uuidV1);
+    });
+
+    it('replaces a UUID without hyphens with a generated UUID', async () => {
+      const noHyphens = 'f47ac10b58cc4372a5670e02b2c3d479';
+
+      const response = await request(app).get('/test').set('X-Request-Id', noHyphens);
+
+      expect(response.headers['x-request-id']).toMatch(UUID_V4_REGEX);
+    });
+  });
+
+  // ── Response headers ────────────────────────────────────────────────────────
 
   describe('Response Headers', () => {
-    it('should include X-Request-Id in response headers', async () => {
+    it('always includes X-Request-Id in response headers', async () => {
       const response = await request(app).get('/test');
 
       expect(response.headers['x-request-id']).toBeDefined();
     });
 
-    it('should return the same ID in header and body', async () => {
+    it('returns the same ID in header and response body', async () => {
       const response = await request(app).get('/test');
 
-      const headerRequestId = response.headers['x-request-id'];
-      const bodyRequestId = response.body.requestId;
-
-      expect(headerRequestId).toBe(bodyRequestId);
+      expect(response.headers['x-request-id']).toBe(response.body.requestId);
     });
   });
 
+  // ── Request context ─────────────────────────────────────────────────────────
+
   describe('Request Context', () => {
-    it('should attach request ID to request object', async () => {
+    it('attaches request ID to the request object', async () => {
       const response = await request(app).get('/test');
 
       expect(response.body.requestId).toBeDefined();
       expect(response.body.requestId).toBe(response.headers['x-request-id']);
     });
 
-    it('should make request ID available via getRequestId()', async () => {
+    it('makes request ID available via getRequestId()', async () => {
       const response = await request(app).get('/test');
 
-      expect(response.body.contextRequestId).toBeDefined();
       expect(response.body.contextRequestId).toBe(response.headers['x-request-id']);
     });
 
-    it('should maintain request ID across async operations', async () => {
+    it('maintains request ID across async operations', async () => {
       const response = await request(app).post('/test-async');
 
       expect(response.status).toBe(200);
-      expect(response.body.requestIdBefore).toBeDefined();
-      expect(response.body.requestIdAfter).toBeDefined();
       expect(response.body.match).toBe(true);
       expect(response.body.requestIdBefore).toBe(response.headers['x-request-id']);
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should handle empty X-Request-Id header', async () => {
-      const response = await request(app).get('/test').set('X-Request-Id', '');
+  // ── Concurrent requests ─────────────────────────────────────────────────────
 
-      // Should generate a new ID since empty string is falsy
-      expect(response.headers['x-request-id']).toBeDefined();
-      expect(response.headers['x-request-id']).not.toBe('');
-    });
+  describe('Concurrent requests', () => {
+    it('handles concurrent requests with valid UUID v4 IDs correctly', async () => {
+      // Use valid UUID v4 values so they pass validation and are echoed back
+      const validIds = [
+        'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        'a8098c1a-f86e-11da-bd1a-00112444be1e',
+        '6ba7b810-9dad-41d1-80b4-00c04fd430c8',
+        '6ba7b811-9dad-41d1-80b4-00c04fd430c8',
+        '6ba7b812-9dad-41d1-80b4-00c04fd430c8',
+      ];
 
-    it('should handle special characters in custom request ID', async () => {
-      const customId = 'request-id-with-special-chars-!@#$%';
-
-      const response = await request(app).get('/test').set('X-Request-Id', customId);
-
-      expect(response.headers['x-request-id']).toBe(customId);
-    });
-
-    it('should handle very long custom request ID', async () => {
-      const customId = 'a'.repeat(500);
-
-      const response = await request(app).get('/test').set('X-Request-Id', customId);
-
-      expect(response.headers['x-request-id']).toBe(customId);
-    });
-  });
-
-  describe('Multiple Requests', () => {
-    it('should handle concurrent requests with different IDs', async () => {
-      const requests = Array.from({ length: 10 }, (_, i) =>
-        request(app).get('/test').set('X-Request-Id', `request-${i}`),
+      const responses = await Promise.all(
+        validIds.map((id) => request(app).get('/test').set('X-Request-Id', id)),
       );
 
-      const responses = await Promise.all(requests);
-
       responses.forEach((response, i) => {
-        expect(response.headers['x-request-id']).toBe(`request-${i}`);
+        expect(response.headers['x-request-id']).toBe(validIds[i]);
       });
+    });
+
+    it('generates unique IDs for concurrent requests without a header', async () => {
+      const responses = await Promise.all(
+        Array.from({ length: 10 }, () => request(app).get('/test')),
+      );
+
+      const ids = responses.map((r) => r.headers['x-request-id']);
+      const unique = new Set(ids);
+      expect(unique.size).toBe(10);
     });
   });
 });
 
+// ── getRequestId outside request context ─────────────────────────────────────
+
 describe('getRequestId() outside request context', () => {
-  it('should return undefined when called outside request context', () => {
+  it('returns undefined when called outside request context', () => {
     const requestId = getRequestId();
     expect(requestId).toBeUndefined();
   });

--- a/backend/src/middleware/requestId.ts
+++ b/backend/src/middleware/requestId.ts
@@ -9,6 +9,23 @@ import { AsyncLocalStorage } from 'async_hooks';
 export const requestContext = new AsyncLocalStorage<{ requestId: string }>();
 
 /**
+ * UUID v4 validation regex.
+ * Accepts the canonical hyphenated form: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+ * where y is one of 8, 9, a, or b.
+ */
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate that a string is a well-formed UUID v4.
+ * Returns true only for the canonical hyphenated format to prevent
+ * log-injection attacks via newlines, control characters, or arbitrary strings.
+ */
+export function isValidUuidV4(value: string): boolean {
+  return UUID_V4_REGEX.test(value);
+}
+
+/**
  * Request ID Middleware
  *
  * Generates a unique ID for each incoming request and:
@@ -16,13 +33,19 @@ export const requestContext = new AsyncLocalStorage<{ requestId: string }>();
  * - Adds it to response headers (X-Request-Id)
  * - Attaches it to the request object
  *
- * The request ID can be:
- * - Generated automatically (UUID v4)
- * - Provided by client via X-Request-Id header (for request tracing)
+ * The request ID is:
+ * - Accepted from the client via X-Request-Id header **only** when it is a
+ *   valid UUID v4 (prevents log-injection via arbitrary header values).
+ * - Generated automatically (crypto.randomUUID / UUID v4) in all other cases.
  */
 export const requestIdMiddleware = (req: Request, res: Response, next: NextFunction): void => {
-  // Check if client provided a request ID, otherwise generate one
-  const requestId = (req.headers['x-request-id'] as string) || uuidv4();
+  const clientId = req.headers['x-request-id'] as string | undefined;
+
+  // Accept the client-supplied value only when it passes UUID v4 validation.
+  // Any other value (empty string, newline-containing string, arbitrary text)
+  // is silently replaced with a freshly generated UUID.
+  const requestId =
+    clientId && isValidUuidV4(clientId) ? clientId : uuidv4();
 
   // Store in AsyncLocalStorage for context-aware logging
   requestContext.run({ requestId }, () => {


### PR DESCRIPTION
closes  #648  
- Add isValidUuidV4() helper with UUID v4 regex (exported for testing)
- requestIdMiddleware now accepts client-supplied X-Request-Id only when it passes UUID v4 validation; falls back to crypto.randomUUID() (uuidv4) for empty strings, arbitrary text, newline/CR injection attempts, UUIDs of other versions, and any other non-conforming value
- Update requestId.test.ts:
  - Add isValidUuidV4() unit tests covering valid UUIDs, invalid strings, newline injection, CR injection, null bytes, shell injection, and non-v4 UUID versions
  - Update integration tests to reflect that only valid UUID v4 values are echoed back; invalid values now produce a freshly generated UUID
  - Add concurrent-request tests using valid UUID v4 values