### PR TITLE
fix: resolve issues #859 #860 #861 #862

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ lerna-debug.log*
 
 # Dependencies
 node_modules/
-package-lock.json/
 
 # Build outputs
 dist
@@ -17,9 +16,11 @@ dist-ssr
 dist-electron
 out
 release
+*.tsbuildinfo
 
 # Environment files
 *.local
+.env
 .env.local
 .env.*.local
 
@@ -29,9 +30,11 @@ test-accounts.json
 # Coverage reports
 coverage
 .nyc_output
+*.lcov
 
 # Test results
 test-results
+junit.xml
 
 # Test snapshots
 **/__snapshots__/
@@ -51,10 +54,6 @@ test-results
 # Project Tracking
 tasks.md
 task.md
-# Test coverage
-coverage
-.nyc_output
-*.lcov
 
 # Prisma
 prisma/dev.db
@@ -63,3 +62,6 @@ prisma/dev.db-journal
 # Uploads
 uploads/
 backend/uploads/
+
+# OS
+Thumbs.db

--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -26,6 +26,17 @@ async function requireAuth(ctx: GraphQLContext): Promise<string> {
   return ctx.userId;
 }
 
+/**
+ * Require the authenticated user to have the 'admin' role.
+ * Throws FORBIDDEN if the user is authenticated but not an admin.
+ */
+async function requireAdmin(ctx: GraphQLContext): Promise<string> {
+  const userId = await requireAuth(ctx);
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
+  if (user?.role !== 'admin') throw new Error('FORBIDDEN');
+  return userId;
+}
+
 export const resolvers = {
   DateTime: DateTimeScalar,
 
@@ -36,9 +47,9 @@ export const resolvers = {
       return prisma.user.findUnique({ where: { id: userId } });
     },
 
-    /** Return a single user by ID. */
+    /** Return a single user by ID (admin only). */
     user: async (_: unknown, { id }: { id: string }, ctx: GraphQLContext) => {
-      await requireAuth(ctx);
+      await requireAdmin(ctx);
       return prisma.user.findUnique({ where: { id } });
     },
 
@@ -59,6 +70,25 @@ export const resolvers = {
     post: async (_: unknown, { id }: { id: string }, ctx: GraphQLContext) => {
       await requireAuth(ctx);
       return prisma.post.findUnique({ where: { id } });
+    },
+  },
+
+  /**
+   * Field-level authorization for User.
+   * email and role are sensitive — only the owner or an admin may read them.
+   */
+  User: {
+    email: async (parent: { id: string; email: string }, _: unknown, ctx: GraphQLContext) => {
+      const userId = await requireAuth(ctx);
+      const viewer = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
+      if (userId !== parent.id && viewer?.role !== 'admin') throw new Error('FORBIDDEN');
+      return parent.email;
+    },
+    role: async (parent: { id: string; role: string }, _: unknown, ctx: GraphQLContext) => {
+      const userId = await requireAuth(ctx);
+      const viewer = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
+      if (userId !== parent.id && viewer?.role !== 'admin') throw new Error('FORBIDDEN');
+      return parent.role;
     },
   },
 

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -16,9 +16,16 @@ async function buildStore() {
     const { default: Redis } = await import('ioredis');
     const client = new Redis(getRedisConnection());
     return new RedisStore({ sendCommand: (...args: string[]) => (client as any).call(...args) });
-  } catch {
-    // If rate-limit-redis isn't installed or Redis is unreachable, fall back to memory store.
-    // The default MemoryStore is used; capture it after limiter creation via the store option.
+  } catch (err) {
+    // In production, a missing Redis store is a fatal misconfiguration —
+    // falling back to in-memory would multiply the effective rate limit by
+    // the replica count, undermining security guarantees.
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        `[rateLimit] Redis store unavailable in production: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    // In development/test, fall back to the default in-memory MemoryStore.
     return undefined;
   }
 }

--- a/backend/src/services/CircuitBreakerService.ts
+++ b/backend/src/services/CircuitBreakerService.ts
@@ -7,8 +7,10 @@ import {
   FALLBACK_STRATEGIES,
 } from '../config/circuitBreaker.config';
 import { createLogger } from '../lib/logger';
+import { createNotificationManager } from './notificationProvider';
 
 const logger = createLogger('circuit-breaker');
+const notificationManager = createNotificationManager();
 
 /**
  * Circuit Breaker State
@@ -184,6 +186,14 @@ class CircuitBreakerService {
   private setupEventListeners(breaker: CircuitBreaker, serviceName: string): void {
     breaker.on('open', () => {
       logger.warn(`Circuit breaker OPENED for ${serviceName}`);
+      notificationManager.sendAlert({
+        severity: 'critical',
+        service: serviceName,
+        message: `Circuit breaker opened for ${serviceName} — requests are being rejected`,
+        timestamp: new Date().toISOString(),
+      }).catch((err) => {
+        logger.error(`Failed to send circuit breaker open alert for ${serviceName}: ${err instanceof Error ? err.message : String(err)}`);
+      });
     });
 
     breaker.on('halfOpen', () => {

--- a/src/components/CreatePostWithReachAnalysis.tsx
+++ b/src/components/CreatePostWithReachAnalysis.tsx
@@ -12,6 +12,14 @@ const PLATFORM_CHAR_LIMITS: Record<Platform, number> = {
   [Platform.INSTAGRAM]: 2200,
 };
 
+// Per-platform file size limits in bytes (image / video)
+const PLATFORM_FILE_SIZE_LIMITS: Record<Platform, { image: number; video: number }> = {
+  [Platform.TWITTER]:   { image: 5 * 1024 * 1024,   video: 512 * 1024 * 1024 },
+  [Platform.LINKEDIN]:  { image: 10 * 1024 * 1024,  video: 200 * 1024 * 1024 },
+  [Platform.FACEBOOK]:  { image: 10 * 1024 * 1024,  video: 4 * 1024 * 1024 * 1024 },
+  [Platform.INSTAGRAM]: { image: 8 * 1024 * 1024,   video: 100 * 1024 * 1024 },
+};
+
 const MaterialIcon = ({ name, className }: { name: string, className?: string }) => (
   <span className={`material-symbols-outlined ${className}`}>{name}</span>
 );
@@ -24,6 +32,32 @@ export const CreatePostWithReachAnalysis: React.FC<ViewProps> = ({ onNavigate })
   const [scheduleDate, setScheduleDate] = useState('');
   const [scheduleTime, setScheduleTime] = useState('10:00');
   const [showReachAnalysis, setShowReachAnalysis] = useState(true);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileSizeErrors, setFileSizeErrors] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setSelectedFile(file);
+    setFileSizeErrors([]);
+
+    if (!file) return;
+
+    const fileKind = file.type.startsWith('video/') ? 'video' : 'image';
+    const errors: string[] = [];
+
+    for (const platform of selectedPlatforms) {
+      const limit = PLATFORM_FILE_SIZE_LIMITS[platform]?.[fileKind];
+      if (limit !== undefined && file.size > limit) {
+        const limitMB = (limit / (1024 * 1024)).toFixed(0);
+        errors.push(
+          `${platform}: ${fileKind} exceeds the ${limitMB} MB limit (${(file.size / (1024 * 1024)).toFixed(1)} MB)`,
+        );
+      }
+    }
+
+    setFileSizeErrors(errors);
+  };
 
   // Extract hashtags from caption
   useEffect(() => {
@@ -143,6 +177,32 @@ export const CreatePostWithReachAnalysis: React.FC<ViewProps> = ({ onNavigate })
             </div>
           </Card>
 
+          {/* Media Upload */}
+          {(mediaType === 'image' || mediaType === 'video' || mediaType === 'carousel') && (
+            <Card>
+              <h3 className="text-sm font-medium text-gray-subtext mb-3">Upload Media</h3>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={mediaType === 'video' ? 'video/*' : 'image/*'}
+                onChange={handleFileChange}
+                className="block w-full text-sm text-gray-subtext file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-medium file:bg-primary-blue file:text-white hover:file:bg-blue-700 cursor-pointer"
+              />
+              {selectedFile && fileSizeErrors.length === 0 && (
+                <p className="mt-2 text-xs text-green-400">
+                  {selectedFile.name} ({(selectedFile.size / (1024 * 1024)).toFixed(1)} MB) — within limits for all selected platforms
+                </p>
+              )}
+              {fileSizeErrors.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {fileSizeErrors.map((err) => (
+                    <li key={err} className="text-xs text-red-400">{err}</li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+          )}
+
           {/* Caption */}
           <Card>
             <h3 className="text-lg font-semibold text-white mb-4">Caption</h3>
@@ -219,10 +279,14 @@ export const CreatePostWithReachAnalysis: React.FC<ViewProps> = ({ onNavigate })
           </Card>
 
           <button 
-            disabled={isOverLimit}
+            disabled={isOverLimit || fileSizeErrors.length > 0}
             className="w-full bg-primary-blue text-white px-6 py-3 rounded-2xl text-sm font-medium hover:bg-blue-700 shadow-lg shadow-blue-500/20 transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary-blue"
           >
-            {isOverLimit ? `Over character limit (${overLimitPlatforms.map(p => p.platform).join(', ')})` : 'Schedule Post'}
+            {isOverLimit
+              ? `Over character limit (${overLimitPlatforms.map(p => p.platform).join(', ')})`
+              : fileSizeErrors.length > 0
+              ? 'File exceeds platform size limit'
+              : 'Schedule Post'}
           </button>
         </div>
 


### PR DESCRIPTION
#859 - Add field-level authorization in GraphQL resolvers
- Add requireAdmin() helper; user query is now admin-only
- Add User field resolvers protecting email and role from non-owners/non-admins

#860 - Fix rate limiter to fail hard when Redis unavailable in production
- buildStore now throws in production instead of silently falling back to in-memory store

#861 - Add circuit breaker open alerting
- Import NotificationManager in CircuitBreakerService
- Send critical alert via notificationManager.sendAlert() when circuit opens

#862 - Add client-side file size validation to post creation
- Add PLATFORM_FILE_SIZE_LIMITS per platform (image + video)
- Add file input with handleFileChange validation
- Show per-platform errors; disable submit button on violations
chore: clean up .gitignore
- Remove duplicate coverage entries and package-lock.json/ typo
- Add .env, *.tsbuildinfo, junit.xml, Thumbs.db
Closes #859 
closes #860 
closes #861 
closes #862 