### PR TITLE
fix: redact sensitive fields from audit logs

### DIFF
--- a/backend/src/__tests__/auditRedaction.test.ts
+++ b/backend/src/__tests__/auditRedaction.test.ts
@@ -1,0 +1,54 @@
+import { redactSensitiveFields, REDACTED_FIELDS } from '../utils/redactSensitiveFields';
+
+const SENSITIVE = ['password', 'token', 'cardNumber', 'cvv', 'secret'];
+
+describe('redactSensitiveFields', () => {
+  it('redacts all required sensitive fields', () => {
+    const input = { password: 'pass123', token: 'tok', cardNumber: '4111', cvv: '123', secret: 'shh' };
+    const result = redactSensitiveFields(input);
+    for (const field of SENSITIVE) {
+      expect(result[field]).toBe('[REDACTED]');
+    }
+  });
+
+  it('never leaks sensitive values in output', () => {
+    const input = { password: 'supersecret', token: 'bearer-abc', cardNumber: '4111111111111111', cvv: '999', secret: 'mysecret' };
+    const result = redactSensitiveFields(input);
+    const serialised = JSON.stringify(result);
+    expect(serialised).not.toContain('supersecret');
+    expect(serialised).not.toContain('bearer-abc');
+    expect(serialised).not.toContain('4111111111111111');
+    expect(serialised).not.toContain('999');
+    expect(serialised).not.toContain('mysecret');
+  });
+
+  it('is case-insensitive for field names', () => {
+    const result = redactSensitiveFields({ Password: 'x', TOKEN: 'y', CardNumber: 'z' });
+    expect(result['Password']).toBe('[REDACTED]');
+    expect(result['TOKEN']).toBe('[REDACTED]');
+    expect(result['CardNumber']).toBe('[REDACTED]');
+  });
+
+  it('redacts sensitive fields nested inside objects', () => {
+    const result = redactSensitiveFields({ user: { password: 'nested', name: 'alice' } });
+    expect((result['user'] as Record<string, unknown>)['password']).toBe('[REDACTED]');
+    expect((result['user'] as Record<string, unknown>)['name']).toBe('alice');
+  });
+
+  it('preserves non-sensitive fields unchanged', () => {
+    const result = redactSensitiveFields({ username: 'alice', email: 'alice@example.com', age: 30 });
+    expect(result).toEqual({ username: 'alice', email: 'alice@example.com', age: 30 });
+  });
+
+  it('does not mutate the original object', () => {
+    const input = { password: 'original' };
+    redactSensitiveFields(input);
+    expect(input.password).toBe('original');
+  });
+
+  it('REDACTED_FIELDS set contains all required fields', () => {
+    for (const field of SENSITIVE) {
+      expect(REDACTED_FIELDS.has(field.toLowerCase())).toBe(true);
+    }
+  });
+});

--- a/backend/src/middleware/audit.ts
+++ b/backend/src/middleware/audit.ts
@@ -2,28 +2,38 @@ import { Response, NextFunction } from 'express';
 import { AuthRequest } from './authMiddleware';
 import { auditLogger } from '../services/AuditLogger';
 import { AuditAction } from '../models/AuditLog';
