### PR TITLE
fix: harden AuthBlacklistService and SocketService org room auth

### DIFF
--- a/backend/src/services/AuthBlacklistService.ts
+++ b/backend/src/services/AuthBlacklistService.ts
@@ -1,5 +1,8 @@
 import Redis from 'ioredis';
 import { redis } from '../lib/redis';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('AuthBlacklistService');
 
 const BLACKLIST_PREFIX = 'jwt:blacklist:';
 
@@ -29,15 +32,25 @@ export const AuthBlacklistService = {
    */
   blacklistToken: async (tokenKey: string, ttlSeconds: number): Promise<void> => {
     if (ttlSeconds <= 0) return; // already expired, nothing to store
-    await getRedis().set(`${BLACKLIST_PREFIX}${tokenKey}`, '1', 'EX', ttlSeconds);
+    try {
+      await getRedis().set(`${BLACKLIST_PREFIX}${tokenKey}`, '1', 'EX', ttlSeconds);
+    } catch (err) {
+      logger.warn('Redis unavailable — token blacklist write skipped', { tokenKey, err });
+    }
   },
 
   /**
    * Returns true if the token has been blacklisted.
+   * Fails closed on Redis error: denies the request to prevent revoked tokens from passing.
    */
   isBlacklisted: async (tokenKey: string): Promise<boolean> => {
-    const result = await getRedis().get(`${BLACKLIST_PREFIX}${tokenKey}`);
-    return result !== null;
+    try {
+      const result = await getRedis().get(`${BLACKLIST_PREFIX}${tokenKey}`);
+      return result !== null;
+    } catch (err) {
+      logger.error('Redis unavailable for blacklist check — failing closed', { tokenKey, err });
+      return true; // deny on error (fail-closed)
+    }
   },
 
   /**

--- a/backend/src/services/SocketService.ts
+++ b/backend/src/services/SocketService.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../lib/logger';
 import { config } from '../config/config';
 import { getRedisConnection } from '../config/runtime';
 import { eventBus, JobProgressEvent } from '../lib/eventBus';
+import { prisma } from '../lib/prisma';
 
 const logger = createLogger('SocketService');
 
@@ -73,7 +74,7 @@ export class SocketService {
       }
     });
 
-    this.io.on('connection', (socket: AuthenticatedSocket) => {
+    this.io.on('connection', async (socket: AuthenticatedSocket) => {
       logger.info(`Authorized connection from ${socket.id}`);
 
       // Join user-specific room for job progress
@@ -86,10 +87,17 @@ export class SocketService {
 
       // Auto-join specific namespace or org-based rooms based on client query
       const orgId = socket.handshake.query.orgId as string;
-      if (orgId) {
-        const roomName = `org:${orgId}`;
-        socket.join(roomName);
-        logger.info(`Client ${socket.id} joined room ${roomName}`);
+      if (orgId && userId) {
+        const member = await prisma.organizationMember.findFirst({
+          where: { organizationId: orgId, userId },
+        });
+        if (member) {
+          socket.join(`org:${orgId}`);
+          logger.info(`Client ${socket.id} joined room org:${orgId}`);
+        } else {
+          socket.emit('error', { message: 'Not a member of this organisation' });
+          logger.warn(`Client ${socket.id} denied access to org:${orgId} — not a member`);
+        }
       }
 
       // Handle message events dynamically


### PR DESCRIPTION
- AuthBlacklistService: wrap Redis calls in try/catch; blacklistToken logs a warning and completes on write failure; isBlacklisted fails closed (returns true) on read failure to prevent revoked tokens passing through a Redis outage (issue #796)
- SocketService: verify org membership via prisma before joining org room; unauthenticated joiners receive an error event (issue #797)

Closes #796 
Closes #797 