### PR TITLE
feat: dependency scanning, TLS enforcement, OTel tracing fix, structured logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,11 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Audit all workspace dependencies
+      - name: Audit root workspace dependencies
+        run: npm audit --audit-level=high
+
+      - name: Audit backend dependencies
+        working-directory: backend
         run: npm audit --audit-level=high
 
       - name: Detect Snyk token availability

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -84,6 +84,7 @@ const envSchema = z.object({
     .transform((v) => v === 'true'),
 
   ELASTICSEARCH_URL: z.string().url('ELASTICSEARCH_URL must be a valid URL').optional(),
+  ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED: z.string().optional(),
   LOG_LEVEL: z.enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly']).default('info'),
 
   // ── Alerting ──────────────────────────────────────────────────────────────
@@ -157,6 +158,15 @@ const envSchema = z.object({
 
   // ── AWS S3 ────────────────────────────────────────────────────────────────
   S3_PRESIGNED_URL_EXPIRY_SECONDS: z.coerce.number().int().positive().default(3600),
+}).superRefine((data, ctx) => {
+  if (data.NODE_ENV === 'production' && data.ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED === 'false') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED'],
+      message:
+        'ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED cannot be "false" in production — disabling TLS verification exposes Elasticsearch traffic to MITM attacks',
+    });
+  }
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -45,7 +45,7 @@ if (config.ELASTICSEARCH_URL) {
             : undefined,
         // Trust self-signed certs in dev/staging; enforce TLS in production
         tls: {
-          rejectUnauthorized: process.env.ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED !== 'false',
+          rejectUnauthorized: config.ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED !== 'false',
         },
       },
       // Map Winston levels to ECS-compatible severity

--- a/backend/src/services/ImageOptimizationService.ts
+++ b/backend/src/services/ImageOptimizationService.ts
@@ -2,7 +2,9 @@ import sharp from 'sharp';
 import fs from 'fs/promises';
 import path from 'path';
 import crypto from 'crypto';
+import { createLogger } from '../lib/logger';
 
+const logger = createLogger('image-optimization');
 const CACHE_DIR = path.join(process.cwd(), 'uploads', 'images', 'cache');
 // TODO: Implement format validation (tracked in future issue)
 
@@ -21,7 +23,7 @@ export const ImageOptimizationService = {
     try {
       await fs.mkdir(CACHE_DIR, { recursive: true });
     } catch (error) {
-      console.error('Failed to create cache directory:', error);
+      logger.error('Failed to create cache directory:', error);
     }
   },
 
@@ -107,7 +109,7 @@ export const ImageOptimizationService = {
     try {
       await fs.writeFile(cachePath, buffer);
     } catch (error) {
-      console.error('Failed to cache optimized image:', error);
+      logger.error('Failed to cache optimized image:', error);
     }
 
     const etag = `"${crypto.createHash('sha256').update(buffer).digest('hex')}"`;
@@ -144,7 +146,7 @@ export const ImageOptimizationService = {
       const files = await fs.readdir(CACHE_DIR);
       await Promise.all(files.map((file) => fs.unlink(path.join(CACHE_DIR, file))));
     } catch (error) {
-      console.error('Failed to clear cache:', error);
+      logger.error('Failed to clear cache:', error);
     }
   },
 

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -6,6 +6,7 @@
  * scaling, this file can be run as a standalone process via:
  *   node -r ts-node/register src/workers/index.ts
  */
+import '../tracing'; // must be first — patches BullMQ and Prisma before they load
 import { Job, Worker } from 'bullmq';
 import { trace, context, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { queueManager } from '../queues/queueManager';


### PR DESCRIPTION
## Summary

This PR resolves four open security and observability issues:

### #840 — Add dependency vulnerability scanning to CI
- Split the existing `npm audit --audit-level=high` step into two separate steps: one for the root workspace and one for `backend/`, ensuring both lockfiles are scanned independently for high-severity CVEs.
- Dependabot version-update tracking for npm (root + backend) and GitHub Actions is already active in `.github/dependabot.yml`.

### #839 — Block `ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED=false` in production
- Added `ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED` as an explicit field in the Zod env schema (`backend/src/config/config.ts`).
- Attached a `.superRefine()` that raises a schema validation error at startup if the value is `"false"` while `NODE_ENV` is `"production"`, preventing the app from booting in an insecure state.
- Updated `backend/src/lib/logger.ts` to read this value through the validated `config` object instead of `process.env` directly.

### #841 — Fix OTel tracing initialization order in workers
- Added `import '../tracing'` as the very first import in `backend/src/workers/index.ts`, before BullMQ and Prisma are loaded.
- This ensures OTel auto-instrumentation patches are applied at require-time so BullMQ and Prisma spans appear correctly in traces.

### #842 — Replace `console.error` with structured logger in `ImageOptimizationService`
- Imported `createLogger` from `../lib/logger` and instantiated `logger = createLogger('image-optimization')` in `backend/src/services/ImageOptimizationService.ts`.
- Replaced all three `console.error` calls (cache dir creation, image caching, cache clearing) with `logger.error` so errors are captured as structured JSON by the ELK stack.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Split npm audit into root + backend steps |
| `backend/src/config/config.ts` | Add `ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED` field + `superRefine` guard |
| `backend/src/lib/logger.ts` | Use `config` instead of `process.env` for TLS flag |
| `backend/src/workers/index.ts` | Move tracing import to top of file |
| `backend/src/services/ImageOptimizationService.ts` | Replace `console.error` with `logger.error` |

Closes #840
Closes #839
Closes #841
Closes #842