### PR TITLE
fix: twitter lazy token, pgbouncer validation, health split, tiktok upload resume

### DIFF
--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -15,6 +15,12 @@ const envSchema = z.object({
   // Override here to hard-pin values regardless of NODE_ENV.
   DB_CONNECTION_LIMIT: z.coerce.number().int().positive().optional(),
   DB_POOL_TIMEOUT: z.coerce.number().int().positive().optional(),
+  // Set to 'true' when a PgBouncer proxy sits in front of Postgres.
+  // In transaction mode, PgBouncer requires connection_limit=1 per application process.
+  PGBOUNCER_MODE: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
 
   // ── JWT ───────────────────────────────────────────────────────────────────
   JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),

--- a/backend/src/jobs/tiktokVideoJob.ts
+++ b/backend/src/jobs/tiktokVideoJob.ts
@@ -99,7 +99,47 @@ export const startTikTokVideoWorker = (): void => {
 async function handleVideoUpload(job: Job): Promise<void> {
   const { accessToken, filePath, fileSizeBytes, request } = job.data as TikTokVideoJobPayload;
 
-  logger.info('Starting TikTok chunked video upload', { filePath, fileSizeBytes });
+  // Derive a stable session key from the file path so that retries of the
+  // same job can resume the same TikTok upload session.
+  const sessionKey = Buffer.from(filePath).toString('base64').slice(0, 64);
+
+  let publishId: string;
+  let uploadUrl: string;
+  let chunkSize: number;
+  let totalChunks: number;
+  let startChunk = 0;
+
+  // Check whether a previous attempt stored an upload session for this file.
+  const existingSession = await tiktokService.getUploadSession(sessionKey);
+
+  if (existingSession) {
+    ({ publishId, uploadUrl, chunkSize, totalChunks } = existingSession);
+    const lastChunk = await tiktokService.getLastUploadedChunk(publishId);
+    startChunk = lastChunk + 1;
+
+    logger.info('Resuming TikTok chunked upload from last successful chunk', {
+      filePath,
+      resumeChunk: startChunk + 1,
+      totalChunks,
+      publishId,
+    });
+  } else {
+    logger.info('Starting TikTok chunked video upload', { filePath, fileSizeBytes });
+
+    // Initiate a new upload session and persist it so retries can resume.
+    ({ publishId, uploadUrl, chunkSize, totalChunks } = await tiktokService.initiateVideoUpload(
+      accessToken,
+      fileSizeBytes,
+      request,
+    ));
+
+    await tiktokService.storeUploadSession(sessionKey, {
+      publishId,
+      uploadUrl,
+      chunkSize,
+      totalChunks,
+    });
+  }
 
   // Dispatch processing event
   await dispatchEvent('tiktok.video_processing', {
@@ -108,17 +148,10 @@ async function handleVideoUpload(job: Job): Promise<void> {
     status: 'uploading',
   });
 
-  // Initiate upload and get upload URL + publishId
-  const { publishId, uploadUrl, chunkSize, totalChunks } = await tiktokService.initiateVideoUpload(
-    accessToken,
-    fileSizeBytes,
-    request,
-  );
-
-  // Read and upload file in chunks
+  // Read and upload file in chunks, starting from the resume point.
   const fileHandle = await fs.promises.open(filePath, 'r');
   try {
-    for (let i = 0; i < totalChunks; i++) {
+    for (let i = startChunk; i < totalChunks; i++) {
       const buffer = Buffer.alloc(Math.min(chunkSize, fileSizeBytes - i * chunkSize));
       await fileHandle.read(buffer, 0, buffer.length, i * chunkSize);
       await tiktokService.uploadChunk(uploadUrl, buffer, i, totalChunks, fileSizeBytes, publishId);
@@ -130,8 +163,9 @@ async function handleVideoUpload(job: Job): Promise<void> {
     await fileHandle.close();
   }
 
-  // Clear progress tracking now that all chunks are confirmed
+  // Clear progress tracking and session now that all chunks are confirmed.
   await tiktokService.clearUploadProgress(publishId);
+  await tiktokService.clearUploadSession(sessionKey);
 
   logger.info('All chunks uploaded, queuing status poll', { publishId });
 

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -25,12 +25,31 @@ function buildDatasourceUrl(): string {
   const env = config.NODE_ENV;
   const defaults = POOL_DEFAULTS[env];
 
-  const connectionLimit = config.DB_CONNECTION_LIMIT ?? defaults.connection_limit;
-  const poolTimeout     = config.DB_POOL_TIMEOUT     ?? defaults.pool_timeout;
+  let connectionLimit = config.DB_CONNECTION_LIMIT ?? defaults.connection_limit;
+  const poolTimeout   = config.DB_POOL_TIMEOUT     ?? defaults.pool_timeout;
+
+  // PgBouncer in transaction mode multiplexes server connections, so each
+  // application process must use connection_limit=1 to avoid holding idle
+  // server connections open.
+  if (config.PGBOUNCER_MODE) {
+    if (connectionLimit !== 1) {
+      console.warn(
+        `[prisma] PGBOUNCER_MODE=true detected: overriding connection_limit from ${connectionLimit} to 1. ` +
+        'PgBouncer transaction mode requires connection_limit=1 per process.',
+      );
+    }
+    connectionLimit = 1;
+  }
 
   const url = new URL(base);
   url.searchParams.set('connection_limit', String(connectionLimit));
   url.searchParams.set('pool_timeout',     String(poolTimeout));
+
+  console.log(
+    `[prisma] Effective pool config — connection_limit: ${connectionLimit}, ` +
+    `pool_timeout: ${poolTimeout}s, pgbouncer_mode: ${config.PGBOUNCER_MODE ?? false}`,
+  );
+
   return url.toString();
 }
 

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -14,6 +14,56 @@ import { audit } from '../middleware/audit';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /health/live:
+ *   get:
+ *     tags: [Health]
+ *     summary: Liveness probe — unauthenticated, returns minimal status
+ *     description: >
+ *       Intended for Kubernetes liveness probes. Returns { status: "ok" }
+ *       without exposing any dependency information to unauthenticated callers.
+ *     security: []
+ *     responses:
+ *       200:
+ *         description: Service is alive
+ */
+router.get('/live', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+/**
+ * @openapi
+ * /health/ready:
+ *   get:
+ *     tags: [Health]
+ *     summary: Readiness probe — authenticated, returns full dependency status
+ *     description: >
+ *       Intended for Kubernetes readiness probes and internal monitoring.
+ *       Requires a valid bearer token. Returns detailed dependency health so
+ *       that dependency information is not exposed to unauthenticated callers.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: All dependencies are healthy
+ *       401:
+ *         description: Missing or invalid bearer token
+ *       500:
+ *         description: Health check failed
+ */
+router.get('/ready', authenticate, async (req, res) => {
+  try {
+    const healthService = getHealthService();
+    const status = await healthService.getSystemStatus();
+    res.status(200).json(status);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Health check failed',
+    });
+  }
+});
+
 // Valid service names for alert configuration
 const VALID_SERVICES = ['database', 'redis', 's3', 'twitter', 'youtube', 'facebook'] as const;
 

--- a/backend/src/services/TikTokService.ts
+++ b/backend/src/services/TikTokService.ts
@@ -6,7 +6,11 @@ import { getRedisConnection } from '../config/runtime';
 const logger = createLogger('tiktok-service');
 
 const UPLOAD_PROGRESS_PREFIX = 'tiktok:upload:progress:';
+const UPLOAD_SESSION_PREFIX = 'tiktok:upload:session:';
 const UPLOAD_PROGRESS_TTL = 86400; // 24 hours
+
+// Field name inside the progress hash that tracks the last confirmed chunk index
+const LAST_CHUNK_FIELD = '__lastChunk';
 
 let _redis: Redis | null = null;
 function getRedis(): Redis {
@@ -326,11 +330,72 @@ class TikTokService {
       );
     }
 
-    // Mark chunk as confirmed and refresh TTL
+    // Mark chunk as confirmed, update last successful chunk index, and refresh TTL
     await redis.hset(progressKey, String(chunkIndex), '1');
+    await redis.hset(progressKey, LAST_CHUNK_FIELD, String(chunkIndex));
     await redis.expire(progressKey, UPLOAD_PROGRESS_TTL);
 
     logger.info('TikTok chunk uploaded', { chunkIndex: chunkIndex + 1, totalChunks });
+  }
+
+  /**
+   * Retrieve the last successfully uploaded chunk index for a session.
+   * Returns -1 when no chunks have been confirmed yet.
+   */
+  public async getLastUploadedChunk(uploadSessionId: string): Promise<number> {
+    const redis = getRedis();
+    const progressKey = `${UPLOAD_PROGRESS_PREFIX}${uploadSessionId}`;
+    const value = await redis.hget(progressKey, LAST_CHUNK_FIELD);
+    return value !== null ? Number(value) : -1;
+  }
+
+  /**
+   * Persist upload session metadata (publishId, uploadUrl, chunk dimensions)
+   * under a stable caller-supplied key so that a retried job can resume the
+   * same TikTok upload session instead of initiating a new one.
+   */
+  public async storeUploadSession(
+    sessionKey: string,
+    data: { publishId: string; uploadUrl: string; chunkSize: number; totalChunks: number },
+  ): Promise<void> {
+    const redis = getRedis();
+    const key = `${UPLOAD_SESSION_PREFIX}${sessionKey}`;
+    await redis.hmset(key, {
+      publishId: data.publishId,
+      uploadUrl: data.uploadUrl,
+      chunkSize: String(data.chunkSize),
+      totalChunks: String(data.totalChunks),
+    });
+    await redis.expire(key, UPLOAD_PROGRESS_TTL);
+  }
+
+  /**
+   * Retrieve a previously stored upload session.
+   * Returns null when no session exists for the given key.
+   */
+  public async getUploadSession(sessionKey: string): Promise<{
+    publishId: string;
+    uploadUrl: string;
+    chunkSize: number;
+    totalChunks: number;
+  } | null> {
+    const redis = getRedis();
+    const key = `${UPLOAD_SESSION_PREFIX}${sessionKey}`;
+    const data = await redis.hgetall(key);
+    if (!data || !data.publishId) return null;
+    return {
+      publishId: data.publishId,
+      uploadUrl: data.uploadUrl,
+      chunkSize: Number(data.chunkSize),
+      totalChunks: Number(data.totalChunks),
+    };
+  }
+
+  /**
+   * Clear upload session metadata for a completed or abandoned upload.
+   */
+  public async clearUploadSession(sessionKey: string): Promise<void> {
+    await getRedis().del(`${UPLOAD_SESSION_PREFIX}${sessionKey}`);
   }
 
   /**

--- a/backend/src/services/TwitterService.ts
+++ b/backend/src/services/TwitterService.ts
@@ -53,10 +53,13 @@ export interface TwitterPostRequest {
  */
 export class TwitterService {
   private readonly API_BASE = 'https://api.twitter.com/2';
-  private readonly bearerToken: string;
 
-  constructor() {
-    this.bearerToken = process.env.TWITTER_BEARER_TOKEN || '';
+  /**
+   * Read bearer token lazily on every access so Kubernetes secret rotation
+   * is picked up without a pod restart.
+   */
+  get bearerToken(): string {
+    return process.env.TWITTER_BEARER_TOKEN || '';
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR resolves four independent backend issues in a single pass.

---

### #909 — Read Twitter bearer token lazily on each request

**Problem:** `TwitterService` read `TWITTER_BEARER_TOKEN` once in the constructor. After a Kubernetes secret rotation the pod continued using the stale token until it restarted.

**Change (`backend/src/services/TwitterService.ts`):**
- Removed the constructor assignment and the `private readonly bearerToken` field.
- Replaced both with a getter `get bearerToken()` that reads `process.env.TWITTER_BEARER_TOKEN` on every call, so a rotated secret is picked up immediately without a pod restart.

---

### #910 — Enforce `connection_limit=1` when `PGBOUNCER_MODE` is enabled

**Problem:** PgBouncer in transaction mode requires `connection_limit=1` per process, but the pool sizing code had no guard for this. Operators could misconfigure the pool and silently exhaust server connections.

**Changes:**
- `backend/src/config/config.ts` — Added `PGBOUNCER_MODE` (boolean env var) to the Zod validation schema.
- `backend/src/lib/prisma.ts` — In `buildDatasourceUrl()`:
  - When `PGBOUNCER_MODE=true`, overrides `connection_limit` to `1` and emits `console.warn` if the configured value was higher.
  - Adds a `console.log` line on every boot showing the effective pool configuration (connection_limit, pool_timeout, pgbouncer_mode).

---

### #911 — Split health endpoint into unauthenticated liveness and authenticated readiness

**Problem:** The `/health` router's detailed dependency status was accessible without authentication, exposing useful reconnaissance information to attackers.

**Change (`backend/src/routes/health.ts`):**
- Added `GET /health/live` — **unauthenticated**, returns `{ status: "ok" }` only. Safe to expose to Kubernetes liveness probes.
- Added `GET /health/ready` — **requires bearer token** via the existing `authenticate` middleware; returns full system health from `HealthService.getSystemStatus()`. Intended for readiness probes and internal monitoring.
- Both routes are documented with OpenAPI annotations.

> **Kubernetes probe update:** point liveness probes at `/health/live` and readiness probes at `/health/ready` (with a valid service-account token).

---

### #912 — Resume TikTok chunked uploads from last successful chunk on retry

**Problem:** If a chunked upload was interrupted, the job always retried from the beginning, wasting bandwidth and risking rate-limit violations because `initiateVideoUpload` was called again (new `publishId`/`uploadUrl`), discarding all confirmed chunk progress.

**Changes:**
- `backend/src/services/TikTokService.ts`:
  - `uploadChunk()` now also writes the confirmed chunk index to a `__lastChunk` field in the per-session Redis hash.
  - Added `getLastUploadedChunk(uploadSessionId)` — returns the last confirmed chunk index (`-1` if none).
  - Added `storeUploadSession(sessionKey, data)` — persists `publishId`, `uploadUrl`, `chunkSize`, and `totalChunks` under a stable, caller-supplied key.
  - Added `getUploadSession(sessionKey)` — retrieves a stored session.
  - Added `clearUploadSession(sessionKey)` — cleans up session metadata after a completed upload.
- `backend/src/jobs/tiktokVideoJob.ts` (`handleVideoUpload`):
  - Derives a stable session key from the file path (base64-encoded, max 64 chars).
  - Before calling `initiateVideoUpload`, checks Redis for an existing session. If found, reuses the same `publishId`/`uploadUrl` and resumes the chunk loop from `lastChunk + 1`.
  - Logs the resume point (`resumeChunk`, `totalChunks`, `publishId`) when retrying.
  - Clears both the progress hash and the session key on successful completion.

---

## Files changed

| File | Issue |
|---|---|
| `backend/src/services/TwitterService.ts` | #909 |
| `backend/src/config/config.ts` | #910 |
| `backend/src/lib/prisma.ts` | #910 |
| `backend/src/routes/health.ts` | #911 |
| `backend/src/services/TikTokService.ts` | #912 |
| `backend/src/jobs/tiktokVideoJob.ts` | #912 |

Closes #909
Closes #910
Closes #911
Closes #912
