### PR TITLE
fix(auth): invalidate refresh tokens on password change (#803)

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -193,6 +193,9 @@ export async function changePassword(req: Request, res: Response): Promise<void>
   const newPasswordHash = await PasswordHistoryService.hashPassword(newPassword);
   await PasswordHistoryService.recordPasswordChange(userId, newPasswordHash);
 
+  // Invalidate all existing refresh tokens
+  await UserStore.update(userId, { refreshTokens: [] });
+
   // Blacklist the current access token — forces re-login after password change
   const authHeader = req.headers.authorization;
   if (authHeader?.startsWith('Bearer ')) {


### PR DESCRIPTION
## Summary

closes #803 

When a user changed their password, existing refresh tokens were not cleared, allowing an attacker who had obtained a refresh token to continue generating new access tokens even after the victim changed their password.

## Change

In `changePassword` (backend/src/controllers/auth.ts), added a call to clear the user's `refreshTokens` array immediately after `recordPasswordChange` succeeds:

```ts
await UserStore.update(userId, { refreshTokens: [] });
```

## Testing

- Existing auth flow: log in → capture refresh token → change password → attempt refresh with old token → should now return 401.