### PR TITLE
fix(ipfs): exclude pinned files from cache eviction (#671)

### DIFF
--- a/src/blockchain/services/IPFSService.ts
+++ b/src/blockchain/services/IPFSService.ts
@@ -368,6 +368,8 @@ export class IPFSService {
     // sort by lastAccess ascending (oldest first)
     all.sort((a, b) => (a.lastAccess || 0) - (b.lastAccess || 0))
     for (const entry of all) {
+      const pin = await idbGet('pins', entry.cid)
+      if (pin?.pinned) continue
       await idbDelete('files', entry.cid)
       total -= entry.size || 0
       if (total <= limit) break


### PR DESCRIPTION
## Summary

closes #671.

`enforceCacheLimit` was evicting the oldest cached files without checking pin status, causing pinned files to be removed from the local IPFS cache.

## Change

In `IPFSService.enforceCacheLimit`, before deleting a cache entry, check the `pins` IndexedDB store. If `pin.pinned === true`, skip that entry and continue to the next oldest unpinned file.

```diff
-    for (const entry of all) {
-      await idbDelete('files', entry.cid)
+    for (const entry of all) {
+      const pin = await idbGet('pins', entry.cid)
+      if (pin?.pinned) continue
+      await idbDelete('files', entry.cid)
```

## Testing

- Cache eviction now only removes unpinned files.
- Pinned files remain in the cache regardless of their `lastAccess` timestamp.