### PR TITLE
fix: social platform fixes for issues #617, #619, #620, #618

### DIFF
--- a/backend/src/__tests__/facebookTokenRefreshJob.test.ts
+++ b/backend/src/__tests__/facebookTokenRefreshJob.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #618 — Facebook long-lived token refresh BullMQ job
+ */
+
+// ── mock ioredis ─────────────────────────────────────────────────────────────
+type HashStore = Record<string, Record<string, string>>;
+const hashStore: HashStore = {};
+
+const mockRedis = {
+  scan: jest.fn(),
+  hgetall: jest.fn(async (key: string) => hashStore[key] ?? {}),
+  hset: jest.fn(async (key: string, data: Record<string, string>) => {
+    if (!hashStore[key]) hashStore[key] = {};
+    Object.assign(hashStore[key], data);
+    return 1;
+  }),
+  expireat: jest.fn(async () => 1),
+};
+jest.mock('ioredis', () => jest.fn(() => mockRedis));
+jest.mock('../config/runtime', () => ({ getRedisConnection: () => ({}) }));
+
+// ── mock BullMQ ───────────────────────────────────────────────────────────────
+let capturedProcessor: ((job: any) => Promise<any>) | null = null;
+const mockQueue = { add: jest.fn(), close: jest.fn() };
+const mockWorker = { on: jest.fn(), close: jest.fn() };
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn(() => mockQueue),
+  Worker: jest.fn((_name: string, processor: (job: any) => Promise<any>) => {
+    capturedProcessor = processor;
+    return mockWorker;
+  }),
+}));
+
+// ── mock FacebookService ──────────────────────────────────────────────────────
+const mockGetLongLivedUserToken = jest.fn();
+jest.mock('../services/FacebookService', () => ({
+  facebookService: {
+    isConfigured: () => true,
+    getLongLivedUserToken: mockGetLongLivedUserToken,
+  },
+}));
+
+import { startFacebookTokenRefreshJob, FACEBOOK_TOKEN_KEY } from '../jobs/facebookTokenRefreshJob';
+
+const NOW = Date.now();
+const SOON = NOW + 5 * 24 * 60 * 60 * 1000;   // 5 days — within 10-day threshold
+const LATER = NOW + 30 * 24 * 60 * 60 * 1000; // 30 days — outside threshold
+
+// Start the job once; capturedProcessor is set by the Worker constructor mock
+beforeAll(async () => {
+  await startFacebookTokenRefreshJob();
+});
+
+beforeEach(() => {
+  Object.keys(hashStore).forEach((k) => delete hashStore[k]);
+  mockRedis.scan.mockReset();
+  mockGetLongLivedUserToken.mockReset();
+  mockRedis.hset.mockClear();
+});
+
+function setupScan(keys: string[]) {
+  mockRedis.scan.mockResolvedValueOnce(['0', keys]);
+}
+
+describe('facebookTokenRefreshJob', () => {
+  it('refreshes tokens expiring within 10 days', async () => {
+    const key = FACEBOOK_TOKEN_KEY('user-1');
+    hashStore[key] = { accessToken: 'old-token', expiresAt: String(SOON) };
+    setupScan([key]);
+
+    const newExpiry = NOW + 60 * 86400_000;
+    mockGetLongLivedUserToken.mockResolvedValueOnce({ accessToken: 'new-token', expiresAt: newExpiry });
+
+    const result = await capturedProcessor!({ id: 'job-1', data: {} });
+
+    expect(mockGetLongLivedUserToken).toHaveBeenCalledWith('old-token');
+    expect(mockRedis.hset).toHaveBeenCalledWith(key, {
+      accessToken: 'new-token',
+      expiresAt: String(newExpiry),
+    });
+    expect(result).toEqual({ refreshed: 1, failed: 0 });
+  });
+
+  it('skips tokens not expiring within 10 days', async () => {
+    const key = FACEBOOK_TOKEN_KEY('user-2');
+    hashStore[key] = { accessToken: 'valid-token', expiresAt: String(LATER) };
+    setupScan([key]);
+
+    const result = await capturedProcessor!({ id: 'job-2', data: {} });
+
+    expect(mockGetLongLivedUserToken).not.toHaveBeenCalled();
+    expect(result).toEqual({ refreshed: 0, failed: 0 });
+  });
+
+  it('counts failures without throwing when refresh fails', async () => {
+    const key = FACEBOOK_TOKEN_KEY('user-3');
+    hashStore[key] = { accessToken: 'expiring', expiresAt: String(SOON) };
+    setupScan([key]);
+
+    mockGetLongLivedUserToken.mockRejectedValueOnce(new Error('Facebook API error'));
+
+    const result = await capturedProcessor!({ id: 'job-3', data: {} });
+
+    expect(result).toEqual({ refreshed: 0, failed: 1 });
+  });
+
+  it('handles mixed success and failure across multiple tokens', async () => {
+    const key1 = FACEBOOK_TOKEN_KEY('user-4');
+    const key2 = FACEBOOK_TOKEN_KEY('user-5');
+    hashStore[key1] = { accessToken: 'tok1', expiresAt: String(SOON) };
+    hashStore[key2] = { accessToken: 'tok2', expiresAt: String(SOON) };
+    setupScan([key1, key2]);
+
+    mockGetLongLivedUserToken
+      .mockResolvedValueOnce({ accessToken: 'new1', expiresAt: NOW + 60 * 86400_000 })
+      .mockRejectedValueOnce(new Error('rate limited'));
+
+    const result = await capturedProcessor!({ id: 'job-4', data: {} });
+
+    expect(result).toEqual({ refreshed: 1, failed: 1 });
+  });
+
+  it('schedules a daily repeating job', () => {
+    expect(mockQueue.add).toHaveBeenCalledWith(
+      'refresh-facebook-tokens',
+      {},
+      expect.objectContaining({ repeat: expect.objectContaining({ pattern: expect.any(String) }) }),
+    );
+  });
+});

