### PR TITLE
fix: resolve issues  migrate all req.userId usages to req.user.id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,11 @@ dist-ssr
 dist-electron
 out
 release
+*.tsbuildinfo
 
 # Environment files
+.env
+.env.*
 *.local
 .env.local
 .env.*.local
@@ -29,9 +32,11 @@ test-accounts.json
 # Coverage reports
 coverage
 .nyc_output
+*.lcov
 
 # Test results
 test-results
+junit.xml
 
 # Test snapshots
 **/__snapshots__/
@@ -51,10 +56,6 @@ test-results
 # Project Tracking
 tasks.md
 task.md
-# Test coverage
-coverage
-.nyc_output
-*.lcov
 
 # Prisma
 prisma/dev.db
@@ -63,3 +64,17 @@ prisma/dev.db-journal
 # Uploads
 uploads/
 backend/uploads/
+
+# Terraform state and local overrides
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform/
+.terraform.lock.hcl
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.bak

--- a/backend/src/__tests__/adminRoutes.test.ts
+++ b/backend/src/__tests__/adminRoutes.test.ts
@@ -7,8 +7,7 @@ import express from 'express';
 // Mock authenticate to inject a user id
 jest.mock('../middleware/authenticate', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.userId = req.headers['x-test-user-id'] || 'anon';
-    req.user = { id: req.userId };
+    req.user = { id: req.headers['x-test-user-id'] || 'anon' };
     next();
   },
 }));

--- a/backend/src/__tests__/authenticate.test.ts
+++ b/backend/src/__tests__/authenticate.test.ts
@@ -142,7 +142,7 @@ describe('#616 edge cases', () => {
     expect(AuthBlacklistService.isBlacklisted).not.toHaveBeenCalled();
   });
 
-  it('sets req.user and req.userId for a valid, non-blacklisted token', async () => {
+  it('sets req.user for a valid, non-blacklisted token', async () => {
     const validToken = jwt.sign({ sub: 'user-6' }, SECRET, { expiresIn: '15m' });
 
     const req = makeReq(validToken);
@@ -151,7 +151,6 @@ describe('#616 edge cases', () => {
     await authenticate(req, res, next);
 
     expect(req.user).toEqual({ id: 'user-6' });
-    expect(req.userId).toBe('user-6');
     expect(next).toHaveBeenCalled();
   });
 });

--- a/backend/src/controllers/organization.ts
+++ b/backend/src/controllers/organization.ts
@@ -21,14 +21,14 @@ export async function createOrganization(req: AuthRequest, res: Response): Promi
       name,
       slug,
       members: {
-        create: { id: randomUUID(), userId: req.userId!, role: 'owner' },
+        create: { id: randomUUID(), userId: req.user!.id, role: 'owner' },
       },
     },
     include: { members: true },
   });
 
   // Invalidate the caller's org list cache
-  await invalidateCachePattern(`org-list:${req.userId!}:*`);
+  await invalidateCachePattern(`org-list:${req.user!.id}:*`);
 
   res.status(201).json(org);
 }
