### PR TITLE
fix: resolve #791 #792 #793 #794 — auth persistence, SQL injection, CORS, video jobs

### DIFF
--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -253,8 +253,8 @@ describe('UserStore', () => {
     expect(UserStore.findByEmail('store@example.com')).toEqual(user);
   });
 
-  it('updates a user', () => {
-    UserStore.create({
+  it('updates a user', async () => {
+    await UserStore.create({
       id: 'upd-id',
       email: 'upd@example.com',
       passwordHash: 'hash',
@@ -262,12 +262,12 @@ describe('UserStore', () => {
       refreshTokens: [],
     });
 
-    const updated = UserStore.update('upd-id', { refreshTokens: ['tok'] });
+    const updated = await UserStore.update('upd-id', { refreshTokens: ['tok'] });
     expect(updated?.refreshTokens).toContain('tok');
   });
 
-  it('returns undefined for unknown id', () => {
-    expect(UserStore.findById('ghost')).toBeUndefined();
+  it('returns undefined for unknown id', async () => {
+    expect(await UserStore.findById('ghost')).toBeNull();
   });
 });
 

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -33,13 +33,13 @@ function signRefresh(userId: string): string {
 export async function register(req: Request, res: Response): Promise<void> {
   const { email, password } = req.body as { email: string; password: string };
 
-  if (UserStore.findByEmail(email)) {
+  if (await UserStore.findByEmail(email)) {
     res.status(409).json({ message: 'Email already registered' });
     return;
   }
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-  const user = UserStore.create({
+  const user = await UserStore.create({
     id: randomUUID(),
     email,
     passwordHash,
@@ -49,7 +49,7 @@ export async function register(req: Request, res: Response): Promise<void> {
 
   const accessToken = signAccess(user.id);
   const refreshToken = signRefresh(user.id);
-  UserStore.update(user.id, { refreshTokens: [refreshToken] });
+  await UserStore.update(user.id, { refreshTokens: [refreshToken] });
 
   auditLogger.log({
     actorId: user.id,
@@ -63,7 +63,7 @@ export async function register(req: Request, res: Response): Promise<void> {
 export async function login(req: Request, res: Response): Promise<void> {
   const { email, password } = req.body as { email: string; password: string };
 
-  const user = UserStore.findByEmail(email);
+  const user = await UserStore.findByEmail(email);
   if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
     res.status(401).json({ message: 'Invalid credentials' });
     return;
@@ -74,7 +74,7 @@ export async function login(req: Request, res: Response): Promise<void> {
 
   const accessToken = signAccess(user.id);
   const refreshToken = signRefresh(user.id);
-  UserStore.update(user.id, { refreshTokens: [...user.refreshTokens, refreshToken] });
+  await UserStore.update(user.id, { refreshTokens: [...user.refreshTokens, refreshToken] });
 
   auditLogger.log({
     actorId: user.id,
@@ -96,7 +96,7 @@ export async function refresh(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const user = UserStore.findById(payload.sub as string);
+  const user = await UserStore.findById(payload.sub as string);
   if (!user || !user.refreshTokens.includes(refreshToken)) {
     res.status(401).json({ message: 'Refresh token revoked' });
     return;
@@ -109,7 +109,7 @@ export async function refresh(req: Request, res: Response): Promise<void> {
 
   // Rotate refresh token
   const newRefresh = signRefresh(user.id);
-  UserStore.update(user.id, {
+  await UserStore.update(user.id, {
     refreshTokens: [...user.refreshTokens.filter((t) => t !== refreshToken), newRefresh],
   });
 
@@ -127,9 +127,9 @@ export async function logout(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const user = UserStore.findById(payload.sub as string);
+  const user = await UserStore.findById(payload.sub as string);
   if (user) {
-    UserStore.update(user.id, {
+    await UserStore.update(user.id, {
       refreshTokens: user.refreshTokens.filter((t) => t !== refreshToken),
     });
     auditLogger.log({

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -1,3 +1,5 @@
+import { prisma } from '../lib/prisma';
+
 export interface User {
   id: string;
   email: string;
@@ -6,28 +8,28 @@ export interface User {
   refreshTokens: string[];
 }
 
-// In-memory store (replace with a real DB in production)
-const users = new Map<string, User>();
-
 export const UserStore = {
-  findByEmail: (email: string): User | undefined =>
-    [...users.values()].find((u) => u.email === email),
+  findByEmail: (email: string): Promise<User | null> =>
+    prisma.user.findUnique({ where: { email } }),
 
-  findById: (id: string): User | undefined => users.get(id),
+  findById: (id: string): Promise<User | null> =>
+    prisma.user.findUnique({ where: { id } }),
 
-  create: (user: User): User => {
-    users.set(user.id, user);
-    return user;
-  },
+  create: (user: User): Promise<User> =>
+    prisma.user.create({
+      data: {
+        id: user.id,
+        email: user.email,
+        passwordHash: user.passwordHash,
+        createdAt: user.createdAt,
+        refreshTokens: user.refreshTokens,
+      },
+    }),
 
-  update: (id: string, patch: Partial<User>): User | undefined => {
-    const user = users.get(id);
-    if (!user) return undefined;
-    const updated = { ...user, ...patch };
-    users.set(id, updated);
-    return updated;
-  },
+  update: (id: string, patch: Partial<User>): Promise<User | null> =>
+    prisma.user.update({ where: { id }, data: patch }).catch(() => null),
 
-  /** Clear all users — intended for test teardown only. */
-  clear: (): void => users.clear(),
+  /** Delete all users — intended for test teardown only. */
+  clear: (): Promise<void> =>
+    prisma.user.deleteMany().then(() => undefined),
 };

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -39,7 +39,7 @@ const portalSchema = z.object({
  *         description: Stripe error
  */
 router.post('/provision', authMiddleware, async (req: AuthRequest, res: Response) => {
-  const user = UserStore.findById(req.userId!);
+  const user = await UserStore.findById(req.userId!);
   if (!user) return res.status(404).json({ message: 'User not found' });
 
   try {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import { queueManager, closeRedisClient } from './queues/queueManager';
 import { startDataPruningJob, stopDataPruningJob } from './jobs/dataPruningJob';
 import { startYouTubeSyncJob, stopYouTubeSyncJob } from './jobs/youtubeSyncJob';
 import { startTikTokVideoWorker } from './jobs/tiktokVideoJob';
+import { startVideoWorker } from './services/VideoService';
 import { startTwitterWebhookWorker } from './queues/twitterWebhookQueue';
 import { startWorkerMonitor, stopWorkerMonitor } from './monitoring/workerMonitorInstance';
 import { startHealthMonitoringJob, stopHealthMonitoringJob } from './jobs/healthMonitoringJob';
@@ -289,6 +290,16 @@ export const bootstrap = async (exit?: (code: number) => void): Promise<void> =>
       logger.info('TikTok video worker started');
     } catch (error) {
       logger.error('Failed to start TikTok video worker', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // Start video transcoding worker
+    try {
+      startVideoWorker();
+      logger.info('Video transcoding worker started');
+    } catch (error) {
+      logger.error('Failed to start video transcoding worker', {
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/backend/src/services/CohortService.ts
+++ b/backend/src/services/CohortService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { sqltag, empty } from '@prisma/client/runtime/library';
 import { createLogger } from '../lib/logger';
 
 const prisma = new PrismaClient();
@@ -124,10 +125,6 @@ export class CohortService {
     organizationId?: string,
     userId?: string,
   ): Promise<UserActivityStats[]> {
-    // Build optional WHERE clauses
-    const orgFilter = organizationId ? `AND om.organization_id = '${organizationId}'` : '';
-    const userFilter = userId ? `AND u.id = '${userId}'` : '';
-
     type RawRow = {
       user_id: string;
       email: string;
@@ -139,7 +136,7 @@ export class CohortService {
       days_since_last_post: number | null;
     };
 
-    const rows = await prisma.$queryRawUnsafe<RawRow[]>(`
+    const rows = (await prisma.$queryRaw(sqltag`
       SELECT
         u.id                                                        AS user_id,
         u.email,
@@ -150,11 +147,13 @@ export class CohortService {
         EXTRACT(EPOCH FROM (NOW() - u."createdAt")) / 86400         AS days_since_joined,
         EXTRACT(EPOCH FROM (NOW() - MAX(p."createdAt"))) / 86400    AS days_since_last_post
       FROM "User" u
-      LEFT JOIN "OrganizationMember" om ON om."userId" = u.id ${orgFilter}
+      LEFT JOIN "OrganizationMember" om ON om."userId" = u.id
+        ${organizationId ? sqltag`AND om.organization_id = ${organizationId}` : empty}
       LEFT JOIN "Post" p ON p."organizationId" = om."organizationId"
-      WHERE u."deletedAt" IS NULL ${userFilter}
+      WHERE u."deletedAt" IS NULL
+        ${userId ? sqltag`AND u.id = ${userId}` : empty}
       GROUP BY u.id, u.email, u.role, u."createdAt"
-    `);
+    `)) as RawRow[];
 
     return rows.map((r: RawRow) => ({
       userId: r.user_id,

--- a/backend/src/services/SocketService.ts
+++ b/backend/src/services/SocketService.ts
@@ -5,6 +5,7 @@ import Redis from 'ioredis';
 import jwt from 'jsonwebtoken';
 import { createLogger } from '../lib/logger';
 import { config } from '../config/config';
+import { corsOptions } from '../config/cors';
 import { getRedisConnection } from '../config/runtime';
 import { eventBus, JobProgressEvent } from '../lib/eventBus';
 
@@ -38,7 +39,7 @@ export class SocketService {
   public initialize(httpServer: HttpServer): void {
     this.io = new Server(httpServer, {
       cors: {
-        origin: '*', // To be restricted in production
+        origin: config.NODE_ENV === 'production' ? corsOptions.origin : '*',
         methods: ['GET', 'POST'],
       },
     });

--- a/backend/src/services/VideoService.ts
+++ b/backend/src/services/VideoService.ts
@@ -1,6 +1,7 @@
 import ffmpeg from 'fluent-ffmpeg';
 import path from 'path';
 import fs from 'fs/promises';
+import { Queue, Worker, Job } from 'bullmq';
 import {
   TranscodingJob,
   VideoQuality,
@@ -11,29 +12,161 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { createLogger } from '../lib/logger';
 import { eventBus } from '../lib/eventBus';
+import { getRedisConnection } from '../config/runtime';
 
 const logger = createLogger('VideoService');
 
+const QUEUE_NAME = 'video-transcoding';
+
+interface VideoJobPayload {
+  jobId: string;
+  inputPath: string;
+  outputDir: string;
+  qualities: VideoQuality[];
+  formats: VideoFormat[];
+  userId?: string;
+}
+
+// Default quality presets
+const DEFAULT_QUALITIES: VideoQuality[] = [
+  { name: '1080p', width: 1920, height: 1080, bitrate: '5000k' },
+  { name: '720p', width: 1280, height: 720, bitrate: '2500k' },
+  { name: '480p', width: 854, height: 480, bitrate: '1000k' },
+  { name: '360p', width: 640, height: 360, bitrate: '500k' },
+];
+
+const DEFAULT_FORMATS: VideoFormat[] = [
+  { extension: 'mp4', codec: 'libx264', audioCodec: 'aac' },
+  { extension: 'webm', codec: 'libvpx-vp9', audioCodec: 'libopus' },
+];
+
+let _queue: Queue | null = null;
+let _worker: Worker | null = null;
+
+function getQueue(): Queue {
+  if (!_queue) {
+    _queue = new Queue(QUEUE_NAME, {
+      connection: getRedisConnection(),
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+        removeOnComplete: { age: 86400 },
+        removeOnFail: { age: 604800 },
+      },
+    });
+  }
+  return _queue;
+}
+
+async function transcodeVideo(
+  job: TranscodingJob,
+  quality: VideoQuality,
+  format: VideoFormat,
+): Promise<TranscodedOutput> {
+  const outputFilename = `video_${quality.name}.${format.extension}`;
+  const outputPath = path.join(job.outputDir, outputFilename);
+
+  return new Promise((resolve, reject) => {
+    ffmpeg(job.inputPath)
+      .videoCodec(format.codec)
+      .audioCodec(format.audioCodec)
+      .size(`${quality.width}x${quality.height}`)
+      .videoBitrate(quality.bitrate)
+      .audioBitrate('128k')
+      .audioChannels(2)
+      .audioFrequency(44100)
+      .format(format.extension)
+      .on('start', (commandLine: string) => {
+        logger.info(`Starting transcoding: ${outputFilename}`, { commandLine });
+      })
+      .on('progress', (progress: { percent?: number }) => {
+        if (progress.percent) {
+          logger.info(`Processing ${outputFilename}: ${Math.round(progress.percent)}%`);
+        }
+      })
+      .on('end', async () => {
+        logger.info(`Completed: ${outputFilename}`);
+        const stats = await fs.stat(outputPath);
+        resolve({ quality: quality.name, format: format.extension, path: outputPath, size: stats.size });
+      })
+      .on('error', (err: Error) => {
+        fs.rm(outputPath, { force: true }).catch(() => {});
+        reject(err);
+      })
+      .save(outputPath);
+  });
+}
+
+async function processVideoJob(bullJob: Job<VideoJobPayload>): Promise<void> {
+  const { jobId, inputPath, outputDir, qualities, formats, userId } = bullJob.data;
+
+  const job: TranscodingJob = {
+    id: jobId,
+    inputPath,
+    outputDir,
+    status: 'processing',
+    progress: 0,
+    qualities,
+    formats,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    outputs: [],
+  };
+
+  if (userId) {
+    eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'processing', progress: 0, message: 'Job processing' });
+  }
+
+  const totalTasks = qualities.length * formats.length;
+  let completedTasks = 0;
+  const outputs: TranscodedOutput[] = [];
+
+  for (const quality of qualities) {
+    for (const format of formats) {
+      const outputPath = path.join(outputDir, `video_${quality.name}.${format.extension}`);
+      try {
+        const output = await transcodeVideo(job, quality, format);
+        outputs.push(output);
+        completedTasks++;
+        const progress = Math.round((completedTasks / totalTasks) * 100);
+        await bullJob.updateProgress(progress);
+        if (userId) {
+          eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'processing', progress, message: `Transcoding ${progress}%` });
+        }
+      } catch (error) {
+        await fs.rm(outputPath, { force: true }).catch(() => {});
+        logger.error(`Failed to transcode ${quality.name} ${format.extension}:`, { error });
+      }
+    }
+  }
+
+  if (outputs.length === 0) {
+    throw new Error('All transcoding attempts failed');
+  }
+
+  if (userId) {
+    eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'completed', progress: 100, message: 'Job completed' });
+  }
+}
+
+export function startVideoWorker(): void {
+  if (_worker) return;
+
+  _worker = new Worker(QUEUE_NAME, processVideoJob, { connection: getRedisConnection(), concurrency: 1 });
+
+  _worker.on('completed', (job) => logger.info(`Video job completed`, { jobId: job.id }));
+  _worker.on('failed', (job, err) => {
+    logger.error(`Video job failed`, { jobId: job?.id, error: err.message });
+    const { jobId, userId } = (job?.data ?? {}) as Partial<VideoJobPayload>;
+    if (jobId && userId) {
+      eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'failed', progress: 0, message: 'Job failed', error: err.message });
+    }
+  });
+
+  logger.info('Video transcoding worker started');
+}
+
 class VideoService {
-  private jobs: Map<string, TranscodingJob> = new Map();
-
-  // Default quality presets
-  private readonly DEFAULT_QUALITIES: VideoQuality[] = [
-    { name: '1080p', width: 1920, height: 1080, bitrate: '5000k' },
-    { name: '720p', width: 1280, height: 720, bitrate: '2500k' },
-    { name: '480p', width: 854, height: 480, bitrate: '1000k' },
-    { name: '360p', width: 640, height: 360, bitrate: '500k' },
-  ];
-
-  // Default format presets
-  private readonly DEFAULT_FORMATS: VideoFormat[] = [
-    { extension: 'mp4', codec: 'libx264', audioCodec: 'aac' },
-    { extension: 'webm', codec: 'libvpx-vp9', audioCodec: 'libopus' },
-  ];
-
-  /**
-   * Create a new transcoding job
-   */
   public async createTranscodingJob(
     inputPath: string,
     options: TranscodingOptions = {},
@@ -41,220 +174,71 @@ class VideoService {
   ): Promise<string> {
     const jobId = uuidv4();
     const outputDir = options.outputDir || path.join(path.dirname(inputPath), 'transcoded', jobId);
-
-    // Ensure output directory exists
     await fs.mkdir(outputDir, { recursive: true });
 
-    const job: TranscodingJob = {
-      id: jobId,
+    const payload: VideoJobPayload = {
+      jobId,
       inputPath,
       outputDir,
-      status: 'pending',
-      progress: 0,
-      qualities: options.qualities || this.DEFAULT_QUALITIES,
-      formats: options.formats || this.DEFAULT_FORMATS,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      outputs: [],
+      qualities: options.qualities || DEFAULT_QUALITIES,
+      formats: options.formats || DEFAULT_FORMATS,
+      userId,
     };
 
-    this.jobs.set(jobId, job);
-
-    // Start processing in background
-    this.processJob(jobId, userId).catch((error) => {
-      console.error(`Job ${jobId} failed:`, error);
-      this.updateJobStatus(jobId, 'failed', error.message, userId);
-    });
-
+    await getQueue().add('transcode', payload, { jobId });
+    logger.info(`Video transcoding job enqueued`, { jobId });
     return jobId;
   }
 
-  /**
-   * Get job status
-   */
-  public getJob(jobId: string): TranscodingJob | undefined {
-    return this.jobs.get(jobId);
+  public async getJob(jobId: string): Promise<TranscodingJob | undefined> {
+    const bullJob = await getQueue().getJob(jobId);
+    if (!bullJob) return undefined;
+    return this.bullJobToTranscodingJob(bullJob);
   }
 
-  /**
-   * Get all jobs
-   */
-  public getAllJobs(): TranscodingJob[] {
-    return Array.from(this.jobs.values());
+  public async getAllJobs(): Promise<TranscodingJob[]> {
+    const queue = getQueue();
+    const [waiting, active, completed, failed] = await Promise.all([
+      queue.getWaiting(),
+      queue.getActive(),
+      queue.getCompleted(),
+      queue.getFailed(),
+    ]);
+    return [...waiting, ...active, ...completed, ...failed].map((j) =>
+      this.bullJobToTranscodingJob(j),
+    );
   }
 
-  /**
-   * Process a transcoding job
-   */
-  private async processJob(jobId: string, userId?: string): Promise<void> {
-    const job = this.jobs.get(jobId);
-    if (!job) throw new Error(`Job ${jobId} not found`);
-
-    this.updateJobStatus(jobId, 'processing', undefined, userId);
-
-    const totalTasks = job.qualities.length * job.formats.length;
-    let completedTasks = 0;
-    const outputs: TranscodedOutput[] = [];
-
-    for (const quality of job.qualities) {
-      for (const format of job.formats) {
-        const outputPath = path.join(job.outputDir, `video_${quality.name}.${format.extension}`);
-        try {
-          const output = await this.transcodeVideo(job, quality, format);
-          outputs.push(output);
-          completedTasks++;
-          const progress = Math.round((completedTasks / totalTasks) * 100);
-          this.updateJobProgress(jobId, progress, userId);
-        } catch (error) {
-          await fs.rm(outputPath, { force: true }).catch(() => {});
-          console.error(`Failed to transcode ${quality.name} ${format.extension}:`, error);
-        }
-      }
-    }
-
-    job.outputs = outputs;
-    job.updatedAt = new Date();
-
-    if (outputs.length === 0) {
-      this.updateJobStatus(jobId, 'failed', 'All transcoding attempts failed', userId);
-    } else {
-      this.updateJobStatus(jobId, 'completed', undefined, userId);
-    }
-  }
-
-  /**
-   * Transcode video to specific quality and format
-   */
-  private async transcodeVideo(
-    job: TranscodingJob,
-    quality: VideoQuality,
-    format: VideoFormat,
-  ): Promise<TranscodedOutput> {
-    const outputFilename = `video_${quality.name}.${format.extension}`;
-    const outputPath = path.join(job.outputDir, outputFilename);
-
-    return new Promise((resolve, reject) => {
-      ffmpeg(job.inputPath)
-        .videoCodec(format.codec)
-        .audioCodec(format.audioCodec)
-        .size(`${quality.width}x${quality.height}`)
-        .videoBitrate(quality.bitrate)
-        .audioBitrate('128k')
-        .audioChannels(2)
-        .audioFrequency(44100)
-        .format(format.extension)
-        .on('start', (commandLine: string) => {
-          logger.info(`Starting transcoding: ${outputFilename}`, { commandLine });
-        })
-        .on('progress', (progress: { percent?: number }) => {
-          if (progress.percent) {
-            logger.info(`Processing ${outputFilename}: ${Math.round(progress.percent)}%`);
-          }
-        })
-        .on('end', async () => {
-          logger.info(`Completed: ${outputFilename}`);
-
-          // Get file size
-          const stats = await fs.stat(outputPath);
-
-          resolve({
-            quality: quality.name,
-            format: format.extension,
-            path: outputPath,
-            size: stats.size,
-          });
-        })
-        .on('error', (err: Error) => {
-          console.error(`Error transcoding ${outputFilename}:`, err);
-          fs.rm(outputPath, { force: true }).catch(() => {});
-          reject(err);
-        })
-        .save(outputPath);
-    });
-  }
-
-  /**
-   * Update job status
-   */
-  private updateJobStatus(
-    jobId: string,
-    status: TranscodingJob['status'],
-    error?: string,
-    userId?: string,
-  ): void {
-    const job = this.jobs.get(jobId);
-    if (job) {
-      job.status = status;
-      job.updatedAt = new Date();
-      if (error) job.error = error;
-      if (userId) {
-        eventBus.emitJobProgress({
-          jobId,
-          userId,
-          type: 'video_transcoding',
-          status,
-          progress: status === 'completed' ? 100 : job.progress,
-          message: status === 'failed' ? error : `Job ${status}`,
-          error,
-        });
-      }
-    }
-  }
-
-  /**
-   * Update job progress
-   */
-  private updateJobProgress(jobId: string, progress: number, userId?: string): void {
-    const job = this.jobs.get(jobId);
-    if (job) {
-      job.progress = progress;
-      job.updatedAt = new Date();
-      if (userId) {
-        eventBus.emitJobProgress({
-          jobId,
-          userId,
-          type: 'video_transcoding',
-          status: 'processing',
-          progress,
-          message: `Transcoding ${progress}%`,
-        });
-      }
-    }
-  }
-
-  /**
-   * Cancel a job
-   */
   public async cancelJob(jobId: string): Promise<boolean> {
-    const job = this.jobs.get(jobId);
-    if (!job) {
-      return false;
-    }
-
-    if (job.status === 'processing') {
-      // In a real implementation, you'd need to track and kill the FFmpeg process
-      this.updateJobStatus(jobId, 'failed', 'Job cancelled by user');
-    }
-
+    const bullJob = await getQueue().getJob(jobId);
+    if (!bullJob) return false;
+    await bullJob.remove();
     return true;
   }
 
-  /**
-   * Clean up old jobs
-   */
-  public async cleanupOldJobs(maxAgeMs: number = 24 * 60 * 60 * 1000): Promise<number> {
-    const now = Date.now();
-    let cleaned = 0;
+  private bullJobToTranscodingJob(bullJob: Job<VideoJobPayload>): TranscodingJob {
+    const { jobId, inputPath, outputDir, qualities, formats } = bullJob.data;
+    const state = bullJob.finishedOn
+      ? bullJob.failedReason
+        ? 'failed'
+        : 'completed'
+      : bullJob.processedOn
+        ? 'processing'
+        : 'pending';
 
-    for (const [jobId, job] of this.jobs.entries()) {
-      const age = now - job.createdAt.getTime();
-      if (age > maxAgeMs && (job.status === 'completed' || job.status === 'failed')) {
-        this.jobs.delete(jobId);
-        cleaned++;
-      }
-    }
-
-    return cleaned;
+    return {
+      id: jobId,
+      inputPath,
+      outputDir,
+      status: state as TranscodingJob['status'],
+      progress: typeof bullJob.progress === 'number' ? bullJob.progress : 0,
+      qualities,
+      formats,
+      createdAt: new Date(bullJob.timestamp),
+      updatedAt: new Date(bullJob.finishedOn ?? bullJob.processedOn ?? bullJob.timestamp),
+      error: bullJob.failedReason,
+      outputs: [],
+    };
   }
 }
 

--- a/backend/src/services/__tests__/VideoService.test.ts
+++ b/backend/src/services/__tests__/VideoService.test.ts
@@ -10,7 +10,7 @@ describe('VideoService', () => {
       expect(jobId).toBeDefined();
       expect(typeof jobId).toBe('string');
 
-      const job = videoService.getJob(jobId);
+      const job = await videoService.getJob(jobId);
       expect(job).toBeDefined();
       expect(job?.inputPath).toBe(mockInputPath);
       expect(job?.status).toBe('pending');
@@ -25,7 +25,7 @@ describe('VideoService', () => {
       };
 
       const jobId = await videoService.createTranscodingJob(mockInputPath, options);
-      const job = videoService.getJob(jobId);
+      const job = await videoService.getJob(jobId);
 
       expect(job?.qualities).toHaveLength(1);
       expect(job?.qualities[0].name).toBe('720p');
@@ -35,8 +35,8 @@ describe('VideoService', () => {
   });
 
   describe('getJob', () => {
-    it('should return undefined for non-existent job', () => {
-      const job = videoService.getJob('non-existent-id');
+    it('should return undefined for non-existent job', async () => {
+      const job = await videoService.getJob('non-existent-id');
       expect(job).toBeUndefined();
     });
   });
@@ -46,7 +46,7 @@ describe('VideoService', () => {
       const jobId1 = await videoService.createTranscodingJob('/path/to/video1.mp4');
       const jobId2 = await videoService.createTranscodingJob('/path/to/video2.mp4');
 
-      const allJobs = videoService.getAllJobs();
+      const allJobs = await videoService.getAllJobs();
       expect(allJobs.length).toBeGreaterThanOrEqual(2);
 
       const jobIds = allJobs.map((job) => job.id);


### PR DESCRIPTION
## Summary

Fixes four critical/high severity issues in a single PR.

### #791 — UserStore in-memory → Prisma
- `UserStore` methods now delegate to `prisma.user` instead of a process-local `Map`
- `register`, `login`, `refresh`, `logout` in `auth.ts` updated to `await` async calls
- `billing.ts` `/provision` route updated to `await findById`
- `clear()` retained for test teardown via `prisma.user.deleteMany()`

### #792 — SQL injection in CohortService
- Replaced `$queryRawUnsafe` with `$queryRaw` + `sqltag`/`empty` from `@prisma/client/runtime/library`
- `organizationId` and `userId` are now safely parameterised — no string interpolation

### #793 — SocketService CORS wildcard
- In `production`, Socket.IO `cors.origin` now uses `corsOptions.origin` from the existing HTTP CORS config (`cors.ts`)
- Non-production environments retain `'*'` for developer convenience

### #794 — VideoService in-memory jobs → BullMQ
- Replaced the private `jobs: Map` with a BullMQ `Queue` (`video-transcoding`) backed by Redis
- `createTranscodingJob` enqueues to Redis; `getJob`/`getAllJobs`/`cancelJob` query the queue
- Added `startVideoWorker()` — a BullMQ `Worker` that runs the ffmpeg transcoding
- `startVideoWorker()` wired into `server.ts` startup

## Testing
- TypeScript compiles cleanly across all changed files (`tsc --noEmit`)
- Updated `VideoService.test.ts` and `auth.test.ts` to `await` the now-async methods

Closes #791, closes #792, closes #793, closes #794