### PR TITLE
fix: resolve issues  StellarService.initializePool now uses distinct Horizon URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,10 @@ dist-ssr
 dist-electron
 out
 release
+*.tsbuildinfo
 
 # Environment files
+.env
 *.local
 .env.local
 .env.*.local
@@ -29,9 +31,11 @@ test-accounts.json
 # Coverage reports
 coverage
 .nyc_output
+*.lcov
 
 # Test results
 test-results
+junit.xml
 
 # Test snapshots
 **/__snapshots__/
@@ -47,14 +51,11 @@ test-results
 *.njsproj
 *.sln
 *.sw?
+Thumbs.db
 
 # Project Tracking
 tasks.md
 task.md
-# Test coverage
-coverage
-.nyc_output
-*.lcov
 
 # Prisma
 prisma/dev.db
@@ -63,3 +64,13 @@ prisma/dev.db-journal
 # Uploads
 uploads/
 backend/uploads/
+
+# OS
+.DS_Store
+desktop.ini
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.bak

--- a/backend/src/__tests__/twitterPkce.test.ts
+++ b/backend/src/__tests__/twitterPkce.test.ts
@@ -37,6 +37,7 @@ import { twitterService } from '../services/TwitterService';
 
 const CLIENT_ID = 'client-123';
 const REDIRECT_URI = 'https://app.example.com/callback';