@@ -36,7 +36,7 @@ export async function createOrganization(req: AuthRequest, res: Response): Promi
 /** GET /api/organizations — list orgs the caller belongs to */
 export async function listOrganizations(req: AuthRequest, res: Response): Promise<void> {
   const params = parsePageLimit(req);
-  const userId = req.userId!;
+  const userId = req.user!.id;
   const cacheKey = `org-list:${userId}:${params.page}:${params.limit}`;
 
   const result = await withCache(cacheKey, CacheTTL.ORG_LIST, async () => {
@@ -63,9 +63,9 @@ export async function listOrganizations(req: AuthRequest, res: Response): Promis
 export async function getOrganization(req: AuthRequest, res: Response): Promise<void> {
   const { orgId } = req.params;
 
-  const membership = await withCache(`org:${orgId}:${req.userId}`, CacheTTL.ORG, () =>
+  const membership = await withCache(`org:${orgId}:${req.user!.id}`, CacheTTL.ORG, () =>
     prisma.organizationMember.findUnique({
-      where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+      where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
       include: {
         organization: {
           include: { members: { include: { user: { select: { id: true, email: true } } } } },
@@ -89,7 +89,7 @@ export async function addMember(req: AuthRequest, res: Response): Promise<void> 
 
   // Only owner/admin can invite
   const callerMembership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
   });
   if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
     res.status(403).json({ message: 'Insufficient permissions' });
@@ -114,7 +114,7 @@ export async function removeMember(req: AuthRequest, res: Response): Promise<voi
   const { orgId, userId } = req.params;
 
   const callerMembership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
   });
   if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
     res.status(403).json({ message: 'Insufficient permissions' });
@@ -139,7 +139,7 @@ export async function switchOrganization(req: AuthRequest, res: Response): Promi
   const { orgId } = req.body as { orgId: string };
 
   const membership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
     include: { organization: true },
   });
 

--- a/backend/src/controllers/tts.ts
+++ b/backend/src/controllers/tts.ts
@@ -10,7 +10,7 @@ export async function createTTSJob(req: AuthRequest, res: Response, next: NextFu
     const body = req.body as CreateTTSJobInput;
     const jobId = await ttsService.createJob({
       ...body,
-      userId: req.userId,
+      userId: req.user?.id,
     });
     res.status(202).json({ jobId, status: 'pending' });
   } catch (err) {

--- a/backend/src/controllers/webhooks.ts
+++ b/backend/src/controllers/webhooks.ts
@@ -11,7 +11,7 @@ import { parsePageLimit, toSkipTake, buildPageResponse } from '../utils/paginati
 export async function listWebhooks(req: AuthRequest, res: Response, next: NextFunction) {
   try {
     const params = parsePageLimit(req);
-    const where = { userId: req.userId! };
+    const where = { userId: req.user!.id };
     const select = {
       id: true,
       url: true,
@@ -45,7 +45,7 @@ export async function createWebhook(req: AuthRequest, res: Response, next: NextF
     const hashedSecret = crypto.createHash('sha256').update(secret).digest('hex');
 
     const sub = await prisma.webhookSubscription.create({
-      data: { userId: req.userId!, url, secret: hashedSecret, events },
+      data: { userId: req.user!.id, url, secret: hashedSecret, events },
       select: { id: true, url: true, events: true, isActive: true, createdAt: true },
     });
 
@@ -59,7 +59,7 @@ export async function createWebhook(req: AuthRequest, res: Response, next: NextF
 // ── Get single subscription ───────────────────────────────────────────────────
 export async function getWebhook(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    const sub = await findOwned(req.params.id, req.userId!);
+    const sub = await findOwned(req.params.id, req.user!.id);
     res.json({
       id: sub.id,
       url: sub.url,
@@ -76,7 +76,7 @@ export async function getWebhook(req: AuthRequest, res: Response, next: NextFunc
 // ── Update subscription ───────────────────────────────────────────────────────
 export async function updateWebhook(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    await findOwned(req.params.id, req.userId!);
+    await findOwned(req.params.id, req.user!.id);
     const body = req.body as UpdateWebhookInput;
 
     const data: Record<string, unknown> = {};
@@ -101,7 +101,7 @@ export async function updateWebhook(req: AuthRequest, res: Response, next: NextF
 // ── Delete subscription ───────────────────────────────────────────────────────
 export async function deleteWebhook(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    await findOwned(req.params.id, req.userId!);
+    await findOwned(req.params.id, req.user!.id);
     await prisma.webhookSubscription.delete({ where: { id: req.params.id } });
     res.status(204).send();
   } catch (err) {
@@ -112,7 +112,7 @@ export async function deleteWebhook(req: AuthRequest, res: Response, next: NextF
 // ── Test delivery ─────────────────────────────────────────────────────────────
 export async function testWebhook(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    const sub = await findOwned(req.params.id, req.userId!);
+    const sub = await findOwned(req.params.id, req.user!.id);
     const { eventType } = req.body;
 
     if (!sub.events.includes(eventType)) {
@@ -122,7 +122,7 @@ export async function testWebhook(req: AuthRequest, res: Response, next: NextFun
 
     await dispatchEvent(
       eventType as any,
-      { test: true, triggeredBy: req.userId },
+      { test: true, triggeredBy: req.user!.id },
       'socialflow-test',
     );
     res.json({ message: 'Test event dispatched' });
@@ -134,7 +134,7 @@ export async function testWebhook(req: AuthRequest, res: Response, next: NextFun
 // ── Delivery history ──────────────────────────────────────────────────────────
 export async function listDeliveries(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    await findOwned(req.params.id, req.userId!);
+    await findOwned(req.params.id, req.user!.id);
     const params = parsePageLimit(req);
     const where = { subscriptionId: req.params.id };
     const select = {
@@ -172,7 +172,7 @@ export async function replayDelivery(req: AuthRequest, res: Response, next: Next
       include: { subscription: true },
     });
     if (!delivery) throw new NotFoundError('Delivery not found');
-    if (delivery.subscription.userId !== req.userId) throw new ForbiddenError();
+    if (delivery.subscription.userId !== req.user!.id) throw new ForbiddenError();
 
     // Reset to pending and re-attempt immediately
     await prisma.webhookDelivery.update({

--- a/backend/src/middleware/audit.ts
+++ b/backend/src/middleware/audit.ts
@@ -6,7 +6,7 @@ import { redactSensitiveFields } from '../utils/redactSensitiveFields';
 
 /**
  * Middleware factory that records an audit log entry after the response is sent.
- * Must be used after `authMiddleware` (requires req.userId).
+ * Must be used after `authMiddleware` (requires req.user.id).
  *
  * Sensitive fields (password, token, cardNumber, cvv, secret) are automatically
  * redacted from any metadata before it is written to the audit log.
@@ -29,7 +29,7 @@ export function audit(
       if (res.statusCode >= 200 && res.statusCode < 300) {
         const rawMetadata = metadata?.(req);
         auditLogger.log({
-          actorId: req.userId ?? 'anonymous',
+          actorId: req.user?.id ?? 'anonymous',
           action,
           resourceType,
           resourceId: resourceId?.(req),

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -4,7 +4,7 @@ import { AuthBlacklistService } from '../services/AuthBlacklistService';
 import { config } from '../config/config';
 
 export interface AuthRequest extends Request {
-  userId?: string;
+  user?: { id: string };
   activeOrgId?: string;
 }
 
@@ -34,6 +34,6 @@ export async function authMiddleware(
     return;
   }
 
-  req.userId = payload.sub as string;
+  req.user = { id: payload.sub as string };
   next();
 }

--- a/backend/src/middleware/authenticate.ts
+++ b/backend/src/middleware/authenticate.ts
@@ -5,8 +5,6 @@ import { config } from '../config/config';
 
 export interface AuthRequest extends Request {
   user?: { id: string };
-  /** @deprecated Use req.user.id instead */
-  userId?: string;
   activeOrgId?: string;
 }
 
@@ -47,7 +45,5 @@ export async function authenticate(
 
   const userId = payload.sub as string;
   req.user = { id: userId };
-  // Keep req.userId for backward-compat with downstream middleware (checkPermission, requireCredits, etc.)
-  req.userId = userId;
   next();
 }

--- a/backend/src/middleware/checkPermission.ts
+++ b/backend/src/middleware/checkPermission.ts
@@ -4,7 +4,7 @@ import { Permission, RoleStore } from '../models/Role';
 
 /**
  * Middleware factory that enforces one or more permissions.
- * Must be used after `authMiddleware` (requires req.userId).
+ * Must be used after `authMiddleware` (requires req.user.id).
  *
  * Usage:
  *   router.post('/posts', authMiddleware, checkPermission('posts:create'), handler)
@@ -12,7 +12,7 @@ import { Permission, RoleStore } from '../models/Role';
  */
 export function checkPermission(...required: Permission[]) {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
-    const userId = req.userId;
+    const userId = req.user?.id;
     if (!userId) {
       res.status(401).json({ message: 'Unauthorized' });
       return;

--- a/backend/src/middleware/orgMiddleware.ts
+++ b/backend/src/middleware/orgMiddleware.ts
@@ -19,7 +19,7 @@ export async function orgMiddleware(
   }
 
   const membership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
   });
 
   if (!membership) {

--- a/backend/src/middleware/requireCredits.ts
+++ b/backend/src/middleware/requireCredits.ts
@@ -12,7 +12,7 @@ import { CreditAction } from '../models/Subscription';
  */
 export function requireCredits(action: CreditAction) {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
-    const userId = req.userId;
+    const userId = req.user?.id;
     if (!userId) {
       res.status(401).json({ message: 'Unauthorized' });
       return;

--- a/backend/src/modules/auth/middleware/authMiddleware.ts
+++ b/backend/src/modules/auth/middleware/authMiddleware.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
 export interface AuthRequest extends Request {
-  userId?: string;
+  user?: { id: string };
   activeOrgId?: string;
 }
 
@@ -18,7 +18,7 @@ export function authMiddleware(req: AuthRequest, res: Response, next: NextFuncti
   const token = authHeader.slice(7);
   try {
     const payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
-    req.userId = payload.sub as string;
+    req.user = { id: payload.sub as string };
     next();
   } catch {
     res.status(401).json({ message: 'Invalid or expired access token' });

--- a/backend/src/modules/billing/routes.ts
+++ b/backend/src/modules/billing/routes.ts
@@ -25,7 +25,7 @@ const portalSchema = z.object({
  * Provision a Stripe customer + free subscription for the authenticated user.
  */
 router.post('/provision', authMiddleware, async (req: AuthRequest, res: Response) => {
-  const user = UserStore.findById(req.userId!);
+  const user = UserStore.findById(req.user!.id);
   if (!user) return res.status(404).json({ message: 'User not found' });
 
   try {
@@ -42,7 +42,7 @@ router.post('/provision', authMiddleware, async (req: AuthRequest, res: Response
  * Get the current user's subscription and credit balance.
  */
 router.get('/subscription', authMiddleware, (req: AuthRequest, res: Response) => {
-  const sub = SubscriptionStore.findByUserId(req.userId!);
+  const sub = SubscriptionStore.findByUserId(req.user!.id);
   if (!sub)
     return res.status(404).json({ message: 'No subscription found. Call /provision first.' });
   return res.json(sub);
@@ -53,7 +53,7 @@ router.get('/subscription', authMiddleware, (req: AuthRequest, res: Response) =>
  * Get the current user's credit log.
  */
 router.get('/credits', authMiddleware, (req: AuthRequest, res: Response) => {
-  const logs = CreditLogStore.forUser(req.userId!);
+  const logs = CreditLogStore.forUser(req.user!.id);
   return res.json(logs);
 });
 
@@ -69,7 +69,7 @@ router.post(
     const { priceId, successUrl, cancelUrl } = req.body;
     try {
       const url = await billingService.createCheckoutSession(
-        req.userId!,
+        req.user!.id,
         priceId,
         successUrl,
         cancelUrl,
@@ -93,7 +93,7 @@ router.post(
   async (req: AuthRequest, res: Response) => {
     const { returnUrl } = req.body;
     try {
-      const url = await billingService.createPortalSession(req.userId!, returnUrl);
+      const url = await billingService.createPortalSession(req.user!.id, returnUrl);
       return res.json({ url });
     } catch (err) {
       logger.error('Portal session failed', { error: (err as Error).message });

--- a/backend/src/modules/organization/controllers/organization.ts
+++ b/backend/src/modules/organization/controllers/organization.ts
@@ -19,7 +19,7 @@ export async function createOrganization(req: AuthRequest, res: Response): Promi
       name,
       slug,
       members: {
-        create: { id: randomUUID(), userId: req.userId!, role: 'owner' },
+        create: { id: randomUUID(), userId: req.user!.id, role: 'owner' },
       },
     },
     include: { members: true },
@@ -31,7 +31,7 @@ export async function createOrganization(req: AuthRequest, res: Response): Promi
 /** GET /api/organizations — list orgs the caller belongs to */
 export async function listOrganizations(req: AuthRequest, res: Response): Promise<void> {
   const memberships = await prisma.organizationMember.findMany({
-    where: { userId: req.userId! },
+    where: { userId: req.user!.id },
     include: { organization: true },
   });
 
@@ -45,7 +45,7 @@ export async function getOrganization(req: AuthRequest, res: Response): Promise<
   const { orgId } = req.params;
 
   const membership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
     include: {
       organization: {
         include: { members: { include: { user: { select: { id: true, email: true } } } } },
@@ -68,7 +68,7 @@ export async function addMember(req: AuthRequest, res: Response): Promise<void> 
 
   // Only owner/admin can invite
   const callerMembership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
   });
   if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
     res.status(403).json({ message: 'Insufficient permissions' });
@@ -87,7 +87,7 @@ export async function removeMember(req: AuthRequest, res: Response): Promise<voi
   const { orgId, userId } = req.params;
 
   const callerMembership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
   });
   if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
     res.status(403).json({ message: 'Insufficient permissions' });
@@ -106,7 +106,7 @@ export async function switchOrganization(req: AuthRequest, res: Response): Promi
   const { orgId } = req.body as { orgId: string };
 
   const membership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
     include: { organization: true },
   });
 

--- a/backend/src/modules/organization/routes.roles.ts
+++ b/backend/src/modules/organization/routes.roles.ts
@@ -47,7 +47,7 @@ router.get(
  * Returns the current user's role and permissions.
  */
 router.get('/me', authMiddleware, (req: AuthRequest, res: Response) => {
-  const role = RoleStore.getRole(req.userId!);
+  const role = RoleStore.getRole(req.user!.id);
   if (!role) return res.json({ role: null, permissions: [] });
   return res.json({ role: role.name, permissions: role.permissions });
 });

--- a/backend/src/routes/audit.ts
+++ b/backend/src/routes/audit.ts
@@ -65,7 +65,7 @@ router.get('/', authMiddleware, (req: Request, res: Response) => {
  */
 router.get('/me', authMiddleware, (req: AuthRequest, res: Response) => {
   const params = parsePageLimit(req);
-  const all = AuditLogStore.forActor(req.userId!, 500);
+  const all = AuditLogStore.forActor(req.user!.id, 500);
   const total = all.length;
   const start = (params.page - 1) * params.limit;
   const data = all.slice(start, start + params.limit);

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -39,7 +39,7 @@ const portalSchema = z.object({
  *         description: Stripe error
  */
 router.post('/provision', authMiddleware, async (req: AuthRequest, res: Response) => {
-  const user = await UserStore.findById(req.userId!);
+  const user = await UserStore.findById(req.user!.id);
   if (!user) return res.status(404).json({ message: 'User not found' });
 
   try {
@@ -68,7 +68,7 @@ router.post('/provision', authMiddleware, async (req: AuthRequest, res: Response
  *         description: No subscription found
  */
 router.get('/subscription', authMiddleware, (req: AuthRequest, res: Response) => {
-  const sub = SubscriptionStore.findByUserId(req.userId!);
+  const sub = SubscriptionStore.findByUserId(req.user!.id);
   if (!sub)
     return res.status(404).json({ message: 'No subscription found. Call /provision first.' });
   return res.json(sub);
@@ -85,7 +85,7 @@ router.get('/subscription', authMiddleware, (req: AuthRequest, res: Response) =>
  *         description: Credit log entries
  */
 router.get('/credits', authMiddleware, (req: AuthRequest, res: Response) => {
-  const logs = CreditLogStore.forUser(req.userId!);
+  const logs = CreditLogStore.forUser(req.user!.id);
   return res.json(logs);
 });
 
@@ -131,7 +131,7 @@ router.post(
     const { priceId, successUrl, cancelUrl } = req.body;
     try {
       const url = await billingService.createCheckoutSession(
-        req.userId!,
+        req.user!.id,
         priceId,
         successUrl,
         cancelUrl,
@@ -180,7 +180,7 @@ router.post(
   async (req: AuthRequest, res: Response) => {
     const { returnUrl } = req.body;
     try {
-      const url = await billingService.createPortalSession(req.userId!, returnUrl);
+      const url = await billingService.createPortalSession(req.user!.id, returnUrl);
       return res.json({ url });
     } catch (err) {
       logger.error('Portal session failed', { error: (err as Error).message });

--- a/backend/src/routes/roles.ts
+++ b/backend/src/routes/roles.ts
@@ -73,7 +73,7 @@ router.get(
  *         description: Current user role
  */
 router.get('/me', authMiddleware, (req: AuthRequest, res: Response) => {
-  const role = RoleStore.getRole(req.userId!);
+  const role = RoleStore.getRole(req.user!.id);
   if (!role) return res.json({ role: null, permissions: [] });
   return res.json({ role: role.name, permissions: role.permissions });
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -331,6 +331,18 @@ export const bootstrap = async (exit?: (code: number) => void): Promise<void> =>
       });
     }
 
+    // Verify database connectivity before accepting traffic
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      logger.info('Database connectivity verified');
+    } catch (error) {
+      logger.error('Database connectivity check failed — aborting startup', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      doExit(1);
+      return;
+    }
+
     // Start HTTP server
     serverInstance = app.listen(PORT, () => {
       logger.info(`🚀 SocialFlow Backend is running on http://localhost:${PORT}`);

--- a/backend/src/shared/middleware/audit.ts
+++ b/backend/src/shared/middleware/audit.ts
@@ -6,7 +6,7 @@ import { redactSensitiveFields } from '../../utils/redactSensitiveFields';
 
 /**
  * Middleware factory that records an audit log entry after the response is sent.
- * Must be used after `authMiddleware` (requires req.userId).
+ * Must be used after `authMiddleware` (requires req.user.id).
  *
  * Sensitive fields (password, token, cardNumber, cvv, secret) are automatically
  * redacted from any metadata before it is written to the audit log.
@@ -26,7 +26,7 @@ export function audit(
       if (res.statusCode >= 200 && res.statusCode < 300) {
         const rawMetadata = metadata?.(req);
         auditLogger.log({
-          actorId: req.userId ?? 'anonymous',
+          actorId: req.user?.id ?? 'anonymous',
           action,
           resourceType,
           resourceId: resourceId?.(req),

--- a/backend/src/shared/middleware/authMiddleware.ts
+++ b/backend/src/shared/middleware/authMiddleware.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
 export interface AuthRequest extends Request {
-  userId?: string;
+  user?: { id: string };
   activeOrgId?: string;
 }
 
@@ -18,7 +18,7 @@ export function authMiddleware(req: AuthRequest, res: Response, next: NextFuncti
   const token = authHeader.slice(7);
   try {
     const payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
-    req.userId = payload.sub as string;
+    req.user = { id: payload.sub as string };
     next();
   } catch {
     res.status(401).json({ message: 'Invalid or expired access token' });

--- a/backend/src/shared/middleware/checkPermission.ts
+++ b/backend/src/shared/middleware/checkPermission.ts
@@ -4,7 +4,7 @@ import { Permission, RoleStore } from '../models/Role';
 
 /**
  * Middleware factory that enforces one or more permissions.
- * Must be used after `authMiddleware` (requires req.userId).
+ * Must be used after `authMiddleware` (requires req.user.id).
  *
  * Usage:
  *   router.post('/posts', authMiddleware, checkPermission('posts:create'), handler)
@@ -12,7 +12,7 @@ import { Permission, RoleStore } from '../models/Role';
  */
 export function checkPermission(...required: Permission[]) {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
-    const userId = req.userId;
+    const userId = req.user?.id;
     if (!userId) {
       res.status(401).json({ message: 'Unauthorized' });
       return;

--- a/backend/src/shared/middleware/orgMiddleware.ts
+++ b/backend/src/shared/middleware/orgMiddleware.ts
@@ -19,7 +19,7 @@ export async function orgMiddleware(
   }
 
   const membership = await prisma.organizationMember.findUnique({
-    where: { organizationId_userId: { organizationId: orgId, userId: req.userId! } },
+    where: { organizationId_userId: { organizationId: orgId, userId: req.user!.id } },
   });
 
   if (!membership) {

--- a/backend/src/shared/middleware/requireCredits.ts
+++ b/backend/src/shared/middleware/requireCredits.ts
@@ -12,7 +12,7 @@ import { CreditAction } from '../models/Subscription';
  */
 export function requireCredits(action: CreditAction) {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
-    const userId = req.userId;
+    const userId = req.user?.id;
     if (!userId) {
       res.status(401).json({ message: 'Unauthorized' });
       return;

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -68,3 +68,51 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private.id
 }
+
+# ── VPC Flow Logs ─────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name              = "/aws/vpc/flow-logs/socialflow-${var.env}"
+  retention_in_days = 90
+  tags              = { Name = "socialflow-${var.env}-vpc-flow-logs" }
+}
+
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "socialflow-${var.env}-vpc-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  name = "socialflow-${var.env}-vpc-flow-logs-policy"
+  role = aws_iam_role.vpc_flow_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+      ]
+      Resource = "${aws_cloudwatch_log_group.vpc_flow_logs.arn}:*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "main" {
+  vpc_id          = aws_vpc.main.id
+  traffic_type    = "ALL"
+  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
+  tags            = { Name = "socialflow-${var.env}-flow-log" }
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -62,6 +62,7 @@ resource "aws_db_instance" "main" {
   parameter_group_name   = aws_db_parameter_group.main.name
   skip_final_snapshot    = var.env == "dev"
   deletion_protection    = var.env == "prod"
+  multi_az               = true
   backup_retention_period = var.backup_retention_days
   tags                   = { Env = var.env }
 }


### PR DESCRIPTION
#849: migrate all req.userId usages to req.user.id
- Remove deprecated userId field from all AuthRequest interfaces
- Update authenticate.ts to only set req.user.id (drop req.userId)
- Update all 3 authMiddleware copies to set req.user instead of req.userId
- Migrate all downstream middleware and controllers to req.user.id
- Update tests to reflect new API

#850: add database connectivity check at startup
- Verify DB reachable via prisma.$queryRaw before server.listen()
- Exit process with code 1 if check fails

#851: enable RDS Multi-AZ in Terraform
- Add multi_az = true to aws_db_instance.main in rds/main.tf

#852: enable VPC flow logs in Terraform networking module
- Add CloudWatch log group with 90-day retention
- Add IAM role and policy for VPC flow logs delivery
- Add aws_flow_log resource for ALL traffic on the VPC

chore: update .gitignore
- Add .env, *.tsbuildinfo, .terraform/, *.tfstate, junit.xml, tmp/
closes #849 
closes #850 
closes #851 
closes #852 