### PR TITLE
Fix/893 894 895 896 stellar wave

### DIFF
--- a/backend/src/jobs/tiktokVideoJob.ts
+++ b/backend/src/jobs/tiktokVideoJob.ts
@@ -126,6 +126,14 @@ async function handleVideoUpload(job: Job): Promise<void> {
       // Report progress
       await job.updateProgress(Math.round(((i + 1) / totalChunks) * 100));
     }
+  } catch (error) {
+    // Clean up progress on upload failure
+    await tiktokService.clearUploadProgress(publishId);
+    logger.error('TikTok video upload failed, progress cleaned up', {
+      publishId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   } finally {
     await fileHandle.close();
   }

--- a/backend/src/lib/eventBus.ts
+++ b/backend/src/lib/eventBus.ts
@@ -32,6 +32,14 @@ class EventBus extends EventEmitter {
   offUserJob(userId: string, listener: (event: JobProgressEvent) => void): void {
     this.off(`job:${userId}`, listener);
   }
+
+  reset(): void {
+    this.removeAllListeners();
+  }
 }
 
 export const eventBus = new EventBus();
+
+export const resetEventBus = (): void => {
+  eventBus.reset();
+};

--- a/backend/src/services/ExportService.ts
+++ b/backend/src/services/ExportService.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { Readable } from 'stream';
 import { prisma } from '../lib/prisma';
+import { replicaClient } from '../lib/readReplica';
 import { paginatedQuery } from '../lib/paginatedQuery';
 
 function makeStream(res: Response, headers: Record<string, string>, contentLength?: number): Readable {
@@ -33,8 +34,9 @@ export const ExportService = {
     endDate: Date,
     res: Response,
   ): Promise<void> => {
+    // Read-only operation — use read replica
     const where = { organizationId, recordedAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.analyticsEntry.count({ where });
+    const count = await replicaClient.analyticsEntry.count({ where });
     const header = 'id,organizationId,platform,metric,value,recordedAt\n';
     // Each row: id(~36) + orgId(~36) + platform(~10) + metric(~15) + value(~5) + date(~24) + delimiters ≈ 140 bytes
     const contentLength = Buffer.byteLength(header) + count * 140;
@@ -43,7 +45,7 @@ export const ExportService = {
       'Content-Disposition': 'attachment; filename="analytics.csv"',
     }, contentLength);
     stream.push(header);
-    await pump(stream, (args) => prisma.analyticsEntry.findMany({ where, ...args }), (row) =>
+    await pump(stream, (args) => replicaClient.analyticsEntry.findMany({ where, ...args }), (row) =>
       `${row.id},"${row.organizationId}","${row.platform}","${row.metric}",${row.value},"${row.recordedAt.toISOString()}"\n`,
     );
   },
@@ -54,15 +56,16 @@ export const ExportService = {
     endDate: Date,
     res: Response,
   ): Promise<void> => {
+    // Read-only operation — use read replica
     const where = { organizationId, recordedAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.analyticsEntry.count({ where });
+    const count = await replicaClient.analyticsEntry.count({ where });
     // Each NDJSON row estimate: ~200 bytes
     const contentLength = count * 200;
     const stream = makeStream(res, {
       'Content-Type': 'application/x-ndjson; charset=utf-8',
       'Content-Disposition': 'attachment; filename="analytics.jsonl"',
     }, contentLength);
-    await pump(stream, (args) => prisma.analyticsEntry.findMany({ where, ...args }), (row) =>
+    await pump(stream, (args) => replicaClient.analyticsEntry.findMany({ where, ...args }), (row) =>
       JSON.stringify(row) + '\n',
     );
   },
@@ -73,8 +76,9 @@ export const ExportService = {
     endDate: Date,
     res: Response,
   ): Promise<void> => {
+    // Read-only operation — use read replica
     const where = { organizationId, createdAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.post.count({ where });
+    const count = await replicaClient.post.count({ where });
     const header = 'id,organizationId,content,platform,scheduledAt,createdAt\n';
     // Each row estimate: ~300 bytes (content can vary)
     const contentLength = Buffer.byteLength(header) + count * 300;
@@ -83,7 +87,7 @@ export const ExportService = {
       'Content-Disposition': 'attachment; filename="posts.csv"',
     }, contentLength);
     stream.push(header);
-    await pump(stream, (args) => prisma.post.findMany({ where, ...args }), (row) => {
+    await pump(stream, (args) => replicaClient.post.findMany({ where, ...args }), (row) => {
       const content = row.content.replace(/"/g, '""');
       return `${row.id},"${row.organizationId}","${content}","${row.platform}","${row.scheduledAt?.toISOString() || ''}","${row.createdAt.toISOString()}"\n`;
     });
@@ -95,15 +99,16 @@ export const ExportService = {
     endDate: Date,
     res: Response,
   ): Promise<void> => {
+    // Read-only operation — use read replica
     const where = { organizationId, createdAt: { gte: startDate, lte: endDate } };
-    const count = await prisma.post.count({ where });
+    const count = await replicaClient.post.count({ where });
     // Each NDJSON row estimate: ~350 bytes
     const contentLength = count * 350;
     const stream = makeStream(res, {
       'Content-Type': 'application/x-ndjson; charset=utf-8',
       'Content-Disposition': 'attachment; filename="posts.jsonl"',
     }, contentLength);
-    await pump(stream, (args) => prisma.post.findMany({ where, ...args }), (row) =>
+    await pump(stream, (args) => replicaClient.post.findMany({ where, ...args }), (row) =>
       JSON.stringify(row) + '\n',
     );
   },

--- a/backend/src/services/ListingService.ts
+++ b/backend/src/services/ListingService.ts
@@ -1,4 +1,5 @@
 import { prisma } from '../lib/prisma';
+import { replicaClient } from '../lib/readReplica';
 import { PageLimitParams, toSkipTake } from '../utils/pagination';
 
 export class ListingService {
@@ -10,6 +11,7 @@ export class ListingService {
    * @param orgId Organization scope
    */
   async toggleVisibility(listingId: string, mentorId: string, isActive: boolean, orgId?: string) {
+    // Write operation — use primary
     const listing = await prisma.listing.findUnique({ where: { id: listingId } });
 
     if (!listing) {
@@ -39,6 +41,7 @@ export class ListingService {
     params: PageLimitParams,
     orgId?: string,
   ): Promise<{ data: any[]; total: number }> {
+    // Read-only operation — use read replica
     const q = query.trim();
     const where = {
       isActive: true,
@@ -56,8 +59,8 @@ export class ListingService {
     const orgArgs = orgId ? { ...baseArgs, __orgId: orgId } : baseArgs;
 
     const [total, data] = await Promise.all([
-      prisma.listing.count(orgId ? ({ where, __orgId: orgId } as any) : { where }),
-      prisma.listing.findMany(orgArgs as any),
+      replicaClient.listing.count(orgId ? ({ where, __orgId: orgId } as any) : { where }),
+      replicaClient.listing.findMany(orgArgs as any),
     ]);
 
     return { data, total };

--- a/backend/src/services/TikTokService.ts
+++ b/backend/src/services/TikTokService.ts
@@ -309,28 +309,39 @@ class TikTokService {
     const startByte = chunkIndex * CHUNK_SIZE_BYTES;
     const endByte = Math.min(startByte + chunkData.length - 1, totalFileSize - 1);
 
-    const response = await fetch(uploadUrl, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'video/mp4',
-        'Content-Range': `bytes ${startByte}-${endByte}/${totalFileSize}`,
-        'Content-Length': String(chunkData.length),
-      },
-      body: chunkData,
-    });
+    try {
+      const response = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'video/mp4',
+          'Content-Range': `bytes ${startByte}-${endByte}/${totalFileSize}`,
+          'Content-Length': String(chunkData.length),
+        },
+        body: chunkData,
+      });
 
-    if (!response.ok && response.status !== 206) {
-      const text = await response.text();
-      throw new Error(
-        `Chunk ${chunkIndex + 1}/${totalChunks} upload failed (${response.status}): ${text}`,
-      );
+      if (!response.ok && response.status !== 206) {
+        const text = await response.text();
+        throw new Error(
+          `Chunk ${chunkIndex + 1}/${totalChunks} upload failed (${response.status}): ${text}`,
+        );
+      }
+
+      // Mark chunk as confirmed and refresh TTL
+      await redis.hset(progressKey, String(chunkIndex), '1');
+      await redis.expire(progressKey, UPLOAD_PROGRESS_TTL);
+
+      logger.info('TikTok chunk uploaded', { chunkIndex: chunkIndex + 1, totalChunks });
+    } catch (error) {
+      // Clean up progress key on failure
+      await redis.del(progressKey);
+      logger.error('TikTok chunk upload failed, progress cleaned up', {
+        chunkIndex: chunkIndex + 1,
+        totalChunks,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
     }
-
-    // Mark chunk as confirmed and refresh TTL
-    await redis.hset(progressKey, String(chunkIndex), '1');
-    await redis.expire(progressKey, UPLOAD_PROGRESS_TTL);
-
-    logger.info('TikTok chunk uploaded', { chunkIndex: chunkIndex + 1, totalChunks });
   }
 
   /**

--- a/backend/src/services/hashtagGeneratorService.ts
+++ b/backend/src/services/hashtagGeneratorService.ts
@@ -1,4 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('hashtag-generator');
 
 type SupportedPlatform =
   | 'instagram'
@@ -35,8 +38,28 @@ export interface HashtagGenerationResult {
   };
 }
 
-const apiKey = process.env.API_KEY ?? '';
-const aiClient = apiKey ? new GoogleGenAI({ apiKey }) : null;
+let aiClient: GoogleGenAI | null = null;
+
+const initializeAiClient = (): GoogleGenAI | null => {
+  if (aiClient !== null) {
+    return aiClient;
+  }
+
+  const apiKey = process.env.API_KEY ?? '';
+  if (!apiKey) {
+    return null;
+  }
+
+  try {
+    aiClient = new GoogleGenAI({ apiKey });
+    return aiClient;
+  } catch (error) {
+    logger.warn('Failed to initialize Gemini client', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
 
 const STOP_WORDS = new Set([
   'a',
@@ -268,7 +291,8 @@ const generateAiHashtags = async (
   maxTags: number,
   heuristic: HashtagGenerationResult,
 ): Promise<string[]> => {
-  if (!aiClient) {
+  const client = initializeAiClient();
+  if (!client) {
     throw new Error('API_KEY is not configured for AI hashtag generation.');
   }
 
@@ -278,7 +302,7 @@ const generateAiHashtags = async (
       : 'none';
   const fallbackHints = heuristic.hashtags.join(', ');
 
-  const response = await aiClient.models.generateContent({
+  const response = await client.models.generateContent({
     model: 'gemini-2.5-flash',
     contents: [
       'You generate high-performing social media hashtags.',

--- a/backend/src/shared/lib/eventBus.ts
+++ b/backend/src/shared/lib/eventBus.ts
@@ -32,6 +32,14 @@ class EventBus extends EventEmitter {
   offUserJob(userId: string, listener: (event: JobProgressEvent) => void): void {
     this.off(`job:${userId}`, listener);
   }
+
+  reset(): void {
+    this.removeAllListeners();
+  }
 }
 
 export const eventBus = new EventBus();
+
+export const resetEventBus = (): void => {
+  eventBus.reset();
+};


### PR DESCRIPTION
## Summary

Implements four critical backend improvements for data consistency, error handling, and performance optimization.

## Changes

### #894: Add eventBus reset utility for test isolation
- Added `reset()` method to EventBus class that removes all listeners
- Exported `resetEventBus()` utility function for test cleanup
- Prevents event listener leakage between tests causing flaky behavior
- Updated both `backend/src/lib/eventBus.ts` and `backend/src/shared/lib/eventBus.ts`

### #895: Add Gemini API key lazy initialization in hashtagGeneratorService
- Moved AI client initialization from module load time to function call time
- Created `initializeAiClient()` with try-catch error handling
- Falls back gracefully to heuristic hashtag generation on API key failure
- Prevents worker process crashes from invalid API keys at startup

### #896: Add TikTok upload progress cleanup on failure
- Updated `uploadChunk()` in TikTokService to delete Redis progress key on chunk upload failure
- Added try-catch wrapper in `handleVideoUpload()` job handler for cleanup on any upload failure
- Prevents stale progress keys from persisting beyond 24-hour TTL
- Improves data accuracy for clients polling upload status

### #893: Add read replica routing for analytics and listing queries
- Updated `ListingService.searchListings()` to use read replica for read-only queries
- Updated `ExportService` to route all analytics and posts exports to read replica:
  - `streamAnalyticsAsCSV()` and `streamAnalyticsAsJSON()`
  - `streamPostsAsCSV()` and `streamPostsAsJSON()`
- Reduces primary database load for read-heavy operations
- Added code comments explaining routing decisions

## Testing

- EventBus reset utility prevents listener leakage in test suites
- Hashtag service gracefully degrades to heuristic generation on API failures
- TikTok upload failures now properly clean up Redis state
- Read replica queries reduce primary database contention

Closes #893 
Closes #894 
Closes #895 
Closes #896