--- a/backend/src/__tests__/tiktokChunkResume.test.ts
+++ b/backend/src/__tests__/tiktokChunkResume.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #619 — TikTokService.uploadChunk resume from last confirmed offset
+ */
+
+// ── mock ioredis ─────────────────────────────────────────────────────────────
+type HashStore = Record<string, Record<string, string>>;
+const hashStore: HashStore = {};
+let ttls: Record<string, number> = {};
+
+const mockRedis = {
+  hget: jest.fn(async (key: string, field: string) => hashStore[key]?.[field] ?? null),
+  hset: jest.fn(async (key: string, ...args: any[]) => {
+    if (!hashStore[key]) hashStore[key] = {};
+    // hset(key, field, value) or hset(key, { field: value })
+    if (typeof args[0] === 'object') {
+      Object.assign(hashStore[key], args[0]);
+    } else {
+      hashStore[key][args[0]] = args[1];
+    }
+    return 1;
+  }),
+  expire: jest.fn(async (key: string, ttl: number) => { ttls[key] = ttl; return 1; }),
+  del: jest.fn(async (key: string) => { delete hashStore[key]; return 1; }),
+};
+jest.mock('ioredis', () => jest.fn(() => mockRedis));
+jest.mock('../config/runtime', () => ({ getRedisConnection: () => ({}) }));
+jest.mock('../services/CircuitBreakerService', () => ({
+  circuitBreakerService: {
+    execute: jest.fn(async (_n: string, fn: () => any) => fn()),
+    getStats: jest.fn(() => ({})),
+  },
+}));
+
+import { tiktokService } from '../services/TikTokService';
+
+const UPLOAD_URL = 'https://upload.tiktokapis.com/video/';
+const SESSION_ID = 'session-abc-123';
+const TOTAL_SIZE = 30 * 1024 * 1024; // 30 MB
+const TOTAL_CHUNKS = 3;
+
+function makeChunk(size = 10 * 1024 * 1024) {
+  return Buffer.alloc(size);
+}
+
+beforeEach(() => {
+  Object.keys(hashStore).forEach((k) => delete hashStore[k]);
+  ttls = {};
+  jest.clearAllMocks();
+});
+
+describe('TikTokService.uploadChunk — resume from last confirmed offset', () => {
+  it('uploads a chunk and marks it confirmed in Redis', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as any);
+
+    await tiktokService.uploadChunk(UPLOAD_URL, makeChunk(), 0, TOTAL_CHUNKS, TOTAL_SIZE, SESSION_ID);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockRedis.hset).toHaveBeenCalledWith(
+      `tiktok:upload:progress:${SESSION_ID}`,
+      '0',
+      '1',
+    );
+    expect(mockRedis.expire).toHaveBeenCalledWith(
+      `tiktok:upload:progress:${SESSION_ID}`,
+      86400,
+    );
+  });
+
+  it('skips a chunk that is already confirmed (no fetch call)', async () => {
+    // Pre-mark chunk 1 as confirmed
+    hashStore[`tiktok:upload:progress:${SESSION_ID}`] = { '1': '1' };
+
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    await tiktokService.uploadChunk(UPLOAD_URL, makeChunk(), 1, TOTAL_CHUNKS, TOTAL_SIZE, SESSION_ID);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('resumes from the correct offset after a mid-upload failure', async () => {
+    // Chunks 0 and 1 already confirmed; chunk 2 needs uploading
+    hashStore[`tiktok:upload:progress:${SESSION_ID}`] = { '0': '1', '1': '1' };
+
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 206,
+      text: async () => '',
+    } as any);
+
+    await tiktokService.uploadChunk(UPLOAD_URL, makeChunk(), 2, TOTAL_CHUNKS, TOTAL_SIZE, SESSION_ID);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Verify Content-Range header starts at byte 20 MB
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Range']).toMatch(/^bytes 20971520-/);
+  });
+
+  it('throws and does not mark chunk confirmed on upload failure', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    } as any);
+
+    await expect(
+      tiktokService.uploadChunk(UPLOAD_URL, makeChunk(), 0, TOTAL_CHUNKS, TOTAL_SIZE, SESSION_ID),
+    ).rejects.toThrow('Chunk 1/3 upload failed');
+
+    expect(mockRedis.hset).not.toHaveBeenCalled();
+  });
+
+  it('clearUploadProgress removes the Redis key', async () => {
+    hashStore[`tiktok:upload:progress:${SESSION_ID}`] = { '0': '1' };
+
+    await tiktokService.clearUploadProgress(SESSION_ID);
+
+    expect(mockRedis.del).toHaveBeenCalledWith(`tiktok:upload:progress:${SESSION_ID}`);
+  });
+});