+import { redactSensitiveFields } from '../utils/redactSensitiveFields';
 
 /**
  * Middleware factory that records an audit log entry after the response is sent.
  * Must be used after `authMiddleware` (requires req.userId).
  *
+ * Sensitive fields (password, token, cardNumber, cvv, secret) are automatically
+ * redacted from any metadata before it is written to the audit log.
+ *
  * Usage:
  *   router.delete('/:id', authMiddleware, audit('post:delete', 'post', (req) => req.params.id), handler)
+ *
+ *   // With metadata (body fields are redacted automatically):
+ *   router.post('/login', audit('auth:login', undefined, undefined, (req) => req.body), handler)
  */
 export function audit(
   action: AuditAction,
   resourceType?: string,
   resourceId?: (req: AuthRequest) => string | undefined,
+  metadata?: (req: AuthRequest) => Record<string, unknown> | undefined,
 ) {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
     res.on('finish', () => {
       // Only log on successful (2xx) responses
       if (res.statusCode >= 200 && res.statusCode < 300) {
+        const rawMetadata = metadata?.(req);
         auditLogger.log({
           actorId: req.userId ?? 'anonymous',
           action,
           resourceType,
           resourceId: resourceId?.(req),
+          metadata: rawMetadata ? redactSensitiveFields(rawMetadata) : undefined,
           ip: req.ip,
           userAgent: req.headers['user-agent'],
         });

--- a/backend/src/services/AuditLogger.ts
+++ b/backend/src/services/AuditLogger.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '../lib/logger';
 import { prisma } from '../lib/prisma';
 import { AuditAction } from '../models/AuditLog';
+import { redactSensitiveFields } from '../utils/redactSensitiveFields';
 
 const logger = createLogger('audit');
 
@@ -22,6 +23,7 @@ export interface AuditContext {
  */
 class AuditLogger {
   async log(ctx: AuditContext): Promise<void> {
+    const safeMetadata = ctx.metadata ? redactSensitiveFields(ctx.metadata) : undefined;
     try {
       await prisma.auditLog.create({
         data: {
@@ -29,7 +31,7 @@ class AuditLogger {
           action: ctx.action,
           resource: ctx.resourceType ?? null,
           resourceId: ctx.resourceId ?? null,
-          metadata: ctx.metadata ? (ctx.metadata as object) : undefined,
+          metadata: safeMetadata ? (safeMetadata as object) : undefined,
           ipAddress: ctx.ip,
           userAgent: ctx.userAgent,
         },

--- a/backend/src/shared/middleware/audit.ts
+++ b/backend/src/shared/middleware/audit.ts
@@ -1,11 +1,15 @@
 import { Response, NextFunction } from 'express';
 import { AuthRequest } from './authMiddleware';
-import { auditLogger } from '../services/AuditLogger';
-import { AuditAction } from '../models/AuditLog';
+import { auditLogger } from '../../services/AuditLogger';
+import { AuditAction } from '../../models/AuditLog';
+import { redactSensitiveFields } from '../../utils/redactSensitiveFields';
 
 /**
  * Middleware factory that records an audit log entry after the response is sent.
  * Must be used after `authMiddleware` (requires req.userId).
+ *
+ * Sensitive fields (password, token, cardNumber, cvv, secret) are automatically
+ * redacted from any metadata before it is written to the audit log.
  *
  * Usage:
  *   router.delete('/:id', authMiddleware, audit('post:delete', 'post', (req) => req.params.id), handler)
@@ -14,16 +18,19 @@ export function audit(
   action: AuditAction,
   resourceType?: string,
   resourceId?: (req: AuthRequest) => string | undefined,
+  metadata?: (req: AuthRequest) => Record<string, unknown> | undefined,
 ) {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
     res.on('finish', () => {
       // Only log on successful (2xx) responses
       if (res.statusCode >= 200 && res.statusCode < 300) {
+        const rawMetadata = metadata?.(req);
         auditLogger.log({
           actorId: req.userId ?? 'anonymous',
           action,
           resourceType,
           resourceId: resourceId?.(req),
+          metadata: rawMetadata ? redactSensitiveFields(rawMetadata) : undefined,
           ip: req.ip,
           userAgent: req.headers['user-agent'],
         });

--- a/backend/src/utils/redactSensitiveFields.ts
+++ b/backend/src/utils/redactSensitiveFields.ts
@@ -1,0 +1,37 @@
+/**
+ * Sensitive field redaction utility for audit logging.
+ *
+ * Any field whose key (case-insensitive) appears in REDACTED_FIELDS
+ * will have its value replaced with '[REDACTED]' before the data is
+ * written to an audit log or emitted to a logger.
+ */
+
+export const REDACTED_FIELDS: ReadonlySet<string> = new Set([
+  'password',
+  'token',
+  'cardnumber',
+  'cvv',
+  'secret',
+]);
+
+/**
+ * Recursively redact sensitive keys from a plain object.
+ * Returns a new object — the original is never mutated.
+ */
+export function redactSensitiveFields(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    if (REDACTED_FIELDS.has(key.toLowerCase())) {
+      result[key] = '[REDACTED]';
+    } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = redactSensitiveFields(value as Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
- Add redactSensitiveFields utility (password, token, cardNumber, cvv, secret)
- Apply redaction in audit middleware before logging metadata
- Apply redaction in AuditLogger before writing to DB
- Add tests asserting sensitive values never appear in log output

closes #646