### PR TITLE
fix: resolve queue reliability and middleware issues (#635 #636 #637 #645)

### DIFF
--- a/backend/src/__tests__/compression.test.ts
+++ b/backend/src/__tests__/compression.test.ts
@@ -1,0 +1,81 @@
+/**
+ * compression middleware – shouldCompress tests
+ *
+ * Verifies that responses already carrying a Content-Encoding header are
+ * not re-compressed, while normal compressible responses still pass through.
+ */
+
+import { Request, Response } from 'express';
+
+// Re-export the private shouldCompress via a thin test shim by importing the
+// module and relying on the fact that compressionMiddleware uses it internally.
+// We test the observable behaviour: the filter function passed to `compression`.
+
+// Capture the filter option by mocking the `compression` package before import.
+let capturedFilter: ((req: Request, res: Response) => boolean) | undefined;
+
+jest.mock('compression', () => {
+  const actual = jest.requireActual<typeof import('compression')>('compression');
+  const mock = jest.fn((opts: any) => {
+    capturedFilter = opts?.filter;
+    return actual(opts);
+  }) as any;
+  mock.filter = actual.filter;
+  return mock;
+});
+
+// Import after mock is set up so capturedFilter is populated.
+require('../middleware/compression');
+
+function makeReq(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+function makeRes(headers: Record<string, string | string[]> = {}): Response {
+  return {
+    getHeader: (name: string) => headers[name.toLowerCase()],
+  } as unknown as Response;
+}
+
+describe('shouldCompress – Content-Encoding guard', () => {
+  it('returns false when Content-Encoding is set to gzip', () => {
+    const result = capturedFilter!(
+      makeReq(),
+      makeRes({ 'content-encoding': 'gzip' }),
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false when Content-Encoding is set to br', () => {
+    const result = capturedFilter!(
+      makeReq(),
+      makeRes({ 'content-encoding': 'br' }),
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false when Content-Encoding is set to deflate', () => {
+    const result = capturedFilter!(
+      makeReq(),
+      makeRes({ 'content-encoding': 'deflate' }),
+    );
+    expect(result).toBe(false);
+  });
+
+  it('does not skip compression when Content-Encoding is absent', () => {
+    // text/html is compressible — should not be blocked by the encoding guard
+    const result = capturedFilter!(
+      makeReq(),
+      makeRes({ 'content-type': 'text/html; charset=utf-8' }),
+    );
+    expect(result).toBe(true);
+  });
+
+  it('still respects x-no-compression opt-out regardless of Content-Encoding', () => {
+    const result = capturedFilter!(
+      makeReq({ 'x-no-compression': '1' }),
+      makeRes({ 'content-type': 'text/html' }),
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/backend/src/__tests__/emailQueue.test.ts
+++ b/backend/src/__tests__/emailQueue.test.ts
@@ -1,0 +1,81 @@
+/**
+ * emailQueue deduplication tests
+ *
+ * Verifies that sendEmail and sendTemplatedEmail derive a deterministic
+ * BullMQ job ID so that a second enqueue for the same recipient + template
+ * on the same day is a no-op.
+ */
+
+jest.mock('../queues/queueManager', () => ({
+  queueManager: {
+    createQueue: jest.fn(() => ({ name: 'email' })),
+    addJob: jest.fn().mockResolvedValue('job-id'),
+  },
+}));
+
+import { queueManager } from '../queues/queueManager';
+import { sendEmail, sendTemplatedEmail, EmailJobData } from '../queues/emailQueue';
+
+const addJob = queueManager.addJob as jest.Mock;
+
+const baseEmail: EmailJobData = {
+  to: 'user@example.com',
+  subject: 'Welcome',
+  body: 'Hello',
+  metadata: { templateId: 'welcome' },
+};
+
+beforeEach(() => addJob.mockClear());
+
+describe('sendEmail – deduplication', () => {
+  it('passes a deterministic jobId derived from recipient + templateId + date', async () => {
+    await sendEmail(baseEmail);
+
+    const [, , , options] = addJob.mock.calls[0];
+    expect(options.jobId).toMatch(/^user@example\.com:welcome:\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('produces the same jobId on a second call (no-op in BullMQ)', async () => {
+    await sendEmail(baseEmail);
+    await sendEmail(baseEmail);
+
+    const id1 = addJob.mock.calls[0][3].jobId;
+    const id2 = addJob.mock.calls[1][3].jobId;
+    expect(id1).toBe(id2);
+  });
+
+  it('uses "default" as templateId when metadata is absent', async () => {
+    const { metadata: _m, ...noMeta } = baseEmail;
+    await sendEmail(noMeta);
+
+    const [, , , options] = addJob.mock.calls[0];
+    expect(options.jobId).toContain(':default:');
+  });
+});
+
+describe('sendTemplatedEmail – deduplication', () => {
+  it('passes a deterministic jobId derived from recipient + templateId + date', async () => {
+    await sendTemplatedEmail('user@example.com', 'verify-email', { code: '123' });
+
+    const [, , , options] = addJob.mock.calls[0];
+    expect(options.jobId).toMatch(/^user@example\.com:verify-email:\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('produces the same jobId on a second call', async () => {
+    await sendTemplatedEmail('user@example.com', 'verify-email', { code: '123' });
+    await sendTemplatedEmail('user@example.com', 'verify-email', { code: '456' });
+
+    const id1 = addJob.mock.calls[0][3].jobId;
+    const id2 = addJob.mock.calls[1][3].jobId;
+    expect(id1).toBe(id2);
+  });
+
+  it('produces different jobIds for different recipients', async () => {
+    await sendTemplatedEmail('alice@example.com', 'welcome', {});
+    await sendTemplatedEmail('bob@example.com', 'welcome', {});
+
+    const id1 = addJob.mock.calls[0][3].jobId;
+    const id2 = addJob.mock.calls[1][3].jobId;
+    expect(id1).not.toBe(id2);
+  });
+});

--- a/backend/src/__tests__/payoutJob.test.ts
+++ b/backend/src/__tests__/payoutJob.test.ts
@@ -1,0 +1,84 @@
+/**
+ * processBatchPayoutJob – partial failure re-enqueue tests
+ *
+ * Verifies that failed payout items are re-enqueued individually and the
+ * batch job is marked as failed when any item fails.
+ */
+
+jest.mock('../queues/queueManager', () => ({
+  queueManager: {
+    createQueue: jest.fn(() => ({ name: 'payout' })),
+    createWorker: jest.fn(),
+    addJob: jest.fn().mockResolvedValue('job-id'),
+    addBulkJobs: jest.fn().mockResolvedValue(['re-job-1']),
+  },
+}));
+
+jest.mock('../lib/prisma', () => ({
+  prisma: { payoutFailure: { create: jest.fn().mockResolvedValue({}) } },
+}));
+
+import { Job } from 'bullmq';
+import { queueManager } from '../queues/queueManager';
+import { processBatchPayoutJob } from '../jobs/payoutJob';
+import { PayoutJobData } from '../queues/payoutQueue';
+
+const addBulkJobs = queueManager.addBulkJobs as jest.Mock;
+
+function makeJob(payouts: PayoutJobData[]): Job<{ payouts: PayoutJobData[] }> {
+  return {
+    id: 'batch-1',
+    data: { payouts },
+    updateProgress: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Job<{ payouts: PayoutJobData[] }>;
+}
+
+const validPayout: PayoutJobData = {
+  groupId: 'g1',
+  amount: 100,
+  recipient: 'alice@example.com',
+  recipientType: 'paypal',
+  currency: 'USD',
+};
+
+const invalidPayout: PayoutJobData = {
+  groupId: '',       // missing — triggers validation error
+  amount: 50,
+  recipient: 'bob@example.com',
+  recipientType: 'bank',
+  currency: 'USD',
+};
+
+beforeEach(() => addBulkJobs.mockClear());
+
+describe('processBatchPayoutJob – partial failure', () => {
+  it('re-enqueues failed items after a partial batch failure', async () => {
+    await expect(processBatchPayoutJob(makeJob([validPayout, invalidPayout]))).rejects.toThrow();
+
+    expect(addBulkJobs).toHaveBeenCalledTimes(1);
+    const [queueName, jobs] = addBulkJobs.mock.calls[0];
+    expect(queueName).toBe('payout');
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].data.recipient).toBe('bob@example.com');
+  });
+
+  it('throws so BullMQ marks the batch job as failed', async () => {
+    await expect(
+      processBatchPayoutJob(makeJob([validPayout, invalidPayout])),
+    ).rejects.toThrow(/failed payouts/i);
+  });
+
+  it('does not re-enqueue anything when all items succeed', async () => {
+    await processBatchPayoutJob(makeJob([validPayout]));
+    expect(addBulkJobs).not.toHaveBeenCalled();
+  });
+
+  it('re-enqueues all items when the entire batch fails', async () => {
+    await expect(
+      processBatchPayoutJob(makeJob([invalidPayout, { ...invalidPayout, recipient: 'carol@example.com' }])),
+    ).rejects.toThrow();
+
+    const [, jobs] = addBulkJobs.mock.calls[0];
+    expect(jobs).toHaveLength(2);
+  });
+});

--- a/backend/src/__tests__/queueManager.test.ts
+++ b/backend/src/__tests__/queueManager.test.ts
@@ -1,0 +1,120 @@
+/**
+ * QueueManager.closeAll – graceful shutdown ordering tests
+ *
+ * Verifies that workers are fully drained before queues/events and the
+ * Redis client are closed, so no in-flight job results are lost.
+ */
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+
+// Track call order across all mock close() calls
+const callOrder: string[] = [];
+
+const mockWorkerClose = jest.fn(() => {
+  callOrder.push('worker');
+  return Promise.resolve();
+});
+
+const mockQueueClose = jest.fn(() => {
+  callOrder.push('queue');
+  return Promise.resolve();
+});
+
+const mockEventsClose = jest.fn(() => {
+  callOrder.push('events');
+  return Promise.resolve();
+});
+
+const mockRedisQuit = jest.fn(() => {
+  callOrder.push('redis');
+  return Promise.resolve('OK' as const);
+});
+
+jest.mock('ioredis', () => {
+  return jest.fn().mockImplementation(() => ({
+    quit: mockRedisQuit,
+    on: jest.fn(),
+  }));
+});
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn().mockImplementation((name: string) => ({
+    name,
+    close: mockQueueClose,
+  })),
+  Worker: jest.fn().mockImplementation(() => ({
+    close: mockWorkerClose,
+    on: jest.fn(),
+  })),
+  QueueEvents: jest.fn().mockImplementation(() => ({
+    close: mockEventsClose,
+    on: jest.fn(),
+  })),
+}));
+
+jest.mock('../config/config', () => ({
+  config: {
+    REDIS_HOST: '127.0.0.1',
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: undefined,
+  },
+}));
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+import { QueueManager } from '../queues/queueManager';
+
+beforeEach(() => {
+  callOrder.length = 0;
+  mockWorkerClose.mockClear();
+  mockQueueClose.mockClear();
+  mockEventsClose.mockClear();
+  mockRedisQuit.mockClear();
+});
+
+describe('QueueManager.closeAll – shutdown ordering', () => {
+  it('closes workers before queues/events and Redis', async () => {
+    const manager = new QueueManager();
+    manager.createQueue('test-queue', {});
+    manager.createWorker('test-queue', jest.fn());
+
+    await manager.closeAll();
+
+    const workerIdx = callOrder.indexOf('worker');
+    const queueIdx = callOrder.indexOf('queue');
+    const redisIdx = callOrder.indexOf('redis');
+
+    expect(workerIdx).toBeLessThan(queueIdx);
+    expect(workerIdx).toBeLessThan(redisIdx);
+  });
+
+  it('closes Redis after queues and events', async () => {
+    const manager = new QueueManager();
+    manager.createQueue('test-queue', {});
+
+    await manager.closeAll();
+
+    const queueIdx = callOrder.indexOf('queue');
+    const redisIdx = callOrder.indexOf('redis');
+
+    expect(queueIdx).toBeLessThan(redisIdx);
+  });
+
+  it('calls close on every registered worker', async () => {
+    const manager = new QueueManager();
+    manager.createQueue('q1', {});
+    manager.createQueue('q2', {});
+    manager.createWorker('q1', jest.fn());
+    manager.createWorker('q2', jest.fn());
+
+    await manager.closeAll();
+
+    expect(mockWorkerClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls quit on the Redis client exactly once', async () => {
+    const manager = new QueueManager();
+    await manager.closeAll();
+    expect(mockRedisQuit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/jobs/payoutJob.ts
+++ b/backend/src/jobs/payoutJob.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq';
 import { queueManager } from '../queues/queueManager';
-import { PayoutJobData } from '../queues/payoutQueue';
+import { PayoutJobData, PAYOUT_QUEUE_NAME } from '../queues/payoutQueue';
 import { prisma } from '../lib/prisma';
 
 /**
@@ -168,6 +168,21 @@ export async function processBatchPayoutJob(job: Job<{ payouts: PayoutJobData[] 
   console.log(
     `[BatchPayoutJob] Job ${job.id} completed: ${successful} successful (${successfulAmount}), ${failed} failed`,
   );
+
+  // Re-enqueue failed items individually so each gets its own retry budget
+  if (failed > 0) {
+    const failedPayouts = payouts.filter((_, i) => !results[i].success);
+    const reEnqueueJobs = failedPayouts.map((payout) => ({
+      name: 'process-payout',
+      data: payout,
+      options: { priority: 1 },
+    }));
+    await queueManager.addBulkJobs(PAYOUT_QUEUE_NAME, reEnqueueJobs);
+
+    throw new Error(
+      `Batch job ${job.id} had ${failed}/${payouts.length} failed payouts; re-enqueued for retry`,
+    );
+  }
 
   return {
     success: true,

--- a/backend/src/middleware/compression.ts
+++ b/backend/src/middleware/compression.ts
@@ -58,6 +58,9 @@ function shouldCompress(req: Request, res: Response): boolean {
   // Respect the caller's explicit opt-out
   if (req.headers['x-no-compression']) return false;
 
+  // Skip re-compression of already-encoded responses
+  if (res.getHeader('Content-Encoding')) return false;
+
   const contentType = (res.getHeader('Content-Type') as string | undefined) ?? '';
 
   // Configurable deny list takes highest priority

--- a/backend/src/queues/emailQueue.ts
+++ b/backend/src/queues/emailQueue.ts
@@ -39,11 +39,23 @@ export const emailQueue = queueManager.createQueue(EMAIL_QUEUE_NAME, {
 });
 
 /**
+ * Build a deterministic job ID to deduplicate transactional emails.
+ * Same recipient + template on the same UTC date will produce the same ID,
+ * so a second enqueue is a no-op in BullMQ.
+ */
+function transactionalJobId(to: string, templateId: string): string {
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  return `${to}:${templateId}:${date}`;
+}
+
+/**
  * Send a single email by adding to the queue
  */
 export async function sendEmail(data: EmailJobData): Promise<string | undefined> {
+  const templateId = data.metadata?.templateId ?? 'default';
   const jobId = await queueManager.addJob(EMAIL_QUEUE_NAME, 'send-email', data, {
-    priority: 1, // High priority for single emails
+    priority: 1,
+    jobId: transactionalJobId(data.to, templateId),
   });
   return jobId;
 }
@@ -130,7 +142,11 @@ export async function sendTemplatedEmail(
     variables,
   };
 
-  return await sendEmail(templateData);
+  const jobId = await queueManager.addJob(EMAIL_QUEUE_NAME, 'send-email', templateData, {
+    priority: 1,
+    jobId: transactionalJobId(to, templateId),
+  });
+  return jobId;
 }
 
 /**

--- a/backend/src/queues/queueManager.ts
+++ b/backend/src/queues/queueManager.ts
@@ -396,23 +396,24 @@ export class QueueManager {
   }
 
   /**
-   * Close all queues and workers gracefully
+   * Close all queues and workers gracefully.
+   * Workers are drained first so in-flight jobs can complete before
+   * the Redis connection is torn down.
    */
   async closeAll(): Promise<void> {
     console.log('Closing all queues and workers...');
 
-    // Close all workers first
-    const workerClosePromises = Array.from(this.workers.values()).map((worker) => worker.close());
+    // 1. Drain workers — wait for in-flight jobs to finish
+    await Promise.all(Array.from(this.workers.values()).map((worker) => worker.close()));
 
-    // Close all queue events
-    const eventsClosePromises = Array.from(this.queueEvents.values()).map((events) =>
-      events.close(),
-    );
+    // 2. Close queue events and queues
+    await Promise.all([
+      ...Array.from(this.queueEvents.values()).map((events) => events.close()),
+      ...Array.from(this.queues.values()).map((queue) => queue.close()),
+    ]);
 
-    // Close all queues
-    const queueClosePromises = Array.from(this.queues.values()).map((queue) => queue.close());
-
-    await Promise.all([...workerClosePromises, ...eventsClosePromises, ...queueClosePromises]);
+    // 3. Close the shared Redis client last
+    await closeRedisClient();
 
     console.log('All queues, workers, and connections closed');
   }

--- a/backend/src/queues/queueManager.ts
+++ b/backend/src/queues/queueManager.ts
@@ -240,6 +240,7 @@ export class QueueManager {
       delay?: number;
       repeat?: any;
       cron?: string;
+      jobId?: string;
     },
   ): Promise<string | undefined> {
     const queue = this.queues.get(queueName);
@@ -251,7 +252,7 @@ export class QueueManager {
       priority: options?.priority,
       delay: options?.delay,
       repeat: options?.repeat,
-      jobId: `${queueName}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      jobId: options?.jobId ?? `${queueName}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
     });
 
     console.log(`Job "${jobName}" added to queue "${queueName}" with ID: ${job.id}`);


### PR DESCRIPTION
## Summary

This PR bundles four bug fixes across the queue infrastructure and compression middleware.

---

### #636 — Deduplicate transactional emails in the email queue

**Problem:** `sendEmail` and `sendTemplatedEmail` enqueued jobs with random IDs, so client retries produced duplicate welcome/verification emails.

**Fix:**
- Added `jobId?` option to `queueManager.addJob` so callers can supply a deterministic ID.
- Both `sendEmail` and `sendTemplatedEmail` now derive a job ID as `${to}:${templateId}:${YYYY-MM-DD}`. BullMQ silently drops a second enqueue with the same ID, making retries a no-op.

**Files changed:**
- `backend/src/queues/emailQueue.ts`
- `backend/src/queues/queueManager.ts`
- `backend/src/__tests__/emailQueue.test.ts` (6 new tests)

Closes #636

---

### #645 — Skip re-compression of already-compressed responses

**Problem:** `shouldCompress` in `compression.ts` checked `Content-Type` but not `Content-Encoding`, so responses already encoded as gzip/br/deflate were passed to the compressor again.

**Fix:**
- Added an early-return guard: `if (res.getHeader('Content-Encoding')) return false;`
- Evaluated before all other checks so it cannot be overridden by the allow/deny lists.

**Files changed:**
- `backend/src/middleware/compression.ts`
- `backend/src/__tests__/compression.test.ts` (5 new tests)

Closes #645

---

### #635 — Await worker drain before closing Redis in QueueManager.closeAll

**Problem:** `closeAll` closed workers, queues, and the Redis client all in one `Promise.all`, so the Redis connection could be torn down while workers still had in-flight jobs writing results.

**Fix:** Shutdown is now strictly ordered:
1. `await Promise.all(workers.map(w => w.close()))` — drain in-flight jobs first.
2. `await Promise.all([...events.close(), ...queues.close()])` — tear down BullMQ connections.
3. `await closeRedisClient()` — close Redis last.

**Files changed:**
- `backend/src/queues/queueManager.ts`
- `backend/src/__tests__/queueManager.test.ts` (4 new tests)

Closes #635

---

### #637 — Re-enqueue failed payout items instead of marking the batch job as succeeded

**Problem:** `processBatchPayoutJob` caught individual payout failures, recorded them in `results`, but always returned `{ success: true }` — failed items were silently dropped with no retry.

**Fix:**
- After the batch loop, failed items are collected and re-enqueued individually via `queueManager.addBulkJobs` so each gets its own retry budget.
- An error is thrown so BullMQ marks the batch job as failed rather than succeeded.
- Successful items in the same batch are unaffected.

**Files changed:**
- `backend/src/jobs/payoutJob.ts`
- `backend/src/__tests__/payoutJob.test.ts` (4 new tests)

Closes #637

---

## Testing

All new tests pass:

```
emailQueue.test.ts    — 6 passed
compression.test.ts   — 5 passed
queueManager.test.ts  — 4 passed
payoutJob.test.ts     — 4 passed
```