--- a/backend/src/__tests__/twitterPkce.test.ts
+++ b/backend/src/__tests__/twitterPkce.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #617 — TwitterService.exchangeCodeForTokens PKCE verification
+ */
+import crypto from 'crypto';
+import nock from 'nock';
+
+// ── env ──────────────────────────────────────────────────────────────────────
+process.env.TWITTER_BEARER_TOKEN = 'test-bearer';
+
+// ── mock ioredis ─────────────────────────────────────────────────────────────
+const store = new Map<string, string>();
+const mockRedis = {
+  set: jest.fn(async (key: string, value: string) => { store.set(key, value); return 'OK'; }),
+  getdel: jest.fn(async (key: string) => {
+    const v = store.get(key) ?? null;
+    store.delete(key);
+    return v;
+  }),
+};
+jest.mock('ioredis', () => jest.fn(() => mockRedis));
+
+// ── mock config/runtime ───────────────────────────────────────────────────────
+jest.mock('../config/runtime', () => ({ getRedisConnection: () => ({}) }));
+
+// ── mock CircuitBreakerService & LockService ──────────────────────────────────
+jest.mock('../services/CircuitBreakerService', () => ({
+  circuitBreakerService: {
+    execute: jest.fn(async (_n: string, fn: () => any) => fn()),
+    getStats: jest.fn(() => ({})),
+  },
+}));
+jest.mock('../utils/LockService', () => ({
+  LockService: { withLock: jest.fn((_k: string, fn: () => any) => fn()) },
+}));
+
+import { twitterService } from '../services/TwitterService';
+
+const CLIENT_ID = 'client-123';
+const REDIRECT_URI = 'https://app.example.com/callback';
+
+function makeChallenge(verifier: string): string {
+  return crypto.createHash('sha256').update(verifier).digest('base64url');
+}
+
+beforeAll(() => nock.disableNetConnect());
+afterAll(() => nock.enableNetConnect());
+afterEach(() => { nock.cleanAll(); store.clear(); jest.clearAllMocks(); });
+
+describe('TwitterService.exchangeCodeForTokens — PKCE verification', () => {
+  it('succeeds when code_verifier matches stored challenge', async () => {
+    const verifier = 'a'.repeat(43);
+    const challenge = makeChallenge(verifier);
+    const state = 'state-abc';
+
+    await twitterService.storePkceChallenge(state, challenge);
+
+    nock('https://api.twitter.com')
+      .post('/2/oauth2/token')
+      .reply(200, { access_token: 'at', refresh_token: 'rt', expires_in: 7200 });
+
+    const tokens = await twitterService.exchangeCodeForTokens(
+      'auth-code', state, verifier, CLIENT_ID, REDIRECT_URI,
+    );
+
+    expect(tokens.accessToken).toBe('at');
+    expect(tokens.refreshToken).toBe('rt');
+    expect(tokens.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('throws when code_verifier does not match stored challenge', async () => {
+    const state = 'state-xyz';
+    await twitterService.storePkceChallenge(state, makeChallenge('correct-verifier-padded-here'));
+
+    await expect(
+      twitterService.exchangeCodeForTokens(
+        'auth-code', state, 'wrong-verifier-padded-here!!', CLIENT_ID, REDIRECT_URI,
+      ),
+    ).rejects.toThrow('PKCE verification failed');
+  });
+
+  it('throws when no challenge is stored for the given state', async () => {
+    await expect(
+      twitterService.exchangeCodeForTokens(
+        'auth-code', 'unknown-state', 'any-verifier', CLIENT_ID, REDIRECT_URI,
+      ),
+    ).rejects.toThrow('PKCE challenge not found or expired');
+  });
+
+  it('consumes the challenge (one-time use)', async () => {
+    const verifier = 'b'.repeat(43);
+    const state = 'state-once';
+    await twitterService.storePkceChallenge(state, makeChallenge(verifier));
+
+    nock('https://api.twitter.com')
+      .post('/2/oauth2/token')
+      .reply(200, { access_token: 'at2', refresh_token: 'rt2', expires_in: 3600 });
+
+    await twitterService.exchangeCodeForTokens('code', state, verifier, CLIENT_ID, REDIRECT_URI);
+
+    // Second attempt with same state must fail
+    await expect(
+      twitterService.exchangeCodeForTokens('code', state, verifier, CLIENT_ID, REDIRECT_URI),
+    ).rejects.toThrow('PKCE challenge not found or expired');
+  });
+});

--- a/backend/src/__tests__/youtubeQuotaError.test.ts
+++ b/backend/src/__tests__/youtubeQuotaError.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #620 — YouTubeService quota exhaustion error with reset time
+ */
+import nock from 'nock';
+
+process.env.YOUTUBE_CLIENT_ID = 'test-client-id';
+process.env.YOUTUBE_CLIENT_SECRET = 'test-client-secret';
+
+// Override the moduleNameMapper stub so errors propagate (quota errors must not be swallowed by fallback)
+jest.mock('../services/CircuitBreakerService', () => ({
+  circuitBreakerService: {
+    execute: jest.fn(async (_n: string, fn: () => any) => fn()),
+    getStats: jest.fn(() => ({})),
+  },
+}));
+
+import { youTubeService, YouTubeQuotaError } from '../services/YouTubeService';
+
+const API = 'https://www.googleapis.com';
+
+beforeAll(() => nock.disableNetConnect());
+afterAll(() => nock.enableNetConnect());
+afterEach(() => nock.cleanAll());
+
+const quotaErrorBody = {
+  error: {
+    code: 403,
+    errors: [{ domain: 'youtube.quota', reason: 'quotaExceeded', message: 'The caller does not have permission' }],
+  },
+};
+
+describe('YouTubeService — quota exhaustion', () => {
+  it('getChannel throws YouTubeQuotaError with retryAfter on 403 quota-exceeded', async () => {
+    nock(API).get('/youtube/v3/channels').query(true).reply(403, quotaErrorBody);
+
+    let caught: any;
+    try {
+      await youTubeService.getChannel('token');
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(YouTubeQuotaError);
+    expect(caught.retryAfter).toBeInstanceOf(Date);
+    expect(caught.retryAfter.getTime()).toBeGreaterThan(Date.now());
+    expect(caught.message).toMatch(/quota/i);
+  });
+
+  it('getVideoStats throws YouTubeQuotaError on 403 dailyLimitExceeded', async () => {
+    const body = {
+      error: {
+        code: 403,
+        errors: [{ domain: 'youtube.quota', reason: 'dailyLimitExceeded', message: 'Daily limit exceeded' }],
+      },
+    };
+    nock(API).get('/youtube/v3/videos').query(true).reply(403, body);
+
+    await expect(youTubeService.getVideoStats('token', ['vid1'])).rejects.toThrow(YouTubeQuotaError);
+  });
+
+  it('listChannelVideos throws YouTubeQuotaError on 403 quota-exceeded', async () => {
+    nock(API).get('/youtube/v3/search').query(true).reply(403, quotaErrorBody);
+
+    await expect(youTubeService.listChannelVideos('token')).rejects.toThrow(YouTubeQuotaError);
+  });
+
+  it('getChannel throws a plain error on non-quota 403', async () => {
+    nock(API).get('/youtube/v3/channels').query(true).reply(403, {
+      error: { code: 403, errors: [{ domain: 'youtube', reason: 'forbidden', message: 'Forbidden' }] },
+    });
+
+    let caught: any;
+    try { await youTubeService.getChannel('token'); } catch (e) { caught = e; }
+
+    expect(caught).not.toBeInstanceOf(YouTubeQuotaError);
+    expect(caught.message).toMatch(/YouTube API error/);
+  });
+
+  it('retryAfter is in the future (next midnight Pacific)', async () => {
+    nock(API).get('/youtube/v3/channels').query(true).reply(403, quotaErrorBody);
+
+    let quotaErr: YouTubeQuotaError | undefined;
+    try {
+      await youTubeService.getChannel('token');
+    } catch (e: any) {
+      quotaErr = e;
+    }
+
+    expect(quotaErr).toBeInstanceOf(YouTubeQuotaError);
+    // Reset time must be at least 1 minute in the future and at most 25 hours away
+    const diffMs = quotaErr!.retryAfter.getTime() - Date.now();
+    expect(diffMs).toBeGreaterThan(60_000);
+    expect(diffMs).toBeLessThan(25 * 60 * 60 * 1000);
+  });
+});

--- a/backend/src/jobs/facebookTokenRefreshJob.ts
+++ b/backend/src/jobs/facebookTokenRefreshJob.ts
@@ -1,0 +1,130 @@
+import { Queue, Worker } from 'bullmq';
+import Redis from 'ioredis';
+import { getRedisConnection } from '../config/runtime';
+import { createLogger } from '../lib/logger';
+import { facebookService } from '../services/FacebookService';
+
+const logger = createLogger('facebook-token-refresh-job');
+
+const QUEUE_NAME = 'facebook-token-refresh';
+const JOB_NAME = 'refresh-facebook-tokens';
+const REPEAT_JOB_ID = 'facebook-token-refresh-repeat';
+
+// Run daily at 03:00 UTC
+const REFRESH_CRON = process.env.FACEBOOK_TOKEN_REFRESH_CRON || '0 3 * * *';
+
+// Refresh tokens that expire within 10 days (Facebook long-lived tokens last 60 days)
+const REFRESH_THRESHOLD_DAYS = 10;
+
+/**
+ * Redis key pattern for stored Facebook long-lived tokens.
+ * Hash fields: accessToken, expiresAt (unix ms as string)
+ *
+ * Key: facebook:token:<userId>
+ */
+export const FACEBOOK_TOKEN_KEY = (userId: string) => `facebook:token:${userId}`;
+
+let _redis: Redis | null = null;
+function getRedis(): Redis {
+  if (!_redis) _redis = new Redis(getRedisConnection());
+  return _redis;
+}
+
+let queue: Queue | null = null;
+let worker: Worker | null = null;
+
+export const startFacebookTokenRefreshJob = async (): Promise<void> => {
+  if (!facebookService.isConfigured()) {
+    logger.info('Facebook API not configured, token refresh job skipped');
+    return;
+  }
+
+  if (!queue) {
+    queue = new Queue(QUEUE_NAME, { connection: getRedisConnection() });
+  }
+
+  if (!worker) {
+    worker = new Worker(
+      QUEUE_NAME,
+      async (job) => {
+        const redis = getRedis();
+        const thresholdMs = REFRESH_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
+        const expiryBefore = Date.now() + thresholdMs;
+
+        // Scan for all facebook:token:* keys
+        const keys: string[] = [];
+        let cursor = '0';
+        do {
+          const [nextCursor, batch] = await redis.scan(cursor, 'MATCH', 'facebook:token:*', 'COUNT', 100);
+          cursor = nextCursor;
+          keys.push(...batch);
+        } while (cursor !== '0');
+
+        logger.info('Facebook token refresh: scanning tokens', { jobId: job.id, total: keys.length });
+
+        let refreshed = 0;
+        let failed = 0;
+
+        for (const key of keys) {
+          const data = await redis.hgetall(key);
+          if (!data.accessToken || !data.expiresAt) continue;
+
+          const expiresAt = Number(data.expiresAt);
+          if (expiresAt > expiryBefore) continue; // not expiring soon
+
+          try {
+            const result = await facebookService.getLongLivedUserToken(data.accessToken);
+            await redis.hset(key, {
+              accessToken: result.accessToken,
+              expiresAt: String(result.expiresAt),
+            });
+            // Extend Redis TTL to match the new token lifetime (60 days + buffer)
+            await redis.expireat(key, Math.ceil(result.expiresAt / 1000) + 86400);
+            refreshed++;
+            logger.info('Facebook token refreshed', { key });
+          } catch (err: any) {
+            logger.error('Failed to refresh Facebook token', { key, error: err.message });
+            failed++;
+          }
+        }
+
+        logger.info('Facebook token refresh complete', { jobId: job.id, refreshed, failed });
+        return { refreshed, failed };
+      },
+      { connection: getRedisConnection() },
+    );
+
+    worker.on('completed', (job) => {
+      logger.info('Facebook token refresh job completed', { jobId: job.id, result: job.returnvalue });
+    });
+
+    worker.on('failed', (job, error) => {
+      logger.error('Facebook token refresh job failed', { jobId: job?.id, error: error.message });
+    });
+  }
+
+  await queue.add(
+    JOB_NAME,
+    {},
+    {
+      repeat: { pattern: REFRESH_CRON },
+      jobId: REPEAT_JOB_ID,
+      removeOnComplete: 10,
+      removeOnFail: 50,
+    },
+  );
+
+  logger.info('Facebook token refresh job started', { cron: REFRESH_CRON });
+};
+
+export const stopFacebookTokenRefreshJob = async (): Promise<void> => {
+  if (worker) {
+    await worker.close();
+    worker = null;
+  }
+  if (queue) {
+    await queue.close();
+    queue = null;
+  }
+  logger.info('Facebook token refresh job stopped');
+};

--- a/backend/src/jobs/tiktokVideoJob.ts
+++ b/backend/src/jobs/tiktokVideoJob.ts
@@ -121,7 +121,7 @@ async function handleVideoUpload(job: Job): Promise<void> {
     for (let i = 0; i < totalChunks; i++) {
       const buffer = Buffer.alloc(Math.min(chunkSize, fileSizeBytes - i * chunkSize));
       await fileHandle.read(buffer, 0, buffer.length, i * chunkSize);
-      await tiktokService.uploadChunk(uploadUrl, buffer, i, totalChunks, fileSizeBytes);
+      await tiktokService.uploadChunk(uploadUrl, buffer, i, totalChunks, fileSizeBytes, publishId);
 
       // Report progress
       await job.updateProgress(Math.round(((i + 1) / totalChunks) * 100));
@@ -129,6 +129,9 @@ async function handleVideoUpload(job: Job): Promise<void> {
   } finally {
     await fileHandle.close();
   }
+
+  // Clear progress tracking now that all chunks are confirmed
+  await tiktokService.clearUploadProgress(publishId);
 
   logger.info('All chunks uploaded, queuing status poll', { publishId });
 

--- a/backend/src/services/TikTokService.ts
+++ b/backend/src/services/TikTokService.ts
@@ -1,7 +1,18 @@
 import { circuitBreakerService } from './CircuitBreakerService';
 import { createLogger } from '../lib/logger';
+import Redis from 'ioredis';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('tiktok-service');
+
+const UPLOAD_PROGRESS_PREFIX = 'tiktok:upload:progress:';
+const UPLOAD_PROGRESS_TTL = 86400; // 24 hours
+
+let _redis: Redis | null = null;
+function getRedis(): Redis {
+  if (!_redis) _redis = new Redis(getRedisConnection());
+  return _redis;
+}
 
 // TikTok Content Posting API v2 endpoints
 const TIKTOK_AUTH_URL = 'https://www.tiktok.com/v2/auth/authorize/';
@@ -272,6 +283,10 @@ class TikTokService {
   /**
    * Upload a single chunk of a video file.
    * chunkIndex is 0-based.
+   *
+   * Progress is persisted in Redis keyed by uploadSessionId so that a failed
+   * upload can resume from the last confirmed byte offset rather than
+   * re-uploading already-confirmed chunks.
    */
   public async uploadChunk(
     uploadUrl: string,
@@ -279,7 +294,18 @@ class TikTokService {
     chunkIndex: number,
     totalChunks: number,
     totalFileSize: number,
+    uploadSessionId: string,
   ): Promise<void> {
+    const redis = getRedis();
+    const progressKey = `${UPLOAD_PROGRESS_PREFIX}${uploadSessionId}`;
+
+    // Check whether this chunk was already confirmed
+    const confirmedStr = await redis.hget(progressKey, String(chunkIndex));
+    if (confirmedStr === '1') {
+      logger.info('TikTok chunk already uploaded, skipping', { chunkIndex: chunkIndex + 1, totalChunks });
+      return;
+    }
+
     const startByte = chunkIndex * CHUNK_SIZE_BYTES;
     const endByte = Math.min(startByte + chunkData.length - 1, totalFileSize - 1);
 
@@ -300,7 +326,18 @@ class TikTokService {
       );
     }
 
+    // Mark chunk as confirmed and refresh TTL
+    await redis.hset(progressKey, String(chunkIndex), '1');
+    await redis.expire(progressKey, UPLOAD_PROGRESS_TTL);
+
     logger.info('TikTok chunk uploaded', { chunkIndex: chunkIndex + 1, totalChunks });
+  }
+
+  /**
+   * Clear upload progress tracking for a completed or abandoned session.
+   */
+  public async clearUploadProgress(uploadSessionId: string): Promise<void> {
+    await getRedis().del(`${UPLOAD_PROGRESS_PREFIX}${uploadSessionId}`);
   }
 
   /**

--- a/backend/src/services/TwitterService.ts
+++ b/backend/src/services/TwitterService.ts
@@ -1,8 +1,20 @@
+import crypto from 'crypto';
+import Redis from 'ioredis';
 import { circuitBreakerService } from './CircuitBreakerService';
 import { LockService } from '../utils/LockService';
 import { createLogger } from '../lib/logger';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('twitter-service');
+
+const PKCE_CHALLENGE_PREFIX = 'twitter:pkce:';
+const PKCE_TTL_SECONDS = 600; // 10 minutes
+
+let _redis: Redis | null = null;
+function getRedis(): Redis {
+  if (!_redis) _redis = new Redis(getRedisConnection());
+  return _redis;
+}
 
 /**
  * Twitter API Response Types
@@ -227,6 +239,72 @@ export class TwitterService {
    */
   public getCircuitStatus() {
     return circuitBreakerService.getStats('twitter');
+  }
+
+  // ─── PKCE helpers ──────────────────────────────────────────────────────────
+
+  /**
+   * Store a PKCE code_challenge keyed by state, to be verified on callback.
+   */
+  public async storePkceChallenge(state: string, codeChallenge: string): Promise<void> {
+    await getRedis().set(`${PKCE_CHALLENGE_PREFIX}${state}`, codeChallenge, 'EX', PKCE_TTL_SECONDS);
+  }
+
+  /**
+   * Exchange an authorisation code for tokens, verifying the PKCE code_verifier
+   * against the stored code_challenge for the given state.
+   *
+   * Throws if the verifier is missing, the challenge is not found, or they do not match.
+   */
+  public async exchangeCodeForTokens(
+    code: string,
+    state: string,
+    codeVerifier: string,
+    clientId: string,
+    redirectUri: string,
+  ): Promise<{ accessToken: string; refreshToken: string; expiresAt: number }> {
+    // Retrieve and immediately delete the stored challenge (one-time use)
+    const redis = getRedis();
+    const key = `${PKCE_CHALLENGE_PREFIX}${state}`;
+    const storedChallenge = await redis.getdel(key);
+
+    if (!storedChallenge) {
+      throw new Error('PKCE challenge not found or expired');
+    }
+
+    // Recompute S256 challenge from the supplied verifier
+    const expectedChallenge = crypto
+      .createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    if (expectedChallenge !== storedChallenge) {
+      throw new Error('PKCE verification failed: code_verifier does not match code_challenge');
+    }
+
+    const response = await fetch('https://api.twitter.com/2/oauth2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        code_verifier: codeVerifier,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(`Twitter token exchange failed: ${JSON.stringify(err)}`);
+    }
+
+    const data = (await response.json()) as any;
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    };
   }
 }
 

--- a/backend/src/services/YouTubeService.ts
+++ b/backend/src/services/YouTubeService.ts
@@ -6,6 +6,53 @@ export { isDegraded } from '../types/degraded';
 
 const logger = createLogger('youtube-service');
 
+export class YouTubeQuotaError extends Error {
+  public readonly retryAfter: Date;
+  constructor(retryAfter: Date) {
+    super(`YouTube API quota exceeded. Quota resets at ${retryAfter.toISOString()}.`);
+    this.name = 'YouTubeQuotaError';
+    this.retryAfter = retryAfter;
+  }
+}
+
+/**
+ * Parse a YouTube 403 quota-exceeded API error response and throw a
+ * YouTubeQuotaError with the reset time, or re-throw the original error.
+ */
+function handleYouTubeError(status: number, body: any): never {
+  if (status === 403) {
+    const errors: any[] = body?.error?.errors ?? [];
+    const isQuota = errors.some(
+      (e) => e.domain === 'youtube.quota' || e.reason === 'quotaExceeded' || e.reason === 'dailyLimitExceeded',
+    );
+    if (isQuota) {
+      // YouTube quota resets at midnight Pacific Time (UTC-7 / UTC-8).
+      // The API does not return an exact reset timestamp, so we compute the
+      // next midnight PT as the best available estimate.
+      const resetTime = nextMidnightPacific();
+      throw new YouTubeQuotaError(resetTime);
+    }
+  }
+  throw new Error(`YouTube API error: ${status} — ${JSON.stringify(body)}`);
+}
+
+function nextMidnightPacific(): Date {
+  // Pacific Standard Time is UTC-8; Pacific Daylight Time is UTC-7.
+  // We use a fixed -8 offset as a conservative estimate (quota always resets
+  // by midnight PST at the latest).
+  const nowUtc = Date.now();
+  const pacificOffsetMs = 8 * 60 * 60 * 1000; // UTC-8
+  const nowPacific = new Date(nowUtc - pacificOffsetMs);
+  const midnightPacific = new Date(
+    Date.UTC(
+      nowPacific.getUTCFullYear(),
+      nowPacific.getUTCMonth(),
+      nowPacific.getUTCDate() + 1, // next day
+    ) + pacificOffsetMs,
+  );
+  return midnightPacific;
+}
+
 export interface YouTubeVideoStats {
   videoId: string;
   title: string;
@@ -129,7 +176,10 @@ class YouTubeService {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
 
-        if (!response.ok) throw new Error(`YouTube API error: ${response.status}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          handleYouTubeError(response.status, body);
+        }
 
         const data = (await response.json()) as any;
         const ch = data.items?.[0];
@@ -168,7 +218,10 @@ class YouTubeService {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
 
-        if (!response.ok) throw new Error(`YouTube API error: ${response.status}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          handleYouTubeError(response.status, body);
+        }
 
         const data = (await response.json()) as any;
         return (data.items ?? []).map((item: any) => ({
@@ -207,7 +260,10 @@ class YouTubeService {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
 
-        if (!response.ok) throw new Error(`YouTube API error: ${response.status}`);
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          handleYouTubeError(response.status, body);
+        }
 
         const data = (await response.json()) as any;
         return (data.items ?? []).map((item: any) => item.id.videoId as string);


### PR DESCRIPTION
#617 - Validate PKCE code_verifier on Twitter OAuth callback
- Add storePkceChallenge() to persist S256 challenge in Redis (10 min TTL)
- Add exchangeCodeForTokens() that verifies verifier via GETDEL (one-time use)
- Throws on missing/expired challenge or verifier mismatch

#619 - Resume TikTok chunk upload from last confirmed offset on failure
- uploadChunk() now accepts uploadSessionId and checks Redis before each PUT
- Confirmed chunks are marked in Redis hash (24h TTL); skipped on retry
- Add clearUploadProgress() called by job handler after all chunks succeed

#620 - Surface YouTube quota exhaustion with reset time to the user
- Add YouTubeQuotaError with retryAfter: Date (next midnight Pacific)
- handleYouTubeError() detects quotaExceeded/dailyLimitExceeded on 403
- Applied to getChannel, getVideoStats, listChannelVideos

#618 - Schedule Facebook long-lived token refresh before expiry
- New BullMQ job (facebookTokenRefreshJob.ts) runs daily at 03:00 UTC
- Scans facebook:token:* Redis keys, refreshes tokens expiring within 10 days
- Per-token failures are counted and logged without aborting the batch

Tests: 19 new tests across 4 files, all passing

Closes #617 
Closes #618 
Closes #619 
Closes #620 