### PR TITLE
fix/refactor: resolve #901, #902, #903, #904

### DIFF
--- a/backend/src/routes/ai.ts
+++ b/backend/src/routes/ai.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { analyzeImage, GeminiServiceError } from '../services/geminiService';
 import { authMiddleware } from '../middleware/authMiddleware';
+import { checkPermission } from '../middleware/checkPermission';
 
 const router = Router();
 
@@ -14,9 +15,11 @@ const router = Router();
  *   mimeType    {string}  MIME type, e.g. "image/jpeg" (optional, default: "image/jpeg")
  *   context     {string}  Optional prompt context to guide caption style/topic
  */
+// Required permission: posts:create
 router.post(
   '/analyze-image',
   authMiddleware,
+  checkPermission('posts:create'),
   async (req: Request, res: Response) => {
     const { imageData, mimeType, context } = req.body;
 

--- a/backend/src/routes/analytics.ts
+++ b/backend/src/routes/analytics.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { replicaClient } from '../lib/readReplica';
 
 /**
@@ -44,7 +46,8 @@ import { replicaClient } from '../lib/readReplica';
  */
 const router = Router();
 
-router.get('/', (_req: Request, res: Response) => {
+// Required permission: analytics:view
+router.get('/', authMiddleware, checkPermission('analytics:view'), (_req: Request, res: Response) => {
   const { platform, from, to } = _req.query;
 
   // Validation

--- a/backend/src/routes/circuitBreaker.ts
+++ b/backend/src/routes/circuitBreaker.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { circuitBreakerService } from '../services/CircuitBreakerService';
 import { aiService } from '../services/AIService';
 import { twitterService } from '../services/TwitterService';
@@ -77,7 +79,8 @@ router.get('/status/:service', (req: Request, res: Response) => {
  *       200:
  *         description: All circuit breakers reset
  */
-router.post('/reset', (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/reset', authMiddleware, checkPermission('settings:manage'), (req: Request, res: Response) => {
   try {
     circuitBreakerService.resetAll();
     res.json({
@@ -109,7 +112,8 @@ router.post('/reset', (req: Request, res: Response) => {
  *       200:
  *         description: Circuit breaker opened
  */
-router.post('/:service/open', (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/:service/open', authMiddleware, checkPermission('settings:manage'), (req: Request, res: Response) => {
   try {
     const { service } = req.params;
     circuitBreakerService.open(service as any);
@@ -142,7 +146,8 @@ router.post('/:service/open', (req: Request, res: Response) => {
  *       200:
  *         description: Circuit breaker closed
  */
-router.post('/:service/close', (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/:service/close', authMiddleware, checkPermission('settings:manage'), (req: Request, res: Response) => {
   try {
     const { service } = req.params;
     circuitBreakerService.close(service as any);

--- a/backend/src/routes/exports.ts
+++ b/backend/src/routes/exports.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { ExportService } from '../services/ExportService';
 
 const router = Router();
@@ -39,7 +41,8 @@ const router = Router();
  *       400:
  *         description: Validation error
  */
-router.get('/analytics', async (req: Request, res: Response) => {
+// Required permission: analytics:export
+router.get('/analytics', authMiddleware, checkPermission('analytics:export'), async (req: Request, res: Response) => {
   try {
     const { organizationId, format, startDate, endDate } = req.query;
 
@@ -115,7 +118,8 @@ router.get('/analytics', async (req: Request, res: Response) => {
  *       400:
  *         description: Validation error
  */
-router.get('/posts', async (req: Request, res: Response) => {
+// Required permission: analytics:export
+router.get('/posts', authMiddleware, checkPermission('analytics:export'), async (req: Request, res: Response) => {
   try {
     const { organizationId, format, startDate, endDate } = req.query;
 

--- a/backend/src/routes/facebook.ts
+++ b/backend/src/routes/facebook.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { facebookService, FacebookPostRequest } from '../services/FacebookService';
 import { createLogger } from '../lib/logger';
 
@@ -92,7 +94,8 @@ router.get('/pages', async (req: Request, res: Response) => {
  * Body: { pageId, message, imageUrl?, scheduledTime? }
  * Header: x-facebook-token (user access token)
  */
-router.post('/post', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/post', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   const accessToken = req.headers['x-facebook-token'] as string;
   const { pageId, message, imageUrl, scheduledTime } = req.body;
 
@@ -156,7 +159,8 @@ router.get('/post/:pageId/:postId/comments', async (req: Request, res: Response)
  * Body: { message }
  * Header: x-facebook-token
  */
-router.post('/comment/:commentId/reply', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/comment/:commentId/reply', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   const accessToken = req.headers['x-facebook-token'] as string;
   const { commentId } = req.params;
   const { message, pageId } = req.body;
@@ -184,7 +188,8 @@ router.post('/comment/:commentId/reply', async (req: Request, res: Response) => 
  * Header: x-facebook-token
  * Query: pageId, access_token
  */
-router.delete('/comment/:commentId', async (req: Request, res: Response) => {
+// Required permission: posts:delete
+router.delete('/comment/:commentId', authMiddleware, checkPermission('posts:delete'), async (req: Request, res: Response) => {
   const accessToken = req.query.access_token as string;
   const { commentId } = req.params;
 

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response } from 'express';
 import multer from 'multer';
 import path from 'path';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { ImageOptimizationService } from '../services/ImageOptimizationService';
 
 const router = Router();
@@ -78,7 +80,8 @@ const upload = multer({
  *       400:
  *         description: No image provided
  */
-router.post('/upload', upload.single('image'), async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/upload', authMiddleware, checkPermission('posts:create'), upload.single('image'), async (req: Request, res: Response) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No image provided' });
@@ -223,7 +226,8 @@ router.get('/cache/size', async (req: Request, res: Response) => {
  *       200:
  *         description: Cache cleared
  */
-router.delete('/cache', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.delete('/cache', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     await ImageOptimizationService.clearCache();
     res.json({ message: 'Cache cleared' });

--- a/backend/src/routes/jobs.ts
+++ b/backend/src/routes/jobs.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { jobMonitor, JobStatus } from '../services/jobMonitor';
 
 const router = Router();
@@ -245,7 +247,8 @@ router.get('/jobs/:queue/failed', async (req: Request, res: Response) => {
  *       400:
  *         description: Failed to retry
  */
-router.post('/jobs/:queue/jobs/:jobId/retry', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/jobs/:queue/jobs/:jobId/retry', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     const { queue, jobId } = req.params;
     const success = await jobMonitor.retryJob(queue, jobId);
@@ -277,7 +280,8 @@ router.post('/jobs/:queue/jobs/:jobId/retry', async (req: Request, res: Response
  *       200:
  *         description: Jobs retried
  */
-router.post('/jobs/:queue/retry-all', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/jobs/:queue/retry-all', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     const { queue } = req.params;
     const retried = await jobMonitor.retryAllFailed(queue);
@@ -293,7 +297,8 @@ router.post('/jobs/:queue/retry-all', async (req: Request, res: Response) => {
  * DELETE /jobs/:queue/jobs/:jobId
  * Remove a specific job
  */
-router.delete('/jobs/:queue/jobs/:jobId', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.delete('/jobs/:queue/jobs/:jobId', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     const { queue, jobId } = req.params;
     const success = await jobMonitor.removeJob(queue, jobId);
@@ -325,7 +330,8 @@ router.delete('/jobs/:queue/jobs/:jobId', async (req: Request, res: Response) =>
  *       200:
  *         description: Queue paused
  */
-router.post('/jobs/:queue/pause', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/jobs/:queue/pause', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     const { queue } = req.params;
     const success = await jobMonitor.pauseQueue(queue);
@@ -357,7 +363,8 @@ router.post('/jobs/:queue/pause', async (req: Request, res: Response) => {
  *       200:
  *         description: Queue resumed
  */
-router.post('/jobs/:queue/resume', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.post('/jobs/:queue/resume', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     const { queue } = req.params;
     const success = await jobMonitor.resumeQueue(queue);
@@ -389,7 +396,8 @@ router.post('/jobs/:queue/resume', async (req: Request, res: Response) => {
  *       200:
  *         description: Queue cleared
  */
-router.delete('/jobs/:queue/clear', async (req: Request, res: Response) => {
+// Required permission: settings:manage
+router.delete('/jobs/:queue/clear', authMiddleware, checkPermission('settings:manage'), async (req: Request, res: Response) => {
   try {
     const { queue } = req.params;
     const success = await jobMonitor.clearQueue(queue);

--- a/backend/src/routes/linkedin.ts
+++ b/backend/src/routes/linkedin.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { linkedInService, LinkedInShareRequest } from '../services/LinkedInService';
 import { createLogger } from '../lib/logger';
 
@@ -86,7 +88,8 @@ router.get('/profile', async (req: Request, res: Response) => {
  * `mediaAssets` is an array of up to 20 objects: { url, title?, description? }
  * When provided it creates a multi-image post and takes precedence over `url`.
  */
-router.post('/share', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/share', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   const accessToken = req.headers['x-linkedin-token'] as string;
   if (!accessToken) {
     return res.status(400).json({ error: 'x-linkedin-token header required.' });

--- a/backend/src/routes/tiktok.ts
+++ b/backend/src/routes/tiktok.ts
@@ -2,6 +2,8 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { tiktokService } from '../services/TikTokService';
 import { enqueueTikTokVideoUpload } from '../jobs/tiktokVideoJob';
 import { dispatchEvent } from '../services/WebhookDispatcher';
@@ -101,7 +103,8 @@ router.get('/user', async (req: Request, res: Response) => {
  *
  * Header: x-tiktok-token, x-tiktok-refresh-token, x-tiktok-expires-at
  */
-router.post('/video/upload', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/video/upload', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   const accessToken = req.headers['x-tiktok-token'] as string;
   const refreshToken = req.headers['x-tiktok-refresh-token'] as string;
   const expiresAt = Number(req.headers['x-tiktok-expires-at']);
@@ -171,7 +174,8 @@ router.post('/video/upload', async (req: Request, res: Response) => {
  * Body: { videoUrl, title, description?, privacyLevel? }
  * Header: x-tiktok-token
  */
-router.post('/video/upload-url', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/video/upload-url', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   const accessToken = req.headers['x-tiktok-token'] as string;
   if (!accessToken) {
     return res.status(400).json({ error: 'x-tiktok-token header required.' });

--- a/backend/src/routes/translation.ts
+++ b/backend/src/routes/translation.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { translationService } from '../services/TranslationService';
 
 const router = Router();
@@ -45,7 +47,8 @@ const router = Router();
  *       500:
  *         description: Translation failed
  */
-router.post('/translate', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/translate', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   try {
     const {
       text,
@@ -150,7 +153,8 @@ router.get('/languages', (req: Request, res: Response) => {
  *       400:
  *         description: Text is required
  */
-router.post('/detect', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/detect', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   try {
     const { text } = req.body;
 
@@ -215,7 +219,8 @@ router.post('/detect', async (req: Request, res: Response) => {
  *       400:
  *         description: Validation error
  */
-router.post('/batch', async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/batch', authMiddleware, checkPermission('posts:create'), async (req: Request, res: Response) => {
   try {
     const { texts, sourceLanguage, targetLanguages } = req.body;
 

--- a/backend/src/routes/video.ts
+++ b/backend/src/routes/video.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response } from 'express';
 import multer from 'multer';
 import path from 'path';
+import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { checkPermission } from '../middleware/checkPermission';
 import { videoService } from '../services/VideoService';
 import { videoQueue } from '../queues/VideoQueue';
 import { videoHealthService } from '../services/VideoHealthService';
@@ -76,7 +78,8 @@ const upload = multer({
  *       500:
  *         description: Upload failed
  */
-router.post('/upload', upload.single('video'), async (req: Request, res: Response) => {
+// Required permission: posts:create
+router.post('/upload', authMiddleware, checkPermission('posts:create'), upload.single('video'), async (req: Request, res: Response) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No video file provided' });
@@ -174,7 +177,8 @@ router.get('/jobs', (req: Request, res: Response) => {
  * DELETE /api/video/job/:jobId
  * Cancel a transcoding job
  */
-router.delete('/job/:jobId', async (req: Request, res: Response) => {
+// Required permission: posts:delete
+router.delete('/job/:jobId', authMiddleware, checkPermission('posts:delete'), async (req: Request, res: Response) => {
   const { jobId } = req.params;
   const cancelled = await videoService.cancelJob(jobId);
 

--- a/backend/src/services/ExportService.ts
+++ b/backend/src/services/ExportService.ts
@@ -3,9 +3,11 @@ import { Readable } from 'stream';
 import { prisma } from '../lib/prisma';
 import { paginatedQuery } from '../lib/paginatedQuery';
 
-function makeStream(res: Response, headers: Record<string, string>, contentLength?: number): Readable {
+function makeStream(res: Response, headers: Record<string, string>): Readable {
   for (const [k, v] of Object.entries(headers)) res.setHeader(k, v);
-  if (contentLength !== undefined) res.setHeader('Content-Length', contentLength);
+  // Use chunked transfer encoding — pre-calculated Content-Length is unreliable
+  // because actual row sizes vary and can cause HTTP clients to truncate the response.
+  res.setHeader('Transfer-Encoding', 'chunked');
   const stream = new Readable({ read() {} });
   stream.pipe(res);
   return stream;
@@ -34,14 +36,11 @@ export const ExportService = {
     res: Response,
   ): Promise<void> => {
     const where = { organizationId, recordedAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.analyticsEntry.count({ where });
     const header = 'id,organizationId,platform,metric,value,recordedAt\n';
-    // Each row: id(~36) + orgId(~36) + platform(~10) + metric(~15) + value(~5) + date(~24) + delimiters ≈ 140 bytes
-    const contentLength = Buffer.byteLength(header) + count * 140;
     const stream = makeStream(res, {
       'Content-Type': 'text/csv; charset=utf-8',
       'Content-Disposition': 'attachment; filename="analytics.csv"',
-    }, contentLength);
+    });
     stream.push(header);
     await pump(stream, (args) => prisma.analyticsEntry.findMany({ where, ...args }), (row) =>
       `${row.id},"${row.organizationId}","${row.platform}","${row.metric}",${row.value},"${row.recordedAt.toISOString()}"\n`,
@@ -55,13 +54,10 @@ export const ExportService = {
     res: Response,
   ): Promise<void> => {
     const where = { organizationId, recordedAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.analyticsEntry.count({ where });
-    // Each NDJSON row estimate: ~200 bytes
-    const contentLength = count * 200;
     const stream = makeStream(res, {
       'Content-Type': 'application/x-ndjson; charset=utf-8',
       'Content-Disposition': 'attachment; filename="analytics.jsonl"',
-    }, contentLength);
+    });
     await pump(stream, (args) => prisma.analyticsEntry.findMany({ where, ...args }), (row) =>
       JSON.stringify(row) + '\n',
     );
@@ -74,14 +70,11 @@ export const ExportService = {
     res: Response,
   ): Promise<void> => {
     const where = { organizationId, createdAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.post.count({ where });
     const header = 'id,organizationId,content,platform,scheduledAt,createdAt\n';
-    // Each row estimate: ~300 bytes (content can vary)
-    const contentLength = Buffer.byteLength(header) + count * 300;
     const stream = makeStream(res, {
       'Content-Type': 'text/csv; charset=utf-8',
       'Content-Disposition': 'attachment; filename="posts.csv"',
-    }, contentLength);
+    });
     stream.push(header);
     await pump(stream, (args) => prisma.post.findMany({ where, ...args }), (row) => {
       const content = row.content.replace(/"/g, '""');
@@ -96,13 +89,10 @@ export const ExportService = {
     res: Response,
   ): Promise<void> => {
     const where = { organizationId, createdAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.post.count({ where });
-    // Each NDJSON row estimate: ~350 bytes
-    const contentLength = count * 350;
     const stream = makeStream(res, {
       'Content-Type': 'application/x-ndjson; charset=utf-8',
       'Content-Disposition': 'attachment; filename="posts.jsonl"',
-    }, contentLength);
+    });
     await pump(stream, (args) => prisma.post.findMany({ where, ...args }), (row) =>
       JSON.stringify(row) + '\n',
     );

--- a/backend/src/tracing.ts
+++ b/backend/src/tracing.ts
@@ -57,7 +57,17 @@ function buildExporter(): SpanExporter {
 
 // ─── SDK initialisation ──────────────────────────────────────────────────────
 
-const isDebug = config.OTEL_DEBUG;
+// #903: Prevent OTEL_DEBUG=true in production — it enables per-span I/O latency logging and degrades performance.
+let isDebug = config.OTEL_DEBUG;
+if (config.NODE_ENV === 'production' && isDebug) {
+  logger.error(
+    'CRITICAL: OTEL_DEBUG=true is set in a production environment. ' +
+    'This enables verbose per-span logging and degrades performance. ' +
+    'Disabling OTEL_DEBUG. Remove OTEL_DEBUG=true from your production configuration.'
+  );
+  isDebug = false;
+}
+
 const serviceName = config.OTEL_SERVICE_NAME;
 
 const exporter = buildExporter();

--- a/src/blockchain/services/IPFSClient.ts
+++ b/src/blockchain/services/IPFSClient.ts
@@ -1,0 +1,151 @@
+import { AppError } from '../../utils/AppError';
+import { ErrorCode } from '../../constants/ErrorCodes';
+
+export type Provider = 'pinata' | 'web3'
+
+export interface IPFSConfig {
+  provider: Provider
+  apiKey?: string
+  secret?: string
+  gatewayUrls: string[]
+}
+
+export interface IPFSUploadResult {
+  cid: string
+  size: number
+  gatewayUrl: string
+}
+
+export const DEFAULT_GATEWAYS = [
+  'https://ipfs.io/ipfs/',
+  'https://cloudflare-ipfs.com/ipfs/',
+  'https://dweb.link/ipfs/',
+]
+
+export const MB = 1024 * 1024
+
+export function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+export async function retryWithBackoff<T>(fn: () => Promise<T>, attempts = 3, baseMs = 300) {
+  let lastErr: any
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastErr = err
+      const wait = baseMs * 2 ** i
+      await sleep(wait)
+    }
+  }
+  throw lastErr
+}
+
+export function timeoutSignal(timeoutMs: number) {
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), timeoutMs)
+  return { signal: controller.signal, clear: () => clearTimeout(id) }
+}
+
+export function openDb() {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('ipfs-cache-db', 1)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains('files')) db.createObjectStore('files', { keyPath: 'cid' })
+      if (!db.objectStoreNames.contains('pins')) db.createObjectStore('pins', { keyPath: 'cid' })
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function idbPut(storeName: string, value: any) {
+  const db = await openDb()
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite')
+    tx.objectStore(storeName).put(value)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}
+
+export async function idbGet(storeName: string, key: string) {
+  const db = await openDb()
+  return new Promise<any>((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly')
+    const req = tx.objectStore(storeName).get(key)
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function idbAll(storeName: string) {
+  const db = await openDb()
+  return new Promise<any[]>((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly')
+    const req = tx.objectStore(storeName).getAll()
+    req.onsuccess = () => resolve(req.result || [])
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function idbDelete(storeName: string, key: string) {
+  const db = await openDb()
+  return new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite')
+    tx.objectStore(storeName).delete(key)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}
+
+export class IPFSClient {
+  config: IPFSConfig
+
+  constructor(config?: Partial<IPFSConfig>) {
+    const fromEnv = IPFSClient.fromEnv()
+    this.config = {
+      provider: config?.provider || fromEnv.provider,
+      apiKey: config?.apiKey || fromEnv.apiKey,
+      secret: config?.secret || fromEnv.secret,
+      gatewayUrls: config?.gatewayUrls || fromEnv.gatewayUrls || DEFAULT_GATEWAYS,
+    }
+  }
+
+  static fromEnv(): IPFSConfig {
+    // @ts-ignore
+    const env = typeof import.meta !== 'undefined' ? import.meta.env : (window as any).__ENV__ || {}
+    const pinataKey = env.VITE_PINATA_API_KEY || env.VITE_PINATA_JWT
+    const web3Key = env.VITE_WEB3_STORAGE_TOKEN
+    const provider: Provider = web3Key ? 'web3' : pinataKey ? 'pinata' : 'web3'
+    return {
+      provider,
+      apiKey: web3Key || pinataKey,
+      secret: env.VITE_PINATA_SECRET || undefined,
+      gatewayUrls: DEFAULT_GATEWAYS,
+    }
+  }
+
+  getProviderInfo() {
+    if (this.config.provider === 'web3') {
+      return {
+        uploadUrl: 'https://api.web3.storage/upload',
+        listUrl: 'https://api.web3.storage/user/uploads',
+        authHeader: this.config.apiKey ? `Bearer ${this.config.apiKey}` : undefined,
+      }
+    }
+    return {
+      uploadUrl: 'https://api.pinata.cloud/pinning/pinFileToIPFS',
+      pinByHashUrl: 'https://api.pinata.cloud/pinning/pinByHash',
+      listUrl: 'https://api.pinata.cloud/data/pinList',
+      authHeader: this.config.apiKey && this.config.secret ? undefined : this.config.apiKey,
+    }
+  }
+
+  getFileUrl(cid: string) {
+    const gw = (this.config.gatewayUrls && this.config.gatewayUrls[0]) || DEFAULT_GATEWAYS[0]
+    return gw + cid
+  }
+}

--- a/src/blockchain/services/IPFSRetriever.ts
+++ b/src/blockchain/services/IPFSRetriever.ts
@@ -1,0 +1,115 @@
+import { AppError } from '../../utils/AppError';
+import { ErrorCode } from '../../constants/ErrorCodes';
+import {
+  IPFSClient,
+  MB,
+  timeoutSignal,
+  idbPut,
+  idbGet,
+  idbAll,
+  idbDelete,
+  openDb,
+} from './IPFSClient';
+
+export class IPFSRetriever {
+  private client: IPFSClient
+
+  constructor(client: IPFSClient) {
+    this.client = client
+  }
+
+  private async fetchWithGatewayFallback(cid: string, timeoutMs = 30_000): Promise<Response> {
+    const gateways = this.client.config.gatewayUrls
+    let lastErr: any
+    for (const gw of gateways) {
+      const url = gw + cid
+      const { signal, clear } = timeoutSignal(timeoutMs)
+      try {
+        const res = await fetch(url, { signal })
+        clear()
+        if (res.ok) return res
+      } catch (err) {
+        lastErr = err
+      }
+    }
+    throw lastErr || new AppError(ErrorCode.ERR_NETWORK_ERROR, 'All gateways failed')
+  }
+
+  async getFile(cid: string): Promise<Blob> {
+    const cached = await idbGet('files', cid)
+    if (cached && cached.data) {
+      await idbPut('files', { ...cached, lastAccess: Date.now() })
+      return new Blob([cached.data])
+    }
+    const res = await this.fetchWithGatewayFallback(cid)
+    const blob = await res.blob()
+    await this.cacheFile(cid, blob)
+    return blob
+  }
+
+  async getJSON(cid: string): Promise<any> {
+    const res = await this.fetchWithGatewayFallback(cid)
+    const text = await res.text()
+    try {
+      return JSON.parse(text)
+    } catch (e) {
+      throw new AppError(ErrorCode.ERR_INVALID_FORMAT, 'Invalid JSON')
+    }
+  }
+
+  async cacheFile(cid: string, blob: Blob) {
+    const size = blob.size
+    const data = await blob.arrayBuffer()
+    const entry = { cid, data, size, lastAccess: Date.now() }
+    await idbPut('files', entry)
+    await this.enforceCacheLimit()
+  }
+
+  async getCacheSize() {
+    const all = await idbAll('files')
+    return all.reduce((s, e) => s + (e.size || 0), 0)
+  }
+
+  async clearCache() {
+    const db = await openDb()
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction('files', 'readwrite')
+      tx.objectStore('files').clear()
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  }
+
+  private async enforceCacheLimit() {
+    const limit = 500 * MB
+    const all = await idbAll('files')
+    let total = all.reduce((s, e) => s + (e.size || 0), 0)
+    if (total <= limit) return
+    all.sort((a, b) => (a.lastAccess || 0) - (b.lastAccess || 0))
+    for (const entry of all) {
+      const pin = await idbGet('pins', entry.cid)
+      if (pin?.pinned) continue
+      await idbDelete('files', entry.cid)
+      total -= entry.size || 0
+      if (total <= limit) break
+    }
+  }
+
+  async unpinFile(cid: string) {
+    if (this.client.config.provider === 'pinata') {
+      const url = `https://api.pinata.cloud/pinning/unpin/${cid}`
+      const headers: any = {}
+      if (this.client.config.apiKey && this.client.config.secret) {
+        headers['pinata_api_key'] = this.client.config.apiKey
+        headers['pinata_secret_api_key'] = this.client.config.secret
+      } else if (this.client.config.apiKey) headers['Authorization'] = `Bearer ${this.client.config.apiKey}`
+      const res = await fetch(url, { method: 'DELETE', headers })
+      if (!res.ok) throw new AppError(ErrorCode.ERR_TRANSACTION_FAILED, 'Unpin failed')
+      await idbPut('pins', { cid, pinned: false, provider: 'pinata', updatedAt: Date.now() })
+      return true
+    } else {
+      await idbPut('pins', { cid, pinned: false, provider: 'web3', updatedAt: Date.now() })
+      return true
+    }
+  }
+}

--- a/src/blockchain/services/IPFSService.ts
+++ b/src/blockchain/services/IPFSService.ts
@@ -1,447 +1,75 @@
-import { AppError } from '../../utils/AppError';
-import { ErrorCode } from '../../constants/ErrorCodes';
+import { IPFSClient, IPFSConfig, IPFSUploadResult, DEFAULT_GATEWAYS } from './IPFSClient';
+import { IPFSUploader } from './IPFSUploader';
+import { IPFSRetriever } from './IPFSRetriever';
 
-/* IPFSService
-   Provides upload/download/pinning/caching helper for IPFS providers
-*/
-
-type Provider = 'pinata' | 'web3'
-
-export interface IPFSConfig {
-  provider: Provider
-  apiKey?: string
-  secret?: string
-  gatewayUrls: string[]
-}
-
-export interface IPFSUploadResult {
-  cid: string
-  size: number
-  gatewayUrl: string
-}
-
-const DEFAULT_GATEWAYS = [
-  'https://ipfs.io/ipfs/',
-  'https://cloudflare-ipfs.com/ipfs/',
-  'https://dweb.link/ipfs/',
-]
-
-const MB = 1024 * 1024
-
-function sleep(ms: number) {
-  return new Promise((r) => setTimeout(r, ms))
-}
-
-async function retryWithBackoff<T>(fn: () => Promise<T>, attempts = 3, baseMs = 300) {
-  let lastErr: any
-  for (let i = 0; i < attempts; i++) {
-    try {
-      return await fn()
-    } catch (err) {
-      lastErr = err
-      const wait = baseMs * 2 ** i
-      await sleep(wait)
-    }
-  }
-  throw lastErr
-}
-
-function timeoutSignal(timeoutMs: number) {
-  const controller = new AbortController()
-  const id = setTimeout(() => controller.abort(), timeoutMs)
-  return { signal: controller.signal, clear: () => clearTimeout(id) }
-}
-
-// Basic IndexedDB helpers
-function openDb() {
-  return new Promise<IDBDatabase>((resolve, reject) => {
-    const req = indexedDB.open('ipfs-cache-db', 1)
-    req.onupgradeneeded = () => {
-      const db = req.result
-      if (!db.objectStoreNames.contains('files')) db.createObjectStore('files', { keyPath: 'cid' })
-      if (!db.objectStoreNames.contains('pins')) db.createObjectStore('pins', { keyPath: 'cid' })
-    }
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-  })
-}
-
-async function idbPut(storeName: string, value: any) {
-  const db = await openDb()
-  return new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(storeName, 'readwrite')
-    tx.objectStore(storeName).put(value)
-    tx.oncomplete = () => resolve()
-    tx.onerror = () => reject(tx.error)
-  })
-}
-
-async function idbGet(storeName: string, key: string) {
-  const db = await openDb()
-  return new Promise<any>((resolve, reject) => {
-    const tx = db.transaction(storeName, 'readonly')
-    const req = tx.objectStore(storeName).get(key)
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-  })
-}
-
-async function idbAll(storeName: string) {
-  const db = await openDb()
-  return new Promise<any[]>((resolve, reject) => {
-    const tx = db.transaction(storeName, 'readonly')
-    const req = tx.objectStore(storeName).getAll()
-    req.onsuccess = () => resolve(req.result || [])
-    req.onerror = () => reject(req.error)
-  })
-}
-
-async function idbDelete(storeName: string, key: string) {
-  const db = await openDb()
-  return new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(storeName, 'readwrite')
-    tx.objectStore(storeName).delete(key)
-    tx.oncomplete = () => resolve()
-    tx.onerror = () => reject(tx.error)
-  })
-}
+export { IPFSConfig, IPFSUploadResult };
 
 export class IPFSService {
   config: IPFSConfig
+  private client: IPFSClient
+  private uploader: IPFSUploader
+  private retriever: IPFSRetriever
 
   constructor(config?: Partial<IPFSConfig>) {
-    const fromEnv = IPFSService.fromEnv()
-    this.config = {
-      provider: config?.provider || fromEnv.provider,
-      apiKey: config?.apiKey || fromEnv.apiKey,
-      secret: config?.secret || fromEnv.secret,
-      gatewayUrls: config?.gatewayUrls || fromEnv.gatewayUrls || DEFAULT_GATEWAYS,
-    }
+    this.client = new IPFSClient(config)
+    this.config = this.client.config
+    this.uploader = new IPFSUploader(this.client)
+    this.retriever = new IPFSRetriever(this.client)
   }
 
   static fromEnv(): IPFSConfig {
-    // Vite env variables (client-side) usually accessible via import.meta.env
-    // We attempt to read both import.meta.env and window.__ENV__ fallback
-    // but keep this minimal — consumers can pass config directly.
-    // @ts-ignore
-    const env = typeof import.meta !== 'undefined' ? import.meta.env : (window as any).__ENV__ || {}
-    const pinataKey = env.VITE_PINATA_API_KEY || env.VITE_PINATA_JWT
-    const web3Key = env.VITE_WEB3_STORAGE_TOKEN
-    const provider: Provider = web3Key ? 'web3' : pinataKey ? 'pinata' : 'web3'
-    return {
-      provider,
-      apiKey: web3Key || pinataKey,
-      secret: env.VITE_PINATA_SECRET || undefined,
-      gatewayUrls: DEFAULT_GATEWAYS,
-    }
+    return IPFSClient.fromEnv()
   }
 
-  // Helper to pick provider URL and auth
-  private getProviderInfo() {
-    if (this.config.provider === 'web3') {
-      return {
-        uploadUrl: 'https://api.web3.storage/upload',
-        listUrl: 'https://api.web3.storage/user/uploads',
-        authHeader: this.config.apiKey ? `Bearer ${this.config.apiKey}` : undefined,
-      }
-    }
-    return {
-      uploadUrl: 'https://api.pinata.cloud/pinning/pinFileToIPFS',
-      pinByHashUrl: 'https://api.pinata.cloud/pinning/pinByHash',
-      listUrl: 'https://api.pinata.cloud/data/pinList',
-      authHeader: this.config.apiKey && this.config.secret ? undefined : this.config.apiKey, // if JWT stored in apiKey
-    }
+  // Upload operations (delegated to IPFSUploader)
+  uploadFile(file: File, onProgress?: (uploadedBytes: number, totalBytes: number) => void): Promise<IPFSUploadResult> {
+    return this.uploader.uploadFile(file, onProgress)
   }
 
-  async uploadFile(
-    file: File,
-    onProgress?: (uploadedBytes: number, totalBytes: number) => void
-  ): Promise<IPFSUploadResult> {
-    const size = file.size
-    const chunkThreshold = 10 * MB
-    if (size > chunkThreshold) {
-      return this.uploadFileChunked(file, onProgress)
-    }
-    return this.uploadFileSimple(file, onProgress)
+  uploadJSON(metadata: any): Promise<{ cid: string; uri: string }> {
+    return this.uploader.uploadJSON(metadata)
   }
 
-  private async uploadFileSimple(file: File, _onProgress?: (a: number, b: number) => void) {
-    const info = this.getProviderInfo()
-    if (this.config.provider === 'web3') {
-      const form = new FormData()
-      form.append('file', file, file.name)
-      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers: { Authorization: info.authHeader || '' }, body: form }), 3)
-      if (!res.ok) throw new AppError(ErrorCode.ERR_NETWORK_ERROR, `Upload failed ${res.status}`)
-      const data = await res.json()
-      // web3.storage returns cid in `cid`
-      const cid = data.cid || (data[0] && data[0].cid) || ''
-      const gatewayUrl = this.getFileUrl(cid)
-      return { cid, size: file.size, gatewayUrl }
-    } else {
-      // Pinata
-      const form = new FormData()
-      form.append('file', file, file.name)
-      const headers: any = {}
-      if (this.config.apiKey && this.config.secret) {
-        headers['pinata_api_key'] = this.config.apiKey
-        headers['pinata_secret_api_key'] = this.config.secret
-      } else if (this.config.apiKey) {
-        headers['Authorization'] = `Bearer ${this.config.apiKey}`
-      }
-      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers, body: form }), 3)
-      if (!res.ok) throw new AppError(ErrorCode.ERR_NETWORK_ERROR, `Upload failed ${res.status}`)
-      const data = await res.json()
-      const cid = data.IpfsHash || data.ipfsHash || ''
-      const gatewayUrl = this.getFileUrl(cid)
-      return { cid, size: file.size, gatewayUrl }
-    }
+  uploadBatch(files: File[], onProgress?: (completed: number, total: number) => void) {
+    return this.uploader.uploadBatch(files, onProgress)
   }
 
-  private async uploadFileChunked(file: File, onProgress?: (a: number, b: number) => void) {
-    // Stream file in slices using ReadableStream and send to provider when possible
-    const chunkSize = 5 * MB
-    let uploaded = 0
-
-    const stream = new ReadableStream<Uint8Array>({
-      async pull(controller) {
-        const start = uploaded
-        if (start >= file.size) {
-          controller.close()
-          return
-        }
-        const end = Math.min(start + chunkSize, file.size)
-        const blob = file.slice(start, end)
-        const arr = new Uint8Array(await blob.arrayBuffer())
-        controller.enqueue(arr)
-        uploaded = end
-        if (onProgress) onProgress(uploaded, file.size)
-      },
-    })
-
-    const info = this.getProviderInfo()
-    const headers: any = {}
-    if (this.config.provider === 'web3') {
-      if (info.authHeader) headers['Authorization'] = info.authHeader
-      headers['Content-Type'] = 'application/octet-stream'
-      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers, body: stream as any }), 3)
-      if (!res.ok) throw new AppError(ErrorCode.ERR_NETWORK_ERROR, `Upload failed ${res.status}`)
-      const data = await res.json()
-      const cid = data.cid || ''
-      return { cid, size: file.size, gatewayUrl: this.getFileUrl(cid) }
-    } else {
-      // Pinata doesn't accept raw streaming in this form; fallback to simple upload
-      return this.uploadFileSimple(file, onProgress)
-    }
+  pinFile(cid: string) {
+    return this.uploader.pinFile(cid)
   }
 
-  async uploadJSON(metadata: any): Promise<{ cid: string; uri: string }> {
-    // Validate JSON: must be object
-    if (typeof metadata !== 'object' || metadata === null) throw new AppError(ErrorCode.ERR_BAD_REQUEST, 'Invalid metadata')
-    const info = this.getProviderInfo()
-    if (this.config.provider === 'web3') {
-      const headers: any = { Authorization: info.authHeader || '', 'Content-Type': 'application/json' }
-      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers, body: JSON.stringify(metadata) }), 3)
-      if (!res.ok) throw new Error('JSON upload failed')
-      const data = await res.json()
-      const cid = data.cid || ''
-      return { cid, uri: `ipfs://${cid}` }
-    } else {
-      // Pinata JSON pinning endpoint
-      const url = 'https://api.pinata.cloud/pinning/pinJSONToIPFS'
-      const headers: any = { 'Content-Type': 'application/json' }
-      if (this.config.apiKey && this.config.secret) {
-        headers['pinata_api_key'] = this.config.apiKey
-        headers['pinata_secret_api_key'] = this.config.secret
-      } else if (this.config.apiKey) {
-        headers['Authorization'] = `Bearer ${this.config.apiKey}`
-      }
-      const res = await retryWithBackoff(() => fetch(url, { method: 'POST', headers, body: JSON.stringify(metadata) }), 3)
-      if (!res.ok) throw new Error('JSON upload failed')
-      const data = await res.json()
-      const cid = data.IpfsHash || data.ipfsHash || ''
-      return { cid, uri: `ipfs://${cid}` }
-    }
+  getPinnedFiles() {
+    return this.uploader.getPinnedFiles()
   }
 
-  async uploadBatch(files: File[], onProgress?: (completed: number, total: number) => void) {
-    const concurrency = 3
-    const results: IPFSUploadResult[] = []
-    let index = 0
-    let completed = 0
-
-    const runOne = async () => {
-      while (index < files.length) {
-        const i = index++
-        try {
-          const res = await this.uploadFile(files[i], (_u, _t) => {
-            // per-file progress ignored here
-          })
-          results[i] = res
-        } catch (e) {
-          results[i] = { cid: '', size: files[i].size, gatewayUrl: '' }
-        }
-        completed++
-        if (onProgress) onProgress(completed, files.length)
-      }
-    }
-
-    const workers = []
-    for (let i = 0; i < concurrency; i++) workers.push(runOne())
-    await Promise.all(workers)
-    return results
+  // Retrieval operations (delegated to IPFSRetriever)
+  getFile(cid: string): Promise<Blob> {
+    return this.retriever.getFile(cid)
   }
 
+  getJSON(cid: string): Promise<any> {
+    return this.retriever.getJSON(cid)
+  }
+
+  cacheFile(cid: string, blob: Blob) {
+    return this.retriever.cacheFile(cid, blob)
+  }
+
+  getCacheSize() {
+    return this.retriever.getCacheSize()
+  }
+
+  clearCache() {
+    return this.retriever.clearCache()
+  }
+
+  unpinFile(cid: string) {
+    return this.retriever.unpinFile(cid)
+  }
+
+  // Connection helpers (delegated to IPFSClient)
   getFileUrl(cid: string) {
-    const gw = (this.config.gatewayUrls && this.config.gatewayUrls[0]) || DEFAULT_GATEWAYS[0]
-    return gw + cid
-  }
-
-  private async fetchWithGatewayFallback(cid: string, timeoutMs = 30_000): Promise<Response> {
-    const gateways = this.config.gatewayUrls || DEFAULT_GATEWAYS
-    let lastErr: any
-    for (const gw of gateways) {
-      const url = gw + cid
-      const { signal, clear } = timeoutSignal(timeoutMs)
-      try {
-        const res = await fetch(url, { signal })
-        clear()
-        if (res.ok) return res
-      } catch (err) {
-        lastErr = err
-      }
-    }
-    throw lastErr || new AppError(ErrorCode.ERR_NETWORK_ERROR, 'All gateways failed')
-  }
-
-  async getFile(cid: string): Promise<Blob> {
-    const cached = await idbGet('files', cid)
-    if (cached && cached.data) {
-      // update access time
-      await idbPut('files', { ...cached, lastAccess: Date.now() })
-      return new Blob([cached.data])
-    }
-    const res = await this.fetchWithGatewayFallback(cid)
-    const blob = await res.blob()
-    await this.cacheFile(cid, blob)
-    return blob
-  }
-
-  async getJSON(cid: string): Promise<any> {
-    const res = await this.fetchWithGatewayFallback(cid)
-    const text = await res.text()
-    try {
-      return JSON.parse(text)
-    } catch (e) {
-      throw new AppError(ErrorCode.ERR_INVALID_FORMAT, 'Invalid JSON')
-    }
-  }
-
-  // Caching
-  async cacheFile(cid: string, blob: Blob) {
-    const size = blob.size
-    const data = await blob.arrayBuffer()
-    const entry = { cid, data, size, lastAccess: Date.now() }
-    await idbPut('files', entry)
-    await this.enforceCacheLimit()
-  }
-
-  async getCacheSize() {
-    const all = await idbAll('files')
-    return all.reduce((s, e) => s + (e.size || 0), 0)
-  }
-
-  async clearCache() {
-    const db = await openDb()
-    return new Promise<void>((resolve, reject) => {
-      const tx = db.transaction('files', 'readwrite')
-      tx.objectStore('files').clear()
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-  }
-
-  private async enforceCacheLimit() {
-    const limit = 500 * MB
-    const all = await idbAll('files')
-    let total = all.reduce((s, e) => s + (e.size || 0), 0)
-    if (total <= limit) return
-    // sort by lastAccess ascending (oldest first)
-    all.sort((a, b) => (a.lastAccess || 0) - (b.lastAccess || 0))
-    for (const entry of all) {
-      const pin = await idbGet('pins', entry.cid)
-      if (pin?.pinned) continue
-      await idbDelete('files', entry.cid)
-      total -= entry.size || 0
-      if (total <= limit) break
-    }
-  }
-
-  // Pinning management
-  async pinFile(cid: string) {
-    const info = this.getProviderInfo()
-    if (this.config.provider === 'pinata') {
-      const url = info.pinByHashUrl!
-      const headers: any = { 'Content-Type': 'application/json' }
-      if (this.config.apiKey && this.config.secret) {
-        headers['pinata_api_key'] = this.config.apiKey
-        headers['pinata_secret_api_key'] = this.config.secret
-      } else if (this.config.apiKey) {
-        headers['Authorization'] = `Bearer ${this.config.apiKey}`
-      }
-      const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify({ hashToPin: cid }) })
-      if (!res.ok) throw new AppError(ErrorCode.ERR_TRANSACTION_FAILED, 'Pin failed')
-      await idbPut('pins', { cid, pinned: true, provider: 'pinata', updatedAt: Date.now() })
-      return true
-    } else {
-      // web3.storage pins at upload time; we store a local pin record
-      await idbPut('pins', { cid, pinned: true, provider: 'web3', updatedAt: Date.now() })
-      return true
-    }
-  }
-
-  async unpinFile(cid: string) {
-    
-    if (this.config.provider === 'pinata') {
-      const url = `https://api.pinata.cloud/pinning/unpin/${cid}`
-      const headers: any = {}
-      if (this.config.apiKey && this.config.secret) {
-        headers['pinata_api_key'] = this.config.apiKey
-        headers['pinata_secret_api_key'] = this.config.secret
-      } else if (this.config.apiKey) headers['Authorization'] = `Bearer ${this.config.apiKey}`
-      const res = await fetch(url, { method: 'DELETE', headers })
-      if (!res.ok) throw new AppError(ErrorCode.ERR_TRANSACTION_FAILED, 'Unpin failed')
-      await idbPut('pins', { cid, pinned: false, provider: 'pinata', updatedAt: Date.now() })
-      return true
-    } else {
-      // web3: best-effort local unpin record
-      await idbPut('pins', { cid, pinned: false, provider: 'web3', updatedAt: Date.now() })
-      return true
-    }
-  }
-
-  async getPinnedFiles() {
-    // return combined local records and remote if available
-    const local = await idbAll('pins')
-    const info = this.getProviderInfo()
-    let remote: any[] = []
-    try {
-      if (this.config.provider === 'web3') {
-        const res = await fetch(info.listUrl!, { headers: { Authorization: info.authHeader || '' } })
-        if (res.ok) remote = await res.json()
-      } else {
-        const url = `${info.listUrl}?status=pinned`
-        const headers: any = {}
-        if (this.config.apiKey && this.config.secret) {
-          headers['pinata_api_key'] = this.config.apiKey
-          headers['pinata_secret_api_key'] = this.config.secret
-        } else if (this.config.apiKey) headers['Authorization'] = `Bearer ${this.config.apiKey}`
-        const res = await fetch(url, { headers })
-        if (res.ok) remote = await res.json()
-      }
-    } catch (e) {
-      // ignore remote failures
-    }
-    return { local, remote }
+    return this.client.getFileUrl(cid)
   }
 }
 

--- a/src/blockchain/services/IPFSUploader.ts
+++ b/src/blockchain/services/IPFSUploader.ts
@@ -1,0 +1,193 @@
+import { AppError } from '../../utils/AppError';
+import { ErrorCode } from '../../constants/ErrorCodes';
+import {
+  IPFSClient,
+  IPFSUploadResult,
+  MB,
+  retryWithBackoff,
+  idbPut,
+  idbAll,
+} from './IPFSClient';
+
+export class IPFSUploader {
+  private client: IPFSClient
+
+  constructor(client: IPFSClient) {
+    this.client = client
+  }
+
+  async uploadFile(
+    file: File,
+    onProgress?: (uploadedBytes: number, totalBytes: number) => void
+  ): Promise<IPFSUploadResult> {
+    const size = file.size
+    const chunkThreshold = 10 * MB
+    if (size > chunkThreshold) {
+      return this.uploadFileChunked(file, onProgress)
+    }
+    return this.uploadFileSimple(file, onProgress)
+  }
+
+  private async uploadFileSimple(file: File, _onProgress?: (a: number, b: number) => void) {
+    const info = this.client.getProviderInfo()
+    if (this.client.config.provider === 'web3') {
+      const form = new FormData()
+      form.append('file', file, file.name)
+      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers: { Authorization: info.authHeader || '' }, body: form }), 3)
+      if (!res.ok) throw new AppError(ErrorCode.ERR_NETWORK_ERROR, `Upload failed ${res.status}`)
+      const data = await res.json()
+      const cid = data.cid || (data[0] && data[0].cid) || ''
+      const gatewayUrl = this.client.getFileUrl(cid)
+      return { cid, size: file.size, gatewayUrl }
+    } else {
+      const form = new FormData()
+      form.append('file', file, file.name)
+      const headers: any = {}
+      if (this.client.config.apiKey && this.client.config.secret) {
+        headers['pinata_api_key'] = this.client.config.apiKey
+        headers['pinata_secret_api_key'] = this.client.config.secret
+      } else if (this.client.config.apiKey) {
+        headers['Authorization'] = `Bearer ${this.client.config.apiKey}`
+      }
+      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers, body: form }), 3)
+      if (!res.ok) throw new AppError(ErrorCode.ERR_NETWORK_ERROR, `Upload failed ${res.status}`)
+      const data = await res.json()
+      const cid = data.IpfsHash || data.ipfsHash || ''
+      const gatewayUrl = this.client.getFileUrl(cid)
+      return { cid, size: file.size, gatewayUrl }
+    }
+  }
+
+  private async uploadFileChunked(file: File, onProgress?: (a: number, b: number) => void) {
+    const chunkSize = 5 * MB
+    let uploaded = 0
+
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const start = uploaded
+        if (start >= file.size) {
+          controller.close()
+          return
+        }
+        const end = Math.min(start + chunkSize, file.size)
+        const blob = file.slice(start, end)
+        const arr = new Uint8Array(await blob.arrayBuffer())
+        controller.enqueue(arr)
+        uploaded = end
+        if (onProgress) onProgress(uploaded, file.size)
+      },
+    })
+
+    const info = this.client.getProviderInfo()
+    const headers: any = {}
+    if (this.client.config.provider === 'web3') {
+      if (info.authHeader) headers['Authorization'] = info.authHeader
+      headers['Content-Type'] = 'application/octet-stream'
+      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers, body: stream as any }), 3)
+      if (!res.ok) throw new AppError(ErrorCode.ERR_NETWORK_ERROR, `Upload failed ${res.status}`)
+      const data = await res.json()
+      const cid = data.cid || ''
+      return { cid, size: file.size, gatewayUrl: this.client.getFileUrl(cid) }
+    } else {
+      return this.uploadFileSimple(file, onProgress)
+    }
+  }
+
+  async uploadJSON(metadata: any): Promise<{ cid: string; uri: string }> {
+    if (typeof metadata !== 'object' || metadata === null) throw new AppError(ErrorCode.ERR_BAD_REQUEST, 'Invalid metadata')
+    const info = this.client.getProviderInfo()
+    if (this.client.config.provider === 'web3') {
+      const headers: any = { Authorization: info.authHeader || '', 'Content-Type': 'application/json' }
+      const res = await retryWithBackoff(() => fetch(info.uploadUrl!, { method: 'POST', headers, body: JSON.stringify(metadata) }), 3)
+      if (!res.ok) throw new Error('JSON upload failed')
+      const data = await res.json()
+      const cid = data.cid || ''
+      return { cid, uri: `ipfs://${cid}` }
+    } else {
+      const url = 'https://api.pinata.cloud/pinning/pinJSONToIPFS'
+      const headers: any = { 'Content-Type': 'application/json' }
+      if (this.client.config.apiKey && this.client.config.secret) {
+        headers['pinata_api_key'] = this.client.config.apiKey
+        headers['pinata_secret_api_key'] = this.client.config.secret
+      } else if (this.client.config.apiKey) {
+        headers['Authorization'] = `Bearer ${this.client.config.apiKey}`
+      }
+      const res = await retryWithBackoff(() => fetch(url, { method: 'POST', headers, body: JSON.stringify(metadata) }), 3)
+      if (!res.ok) throw new Error('JSON upload failed')
+      const data = await res.json()
+      const cid = data.IpfsHash || data.ipfsHash || ''
+      return { cid, uri: `ipfs://${cid}` }
+    }
+  }
+
+  async uploadBatch(files: File[], onProgress?: (completed: number, total: number) => void) {
+    const concurrency = 3
+    const results: IPFSUploadResult[] = []
+    let index = 0
+    let completed = 0
+
+    const runOne = async () => {
+      while (index < files.length) {
+        const i = index++
+        try {
+          const res = await this.uploadFile(files[i], (_u, _t) => {})
+          results[i] = res
+        } catch (e) {
+          results[i] = { cid: '', size: files[i].size, gatewayUrl: '' }
+        }
+        completed++
+        if (onProgress) onProgress(completed, files.length)
+      }
+    }
+
+    const workers = []
+    for (let i = 0; i < concurrency; i++) workers.push(runOne())
+    await Promise.all(workers)
+    return results
+  }
+
+  async pinFile(cid: string) {
+    const info = this.client.getProviderInfo()
+    if (this.client.config.provider === 'pinata') {
+      const url = info.pinByHashUrl!
+      const headers: any = { 'Content-Type': 'application/json' }
+      if (this.client.config.apiKey && this.client.config.secret) {
+        headers['pinata_api_key'] = this.client.config.apiKey
+        headers['pinata_secret_api_key'] = this.client.config.secret
+      } else if (this.client.config.apiKey) {
+        headers['Authorization'] = `Bearer ${this.client.config.apiKey}`
+      }
+      const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify({ hashToPin: cid }) })
+      if (!res.ok) throw new AppError(ErrorCode.ERR_TRANSACTION_FAILED, 'Pin failed')
+      await idbPut('pins', { cid, pinned: true, provider: 'pinata', updatedAt: Date.now() })
+      return true
+    } else {
+      await idbPut('pins', { cid, pinned: true, provider: 'web3', updatedAt: Date.now() })
+      return true
+    }
+  }
+
+  async getPinnedFiles() {
+    const local = await idbAll('pins')
+    const info = this.client.getProviderInfo()
+    let remote: any[] = []
+    try {
+      if (this.client.config.provider === 'web3') {
+        const res = await fetch(info.listUrl!, { headers: { Authorization: info.authHeader || '' } })
+        if (res.ok) remote = await res.json()
+      } else {
+        const url = `${info.listUrl}?status=pinned`
+        const headers: any = {}
+        if (this.client.config.apiKey && this.client.config.secret) {
+          headers['pinata_api_key'] = this.client.config.apiKey
+          headers['pinata_secret_api_key'] = this.client.config.secret
+        } else if (this.client.config.apiKey) headers['Authorization'] = `Bearer ${this.client.config.apiKey}`
+        const res = await fetch(url, { headers })
+        if (res.ok) remote = await res.json()
+      }
+    } catch (e) {
+      // ignore remote failures
+    }
+    return { local, remote }
+  }
+}


### PR DESCRIPTION
## Summary

This PR resolves four issues across tracing, export streaming, route authorization, and IPFS service architecture.

---

### #903 — Add OTEL\_DEBUG production guard

**File:** `backend/src/tracing.ts`

Added a startup check that detects `NODE_ENV=production` combined with `OTEL_DEBUG=true`. When this combination is found, the service logs a CRITICAL error explaining the performance risk (per-span I/O latency logging and verbose output) and programmatically disables debug mode before the SDK initialises. This prevents the dangerous configuration from silently degrading production performance.

---

### #902 — Fix ExportService Content-Length for streaming responses

**File:** `backend/src/services/ExportService.ts`

Removed the pre-calculated `Content-Length` header from all four streaming export methods (analytics CSV, analytics NDJSON, posts CSV, posts NDJSON) and from the shared `makeStream` helper. Replaced with `Transfer-Encoding: chunked`. The old estimate (`count * N bytes`) was unreliable because actual row sizes vary, causing some HTTP clients to truncate the response body when real data exceeded the estimate.

---

### #901 — Audit and standardise permission checks across all routes

**Files:** `backend/src/routes/*.ts`

Audited every route file for missing `authMiddleware` and `checkPermission` coverage. Applied both middlewares to all state-changing endpoints that lacked them:

| Route file | Endpoints fixed | Permission |
|---|---|---|
| `ai.ts` | `POST /analyze-image` | `posts:create` |
| `analytics.ts` | `GET /` | `analytics:view` |
| `circuitBreaker.ts` | `POST /reset`, `POST /:service/open`, `POST /:service/close` | `settings:manage` |
| `exports.ts` | `GET /analytics`, `GET /posts` | `analytics:export` |
| `facebook.ts` | `POST /post`, `POST /comment/:id/reply` | `posts:create` |
| `facebook.ts` | `DELETE /comment/:id` | `posts:delete` |
| `images.ts` | `POST /upload` | `posts:create` |
| `images.ts` | `DELETE /cache` | `settings:manage` |
| `jobs.ts` | retry, retry-all, delete, pause, resume, clear | `settings:manage` |
| `linkedin.ts` | `POST /share` | `posts:create` |
| `tiktok.ts` | `POST /video/upload`, `POST /video/upload-url` | `posts:create` |
| `translation.ts` | `POST /translate`, `POST /detect`, `POST /batch` | `posts:create` |
| `video.ts` | `POST /upload` | `posts:create` |
| `video.ts` | `DELETE /job/:jobId` | `posts:delete` |

Each route now documents its required permission in an inline comment. Webhook endpoints (TikTok, Stripe, Twitter) are intentionally excluded as they are called by external services and verified by HMAC signatures instead.

---

### #904 — Split IPFSService into focused modules

**Files:** `src/blockchain/services/`

Refactored the 16 KB `IPFSService.ts` monolith into three independently testable modules:

- **`IPFSClient.ts`** — connection management, provider config (`web3` / `pinata`), IndexedDB helpers (`openDb`, `idbPut`, `idbGet`, `idbAll`, `idbDelete`), shared utilities (`retryWithBackoff`, `timeoutSignal`, `sleep`)
- **`IPFSUploader.ts`** — file upload (simple + chunked streaming), JSON upload, concurrent batch upload, pin management, remote pin listing
- **`IPFSRetriever.ts`** — file retrieval with gateway fallback, JSON retrieval, cache store/evict/clear (LRU with pin awareness), unpin

`IPFSService.ts` is kept as a **backward-compatible facade** that composes all three modules and delegates every method call, so existing consumers require no changes.

---

## Test plan

- [ ] Verify OTEL_DEBUG warning fires at startup when `NODE_ENV=production` and `OTEL_DEBUG=true`
- [ ] Confirm export endpoints return no `Content-Length` header and stream correctly end-to-end
- [ ] Confirm protected endpoints return `403` for users without the required permission
- [ ] Confirm webhook endpoints (`/billing/webhook`, `/tiktok/webhook`, `/twitter-webhook`) remain unauthenticated
- [ ] Verify `IPFSService` public API is unchanged — existing callers work without modification

Closes #901
Closes #902
Closes #903
Closes #904