### PR TITLE
fix: resolve security and bug issues #799, #798, #795

### DIFF
--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -132,6 +132,12 @@ const envSchema = z.object({
   MEILISEARCH_ADMIN_KEY: z.string().optional(),
   MEILISEARCH_SEARCH_KEY: z.string().optional(),
 
+  // ── Moderation ────────────────────────────────────────────────────────────
+  // fail-closed (default): block content when provider is unavailable — safer for production.
+  // fail-open: allow content through when provider is unavailable — requires explicit opt-in.
+  MODERATION_MODE: z.enum(['fail-open', 'fail-closed']).default('fail-closed'),
+  MODERATION_SENSITIVITY: z.enum(['low', 'medium', 'high']).default('medium'),
+
   // ── AWS S3 ────────────────────────────────────────────────────────────────
   S3_PRESIGNED_URL_EXPIRY_SECONDS: z.coerce.number().int().positive().default(3600),
 });

--- a/backend/src/services/BillingService.ts
+++ b/backend/src/services/BillingService.ts
@@ -245,8 +245,8 @@ export class BillingService {
       plan,
       status: stripeSub.status as Subscription['status'],
       stripeSubscriptionId: stripeSub.id,
-      currentPeriodEnd: stripeSub.billing_cycle_anchor
-        ? new Date(stripeSub.billing_cycle_anchor * 1000)
+      currentPeriodEnd: stripeSub.items.data[0]?.current_period_end
+        ? new Date(stripeSub.items.data[0].current_period_end * 1000)
         : null,
     });
   }

--- a/backend/src/services/ModerationService.ts
+++ b/backend/src/services/ModerationService.ts
@@ -63,13 +63,16 @@ function getSensitivity(tenantId?: string): SensitivityLevel {
  * MODERATION_MODE controls behaviour when the provider is unavailable
  * (missing API key, timeout, or malformed response):
  *
- *   fail-open   (default) — bypass moderation and allow the content through.
- *                           Logs a warning. Use when availability > safety.
- *   fail-closed           — block the content and throw.
+ *   fail-closed (default) — block the content and throw.
  *                           Use when safety > availability.
+ *   fail-open             — bypass moderation and allow the content through.
+ *                           Logs a warning. Use when availability > safety.
+ *                           Requires explicit opt-in: MODERATION_MODE=fail-open
  */
 function getMode(): 'fail-open' | 'fail-closed' {
-  return process.env.MODERATION_MODE === 'fail-closed' ? 'fail-closed' : 'fail-open';
+  if (process.env.MODERATION_MODE === 'fail-open') return 'fail-open';
+  // Default to fail-closed — safer for production
+  return 'fail-closed';
 }
 
 const BYPASS_RESULT: ModerationResult = { flagged: false, blocked: false, categories: {}, scores: {} };
@@ -119,17 +122,8 @@ export const ModerationService = {
    *
    * Behavior when the provider is unavailable depends on MODERATION_MODE:
    *
-   *   fail-open (default)
-   *   ─────────────────
-   *   - Content is allowed through
-   *   - Warning is logged
-   *   - Alert is emitted
-   *   - Use when: service availability > safety (e.g., user-facing features)
-   *   - Risk: unsafe content may slip through in misconfigured deployments
-   *   - Test: verify alerts are emitted for missing OPENAI_API_KEY
-   *
-   *   fail-closed
-   *   ──────────
+   *   fail-closed (default)
+   *   ─────────────────────
    *   - Content is blocked with an error
    *   - Error is logged and thrown
    *   - Critical alert is emitted
@@ -137,9 +131,19 @@ export const ModerationService = {
    *   - Risk: legitimate content blocked if service is down
    *   - Test: verify errors are thrown and requests rejected
    *
+   *   fail-open
+   *   ─────────
+   *   - Content is allowed through
+   *   - Warning is logged
+   *   - Alert is emitted
+   *   - Use when: service availability > safety (e.g., user-facing features)
+   *   - Risk: unsafe content may slip through in misconfigured deployments
+   *   - Test: verify alerts are emitted for missing OPENAI_API_KEY
+   *   - Requires explicit opt-in: MODERATION_MODE=fail-open
+   *
    * Configuration:
-   *   MODERATION_MODE=fail-open     (default, less strict)
-   *   MODERATION_MODE=fail-closed   (strict, safety-first)
+   *   MODERATION_MODE=fail-closed   (default, safety-first)
+   *   MODERATION_MODE=fail-open     (explicit opt-in, less strict)
    *   OPENAI_API_KEY=sk-xxx         (required, otherwise behavior above applies)
    *   MODERATION_SENSITIVITY=low|medium|high  (default: medium)
    */

--- a/backend/src/services/SearchService.ts
+++ b/backend/src/services/SearchService.ts
@@ -63,6 +63,16 @@ export async function searchPosts(
     offset?: number;
   } = {},
 ) {
+  const VALID_PLATFORMS = new Set(['twitter', 'instagram', 'facebook', 'linkedin', 'tiktok', 'youtube']);
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  if (opts.platform && !VALID_PLATFORMS.has(opts.platform)) {
+    throw new Error('Invalid platform value');
+  }
+  if (opts.organizationId && !UUID_RE.test(opts.organizationId)) {
+    throw new Error('Invalid organizationId');
+  }
+
   const filter: string[] = [];
   if (opts.organizationId) filter.push(`organizationId = "${opts.organizationId}"`);
   if (opts.platform) filter.push(`platform = "${opts.platform}"`);


### PR DESCRIPTION
- #799 ModerationService: change default from fail-open to fail-closed; require explicit MODERATION_MODE=fail-open opt-in; add MODERATION_MODE and MODERATION_SENSITIVITY to startup config validation in config.ts

- #798 BillingService.syncSubscription: replace billing_cycle_anchor with current_period_end (via items.data[0]) so currentPeriodEnd reflects the actual end of the current billing period (Stripe v20 API)

- #795 SearchService.searchPosts: validate organizationId as UUID and platform against an allowlist before interpolating into MeiliSearch filter strings, preventing filter injection / tenant data isolation bypass
closes #799 
closes #798 
closes #795 