### PR TITLE
fix: sequence weekly cohort job after daily on Monday

### DIFF
--- a/backend/src/__tests__/cohortJobMonday.test.ts
+++ b/backend/src/__tests__/cohortJobMonday.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for Monday cohort-job sequencing (issue: weekly must wait for daily).
+ *
+ * All Redis and service calls are mocked — no real infrastructure required.
+ */
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('../queues/queueManager', () => ({
+  queueManager: {
+    createWorker: jest.fn(),
+    createQueue: jest.fn(() => ({ name: 'mock-queue' })),
+    addJob: jest.fn(),
+  },
+  redisClient: {
+    exists: jest.fn(),
+    set: jest.fn().mockResolvedValue('OK'),
+  },
+}));
+
+jest.mock('../services/CohortService', () => ({
+  cohortService: {
+    invalidateCache: jest.fn(),
+    computeCohorts: jest.fn(),
+  },
+}));
+
+// ── imports ───────────────────────────────────────────────────────────────────
+
+import { redisClient } from '../queues/queueManager';
+import { cohortService } from '../services/CohortService';
+import {
+  processCohortJob,
+  dailyCompleteKey,
+  isMonday,
+  waitForDailyComplete,
+  WaitOptions,
+} from '../jobs/cohortJob';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const mockExists = redisClient.exists as jest.Mock;
+const mockSet = redisClient.set as jest.Mock;
+
+const MONDAY  = new Date('2026-01-05T01:00:00Z'); // UTC Monday
+const TUESDAY = new Date('2026-01-06T01:00:00Z'); // UTC Tuesday
+
+function makeJob(id: string, data: Record<string, unknown>): any {
+  return { id, name: 'compute-cohorts', data, updateProgress: jest.fn() };
+}
+
+const mockResult = {
+  totalUsers: 10,
+  segments: [{ cohort: 'power', count: 10 }],
+  computedAt: new Date('2026-01-05T00:00:00Z'),
+};
+
+// Suppress logger noise
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'info').mockImplementation(() => {});
+});
+afterAll(() => jest.restoreAllMocks());
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (cohortService.computeCohorts as jest.Mock).mockResolvedValue(mockResult);
+});
+
+// ── unit helpers ──────────────────────────────────────────────────────────────
+
+describe('isMonday', () => {
+  it('returns true for a Monday UTC date', () => {
+    expect(isMonday(new Date('2026-01-05T00:00:00Z'))).toBe(true);
+  });
+
+  it('returns false for a non-Monday UTC date', () => {
+    expect(isMonday(new Date('2026-01-06T00:00:00Z'))).toBe(false);
+  });
+});
+
+describe('dailyCompleteKey', () => {
+  it('returns a key scoped to the UTC date', () => {
+    expect(dailyCompleteKey(new Date('2026-01-05T00:30:00Z'))).toBe('cohort:daily-complete:2026-01-05');
+  });
+});
+
+describe('waitForDailyComplete', () => {
+  it('resolves true immediately when the key already exists', async () => {
+    mockExists.mockResolvedValueOnce(1);
+    const result = await waitForDailyComplete(MONDAY, { pollMs: 10, timeoutMs: 100 });
+    expect(result).toBe(true);
+    expect(mockExists).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves true after the key appears on a subsequent poll', async () => {
+    mockExists
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
+    const result = await waitForDailyComplete(MONDAY, { pollMs: 10, timeoutMs: 500 });
+    expect(result).toBe(true);
+    expect(mockExists).toHaveBeenCalledTimes(3);
+  });
+
+  it('resolves false when the key never appears within the timeout', async () => {
+    mockExists.mockResolvedValue(0);
+    const result = await waitForDailyComplete(MONDAY, { pollMs: 10, timeoutMs: 30 });
+    expect(result).toBe(false);
+  });
+});
+
+// ── processCohortJob — daily job ──────────────────────────────────────────────
+
+describe('processCohortJob — daily', () => {
+  it('writes the daily-complete Redis key after computing', async () => {
+    const job = makeJob('d1', { triggeredBy: 'daily', organizationId: 'org-1' });
+    await processCohortJob(job, MONDAY);
+    expect(mockSet).toHaveBeenCalledWith('cohort:daily-complete:2026-01-05', '1', 'EX', 7200);
+  });
+
+  it('writes the key even on a non-Monday (daily always signals)', async () => {
+    const job = makeJob('d2', { triggeredBy: 'daily' });
+    await processCohortJob(job, TUESDAY);
+    expect(mockSet).toHaveBeenCalledWith('cohort:daily-complete:2026-01-06', '1', 'EX', 7200);
+  });
+});
+
+// ── processCohortJob — weekly job on Monday ───────────────────────────────────
+
+const SHORT_WAIT: WaitOptions = { pollMs: 10, timeoutMs: 500 };
+
+describe('processCohortJob — weekly on Monday', () => {
+  it('waits for the daily-complete key before computing', async () => {
+    mockExists.mockResolvedValueOnce(0).mockResolvedValueOnce(1);
+    const job = makeJob('w1', { triggeredBy: 'weekly' });
+    await processCohortJob(job, MONDAY, SHORT_WAIT);
+    expect(mockExists).toHaveBeenCalledWith('cohort:daily-complete:2026-01-05');
+    expect(cohortService.computeCohorts).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the daily job does not complete within the timeout', async () => {
+    mockExists.mockResolvedValue(0);
+    const job = makeJob('w2', { triggeredBy: 'weekly' });
+    await expect(
+      processCohortJob(job, MONDAY, { pollMs: 10, timeoutMs: 50 }),
+    ).rejects.toThrow('Weekly cohort job timed out waiting for daily job to complete on Monday');
+    expect(cohortService.computeCohorts).not.toHaveBeenCalled();
+  });
+
+  it('proceeds immediately when the daily key is already present', async () => {
+    mockExists.mockResolvedValueOnce(1);
+    const job = makeJob('w3', { triggeredBy: 'weekly' });
+    await processCohortJob(job, MONDAY, SHORT_WAIT);
+    expect(mockExists).toHaveBeenCalledTimes(1);
+    expect(cohortService.computeCohorts).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── processCohortJob — weekly job on non-Monday ───────────────────────────────
+
+describe('processCohortJob — weekly on non-Monday', () => {
+  it('skips the wait and computes immediately', async () => {
+    const job = makeJob('w4', { triggeredBy: 'weekly' });
+    await processCohortJob(job, TUESDAY);
+    expect(mockExists).not.toHaveBeenCalled();
+    expect(cohortService.computeCohorts).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── processCohortJob — ordering guarantee ─────────────────────────────────────
+
+describe('processCohortJob — ordering guarantee on Monday', () => {
+  it('computeCohorts is called only after the daily-complete key is confirmed', async () => {
+    const callOrder: string[] = [];
+    mockExists.mockImplementationOnce(async () => { callOrder.push('exists'); return 1; });
+    (cohortService.computeCohorts as jest.Mock).mockImplementationOnce(async () => {
+      callOrder.push('compute');
+      return mockResult;
+    });
+
+    const job = makeJob('w5', { triggeredBy: 'weekly' });
+    await processCohortJob(job, MONDAY, SHORT_WAIT);
+
+    expect(callOrder).toEqual(['exists', 'compute']);
+  });
+});

--- a/backend/src/__tests__/jobHandlers.test.ts
+++ b/backend/src/__tests__/jobHandlers.test.ts
@@ -18,6 +18,10 @@ jest.mock('../queues/queueManager', () => ({
     retryJob: jest.fn(),
     removeJob: jest.fn(),
   },
+  redisClient: {
+    exists: jest.fn().mockResolvedValue(0),
+    set: jest.fn().mockResolvedValue('OK'),
+  },
 }));
 
 jest.mock('../services/CohortService', () => ({

--- a/backend/src/jobs/cohortJob.ts
+++ b/backend/src/jobs/cohortJob.ts
@@ -2,10 +2,49 @@ import { Job } from 'bullmq';
 import { cohortService } from '../services/CohortService';
 import { createLogger } from '../lib/logger';
 import { CohortJobData } from '../queues/cohortQueue';
+import { redisClient } from '../queues/queueManager';
 
 const logger = createLogger('cohort-job');
 
-export async function processCohortJob(job: Job<CohortJobData>): Promise<object> {
+export interface WaitOptions {
+  pollMs?: number;
+  timeoutMs?: number;
+}
+
+/** Key written by the daily job so the weekly job can wait for it on Monday. */
+export function dailyCompleteKey(date: Date): string {
+  return `cohort:daily-complete:${date.toISOString().slice(0, 10)}`;
+}
+
+/** Returns true when the given date falls on a Monday (UTC). */
+export function isMonday(date: Date): boolean {
+  return date.getUTCDay() === 1;
+}
+
+/**
+ * Poll Redis until the daily-complete key exists or the timeout elapses.
+ * Resolves true if the key appeared, false on timeout.
+ */
+export async function waitForDailyComplete(
+  date: Date,
+  { pollMs = 5_000, timeoutMs = 55 * 60 * 1_000 }: WaitOptions = {},
+): Promise<boolean> {
+  const key = dailyCompleteKey(date);
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const exists = await redisClient.exists(key);
+    if (exists) return true;
+    await new Promise((res) => setTimeout(res, pollMs));
+  }
+  return false;
+}
+
+export async function processCohortJob(
+  job: Job<CohortJobData>,
+  now: Date = new Date(),
+  waitOptions: WaitOptions = {},
+): Promise<object> {
   const { organizationId, triggeredBy = 'manual' } = job.data;
 
   logger.info('Starting cohort computation job', {
@@ -14,10 +53,28 @@ export async function processCohortJob(job: Job<CohortJobData>): Promise<object>
     triggeredBy,
   });
 
+  // On Monday, the weekly job must wait until the daily job has finished.
+  if (triggeredBy === 'weekly' && isMonday(now)) {
+    logger.info('Weekly cohort job waiting for daily job to complete', { jobId: job.id });
+    const dailyDone = await waitForDailyComplete(now, waitOptions);
+    if (!dailyDone) {
+      throw new Error('Weekly cohort job timed out waiting for daily job to complete on Monday');
+    }
+    logger.info('Daily cohort job confirmed complete; proceeding with weekly run', { jobId: job.id });
+  }
+
   // Invalidate stale cache before recomputing
   cohortService.invalidateCache(organizationId);
 
   const result = await cohortService.computeCohorts(organizationId);
+
+  // Signal that the daily job has finished so the weekly job can proceed.
+  if (triggeredBy === 'daily') {
+    const key = dailyCompleteKey(now);
+    // TTL of 2 hours — well past the weekly job's 1 AM window.
+    await redisClient.set(key, '1', 'EX', 7_200);
+    logger.info('Daily cohort complete signal written', { key });
+  }
 
   const summary = {
     jobId: job.id,


### PR DESCRIPTION
Fix Monday cohort job race condition
  
  On Monday mornings both scheduleDailyCohortJob (midnight UTC) and scheduleWeeklyCohortJob (1 AM UTC) fire within the
  same hour. If the daily job is still running when the weekly job starts, both jobs compute cohorts concurrently
  against stale or partially-updated data.
  
  What changed
  
  - The daily job writes a Redis key cohort:daily-complete:YYYY-MM-DD (2h TTL) after it finishes computing.
  - The weekly job, when running on a Monday, polls for that key before proceeding. It waits up to 55 minutes (5s poll
  interval), then throws so BullMQ retries it.
  - On all other days the weekly job is unaffected.
  
  Testing
  
  13 new unit tests in cohortJobMonday.test.ts assert:
  
  - Weekly job waits and proceeds once the key appears
  - Weekly job throws on timeout (no compute called)
  - Daily job always writes the signal key
  - Non-Monday weekly runs skip the wait entirely
  - computeCohorts is only called after the key is confirmed
  
  No Redis or real infrastructure required — all mocked.
closes #639 