### PR TITLE
feat: resolve issues #921 #922 #923 #924

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Root npm dependencies (frontend / shared packages)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions workflow dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/backend/src/services/CohortService.ts
+++ b/backend/src/services/CohortService.ts
@@ -120,7 +120,19 @@ export class CohortService {
   /**
    * Raw SQL aggregation: joins User → OrganizationMember → Post to get
    * per-user activity counts and recency in a single query.
+   *
+   * SQL-INJECTION AUDIT (issue #922): All user-supplied values (organizationId,
+   * userId) are passed as sqltag template parameters, never via string
+   * interpolation. Prisma's sqltag sends them as prepared-statement bind
+   * variables, so they cannot alter query structure.
+   *
+   * REVIEW CHECKLIST for any future edits to this method:
+   *   - Never use `${value}` inside a plain template literal passed to $queryRaw.
+   *   - Always use sqltag`…${value}…` so Prisma parameterises the value.
+   *   - Conditional clauses must use sqltag`` fragments or `empty`, not string
+   *     concatenation.
    */
+  // sql-review: raw query — all dynamic values are sqltag-parameterised
   private async fetchActivityStats(
     organizationId?: string,
     userId?: string,

--- a/k8s/overlays/dev/limitrange.yaml
+++ b/k8s/overlays/dev/limitrange.yaml
@@ -8,8 +8,8 @@ spec:
     - type: Container
       # Applied to any container that omits requests/limits
       default:
-        cpu: 250m
-        memory: 256Mi
+        cpu: 500m
+        memory: 512Mi
       defaultRequest:
         cpu: 100m
         memory: 128Mi

--- a/k8s/overlays/prod/limitrange.yaml
+++ b/k8s/overlays/prod/limitrange.yaml
@@ -8,11 +8,11 @@ spec:
     - type: Container
       # Applied to any container that omits requests/limits
       default:
-        cpu: "1"
+        cpu: 1000m
         memory: 1Gi
       defaultRequest:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 250m
+        memory: 256Mi
       max:
         cpu: "2"
         memory: 2Gi

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -28,10 +28,26 @@ resource "aws_s3_bucket_public_access_block" "main" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "main" {
   bucket = aws_s3_bucket.main.id
+
   rule {
     id     = "expire-old-uploads"
     status = "Enabled"
     filter { prefix = "uploads/" }
     expiration { days = var.env == "prod" ? 365 : 30 }
+  }
+
+  rule {
+    id     = "backup-retention"
+    status = "Enabled"
+    filter { prefix = "backups/" }
+
+    # Remove current backup objects after 30 days
+    expiration { days = 30 }
+
+    # Remove non-current versions (after versioning overwrites) after 7 days
+    noncurrent_version_expiration { noncurrent_days = 7 }
+
+    # Clean up incomplete multipart uploads after 1 day
+    abort_incomplete_multipart_upload { days_after_initiation = 1 }
   }
 }


### PR DESCRIPTION
## Summary

Resolves four infrastructure and security issues in a single PR.

---

### #921 — S3 backup bucket lifecycle policy

Added a `backup-retention` lifecycle rule to `terraform/modules/s3/main.tf`:
- Expires current backup objects after **30 days**
- Expires non-current versions after **7 days**
- Aborts incomplete multipart uploads after **1 day**

This provides server-side cleanup independent of the backup script, so old backups are removed even when the script fails or is skipped.

---

### #922 — CohortService SQL injection audit

Audited all raw SQL in `backend/src/services/CohortService.ts`:
- Confirmed every dynamic value (`organizationId`, `userId`) is passed as a `sqltag` template parameter (prepared-statement bind variable) — no string interpolation of user input exists.
- Added a detailed audit comment and a `sql-review:` marker convention to `fetchActivityStats()` to enforce the same pattern on future edits.

---

### #923 — Kubernetes LimitRange defaults

Updated default resource requests and limits for containers that omit them:

| Overlay | CPU request | CPU limit | Memory request | Memory limit |
|---------|-------------|-----------|----------------|--------------|
| dev     | 100m        | 500m      | 128Mi          | 512Mi        |
| prod    | 250m        | 1000m     | 256Mi          | 1Gi          |

---

### #924 — Dependabot configuration

Created `.github/dependabot.yml` covering:
- `npm` at `/` (frontend/shared) — weekly
- `npm` at `/backend` — weekly
- `github-actions` at `/` — weekly

All ecosystems use `open-pull-requests-limit: 10` to avoid PR flooding.

---

## Files changed

- `terraform/modules/s3/main.tf`
- `backend/src/services/CohortService.ts`
- `k8s/overlays/dev/limitrange.yaml`
- `k8s/overlays/prod/limitrange.yaml`
- `.github/dependabot.yml`

## Tested

- Terraform: lifecycle rule syntax validated against AWS provider docs; `terraform plan` will show the new rule on next apply.
- CohortService: no runtime changes — audit is comment-only; existing tests continue to pass.
- LimitRange: YAML is valid; apply with `kubectl apply -k k8s/overlays/dev` and `kubectl apply -k k8s/overlays/prod`.
- Dependabot: will activate after merge once enabled in repository settings.

Closes #921
Closes #922
Closes #923
Closes #924