+const USER_ID = 'user-test-1';
 
 function makeChallenge(verifier: string): string {
   return crypto.createHash('sha256').update(verifier).digest('base64url');
@@ -52,14 +53,14 @@ describe('TwitterService.exchangeCodeForTokens — PKCE verification', () => {
     const challenge = makeChallenge(verifier);
     const state = 'state-abc';
 
-    await twitterService.storePkceChallenge(state, challenge);
+    await twitterService.storePkceChallenge(state, challenge, USER_ID);
 
     nock('https://api.twitter.com')
       .post('/2/oauth2/token')
       .reply(200, { access_token: 'at', refresh_token: 'rt', expires_in: 7200 });
 
     const tokens = await twitterService.exchangeCodeForTokens(
-      'auth-code', state, verifier, CLIENT_ID, REDIRECT_URI,
+      'auth-code', state, verifier, CLIENT_ID, REDIRECT_URI, USER_ID,
     );
 
     expect(tokens.accessToken).toBe('at');
@@ -69,11 +70,11 @@ describe('TwitterService.exchangeCodeForTokens — PKCE verification', () => {
 
   it('throws when code_verifier does not match stored challenge', async () => {
     const state = 'state-xyz';
-    await twitterService.storePkceChallenge(state, makeChallenge('correct-verifier-padded-here'));
+    await twitterService.storePkceChallenge(state, makeChallenge('correct-verifier-padded-here'), USER_ID);
 
     await expect(
       twitterService.exchangeCodeForTokens(
-        'auth-code', state, 'wrong-verifier-padded-here!!', CLIENT_ID, REDIRECT_URI,
+        'auth-code', state, 'wrong-verifier-padded-here!!', CLIENT_ID, REDIRECT_URI, USER_ID,
       ),
     ).rejects.toThrow('PKCE verification failed');
   });
@@ -81,7 +82,7 @@ describe('TwitterService.exchangeCodeForTokens — PKCE verification', () => {
   it('throws when no challenge is stored for the given state', async () => {
     await expect(
       twitterService.exchangeCodeForTokens(
-        'auth-code', 'unknown-state', 'any-verifier', CLIENT_ID, REDIRECT_URI,
+        'auth-code', 'unknown-state', 'any-verifier', CLIENT_ID, REDIRECT_URI, USER_ID,
       ),
     ).rejects.toThrow('PKCE challenge not found or expired');
   });
@@ -89,17 +90,17 @@ describe('TwitterService.exchangeCodeForTokens — PKCE verification', () => {
   it('consumes the challenge (one-time use)', async () => {
     const verifier = 'b'.repeat(43);
     const state = 'state-once';
-    await twitterService.storePkceChallenge(state, makeChallenge(verifier));
+    await twitterService.storePkceChallenge(state, makeChallenge(verifier), USER_ID);
 
     nock('https://api.twitter.com')
       .post('/2/oauth2/token')
       .reply(200, { access_token: 'at2', refresh_token: 'rt2', expires_in: 3600 });
 
-    await twitterService.exchangeCodeForTokens('code', state, verifier, CLIENT_ID, REDIRECT_URI);
+    await twitterService.exchangeCodeForTokens('code', state, verifier, CLIENT_ID, REDIRECT_URI, USER_ID);
 
     // Second attempt with same state must fail
     await expect(
-      twitterService.exchangeCodeForTokens('code', state, verifier, CLIENT_ID, REDIRECT_URI),
+      twitterService.exchangeCodeForTokens('code', state, verifier, CLIENT_ID, REDIRECT_URI, USER_ID),
     ).rejects.toThrow('PKCE challenge not found or expired');
   });
 });

--- a/backend/src/services/TwitterService.ts
+++ b/backend/src/services/TwitterService.ts
@@ -247,15 +247,18 @@ export class TwitterService {
   // ─── PKCE helpers ──────────────────────────────────────────────────────────
 
   /**
-   * Store a PKCE code_challenge keyed by state, to be verified on callback.
+   * Store a PKCE code_challenge keyed by both state and userId so the
+   * challenge is bound to the initiating user's session, preventing OAuth
+   * flow hijacking by a different user reusing the same state value.
    */
-  public async storePkceChallenge(state: string, codeChallenge: string): Promise<void> {
-    await getRedis().set(`${PKCE_CHALLENGE_PREFIX}${state}`, codeChallenge, 'EX', PKCE_TTL_SECONDS);
+  public async storePkceChallenge(state: string, codeChallenge: string, userId: string): Promise<void> {
+    const key = `${PKCE_CHALLENGE_PREFIX}${userId}:${state}`;
+    await getRedis().set(key, codeChallenge, 'EX', PKCE_TTL_SECONDS);
   }
 
   /**
    * Exchange an authorisation code for tokens, verifying the PKCE code_verifier
-   * against the stored code_challenge for the given state.
+   * against the stored code_challenge for the given state and userId.
    *
    * Throws if the verifier is missing, the challenge is not found, or they do not match.
    */
@@ -265,10 +268,11 @@ export class TwitterService {
     codeVerifier: string,
     clientId: string,
     redirectUri: string,
+    userId: string,
   ): Promise<{ accessToken: string; refreshToken: string; expiresAt: number }> {
     // Retrieve and immediately delete the stored challenge (one-time use)
     const redis = getRedis();
-    const key = `${PKCE_CHALLENGE_PREFIX}${state}`;
+    const key = `${PKCE_CHALLENGE_PREFIX}${userId}:${state}`;
     const storedChallenge = await redis.getdel(key);
 
     if (!storedChallenge) {

--- a/src/blockchain/services/OfflineQueue.ts
+++ b/src/blockchain/services/OfflineQueue.ts
@@ -12,20 +12,28 @@ interface QueuedTransaction {
 export class OfflineQueue {
   private readonly QUEUE_KEY = 'stellar:offline:queue';
   private readonly QUEUE_TTL = 7 * 24 * 60 * 60; // 7 days in seconds
+  private readonly MAX_QUEUE_SIZE: number;
   private redis: any;
   private inMemoryQueue: QueuedTransaction[] = [];
 
-  constructor(redisClient?: any) {
+  constructor(redisClient?: any, maxQueueSize = 1000) {
     this.redis = redisClient;
+    this.MAX_QUEUE_SIZE = maxQueueSize;
     if (!this.redis) {
       console.warn('OfflineQueue: Redis client not provided, using in-memory storage only');
     }
   }
 
   /**
-   * Queue a transaction for offline submission
+   * Queue a transaction for offline submission.
+   * Throws if the queue has reached MAX_QUEUE_SIZE.
    */
   async queueTransaction(xdr: string): Promise<string> {
+    const currentSize = await this.getQueueSize();
+    if (currentSize >= this.MAX_QUEUE_SIZE) {
+      throw new Error(`Offline queue is full (max ${this.MAX_QUEUE_SIZE} transactions)`);
+    }
+
     const id = `tx_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
     const transaction: QueuedTransaction = {
       id,

--- a/src/blockchain/services/StellarService.ts
+++ b/src/blockchain/services/StellarService.ts
@@ -2,7 +2,7 @@
 import StellarSdk from '@stellar/stellar-sdk';
 const { Server, TransactionBuilder, Asset, Operation, Transaction, FeeBumpTransaction } = StellarSdk;
 import { NetworkConfig, DEFAULT_NETWORK } from '../config/networks';
-import { OfflineQueue } from './OfflineQueue.ts';
+import { OfflineQueue } from './OfflineQueue';
 import { AppError } from '../../utils/AppError';
 import { ErrorCode } from '../../constants/ErrorCodes';
 
@@ -31,8 +31,20 @@ export class StellarService {
   }
 
   // --- 2.2 Connection Management ---
+  // Fallback Horizon endpoints provide real redundancy; primary URL is always first.
+  private static readonly FALLBACK_HORIZON_URLS = [
+    'https://horizon.stellar.org',
+    'https://horizon-testnet.stellar.org',
+    'https://horizon-futurenet.stellar.org',
+  ];
+
   private initializePool(horizonUrl: string): typeof Server[] {
-    return [new Server(horizonUrl), new Server(horizonUrl), new Server(horizonUrl)];
+    // Build a deduplicated list: primary URL first, then distinct fallbacks.
+    const urls = [
+      horizonUrl,
+      ...StellarService.FALLBACK_HORIZON_URLS.filter((u) => u !== horizonUrl),
+    ].slice(0, 3);
+    return urls.map((u) => new Server(u));
   }
 
   private getServer(): typeof Server {


### PR DESCRIPTION
#855 - StellarService.initializePool now uses distinct Horizon URLs
       (primary + fallback endpoints) instead of three identical instances
#856 - Remove .ts extension from OfflineQueue import in StellarService #857 - Add MAX_QUEUE_SIZE limit to OfflineQueue; queueTransaction throws
       when the limit is reached to prevent unbounded Redis growth
#858 - Bind Twitter PKCE state to userId in Redis key so challenges are
       scoped per-user, preventing OAuth flow hijacking; update test
       signatures accordingly
closes #855 
closes #856 
closes #857 
closes #858 