### PR TITLE
fix: soft delete models, Prisma singleton, HPA queue metrics, worker grace period

### DIFF
--- a/backend/prisma/migrations/20260530000000_add_soft_delete_post_org_webhook/migration.sql
+++ b/backend/prisma/migrations/20260530000000_add_soft_delete_post_org_webhook/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "WebhookSubscription" ADD COLUMN "deletedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Organization_deletedAt_idx" ON "Organization"("deletedAt");
+
+-- CreateIndex
+CREATE INDEX "Post_deletedAt_idx" ON "Post"("deletedAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookSubscription_deletedAt_idx" ON "WebhookSubscription"("deletedAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Organization {
   name      String
   slug      String               @unique
   createdAt DateTime             @default(now())
+  deletedAt DateTime?
   members   OrganizationMember[]
   posts     Post[]
   analytics AnalyticsEntry[]
@@ -48,6 +49,7 @@ model Organization {
 
   @@index([slug])
   @@index([createdAt])
+  @@index([deletedAt])
 }
 
 model OrganizationMember {
@@ -73,6 +75,7 @@ model Post {
   scheduledAt       DateTime?
   moderationStatus  String       @default("pending")
   createdAt         DateTime     @default(now())
+  deletedAt         DateTime?
   organization      Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
@@ -80,6 +83,7 @@ model Post {
   @@index([createdAt])
   @@index([scheduledAt])
   @@index([moderationStatus])
+  @@index([deletedAt])
 }
 
 model AnalyticsEntry {
@@ -167,10 +171,12 @@ model WebhookSubscription {
   isActive  Boolean           @default(true)
   createdAt DateTime          @default(now())
   updatedAt DateTime          @updatedAt
+  deletedAt DateTime?
   deliveries WebhookDelivery[]
 
   @@index([isActive])
   @@index([userId])
+  @@index([deletedAt])
 }
 
 model WebhookDelivery {

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -9,7 +9,7 @@ const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 const tracer = trace.getTracer('socialflow-db');
 
 // Models that support soft delete (have a deletedAt field)
-const SOFT_DELETE_MODELS = new Set(['User', 'Listing']);
+const SOFT_DELETE_MODELS = new Set(['User', 'Listing', 'Post', 'Organization', 'WebhookSubscription']);
 
 // Models that should be scoped to an organization
 const ORG_SCOPED_MODELS = new Set(['Post', 'AnalyticsEntry']);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -51,7 +51,7 @@ export const gracefulShutdown = async (
   opts?: { exit?: (code: number) => void; timeoutMs?: number },
 ): Promise<void> => {
   const doExit = opts?.exit ?? ((code) => process.exit(code));
-  const timeoutMs = opts?.timeoutMs ?? 30000;
+  const timeoutMs = opts?.timeoutMs ?? 270000;
   const srv = deps?.server ?? serverInstance;
   const ww = deps?.webhookWorker ?? webhookWorker;
   const tww = deps?.twitterWebhookWorker ?? twitterWebhookWorker;

--- a/backend/src/services/CohortService.ts
+++ b/backend/src/services/CohortService.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { sqltag, empty } from '@prisma/client/runtime/library';
 import { createLogger } from '../lib/logger';
-
-const prisma = new PrismaClient();
+import { prisma } from '../lib/prisma';
 const logger = createLogger('cohort-service');
 
 export type CohortLabel =

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: socialflow-backend
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Summary

This PR resolves four issues across database, infrastructure, and backend worker configuration.

### #843 — Scope soft delete to additional models
- Added `deletedAt DateTime?` field to `Post`, `Organization`, and `WebhookSubscription` models in `backend/prisma/schema.prisma`
- Added `@@index([deletedAt])` to each of the three models for query performance
- Created migration `20260530000000_add_soft_delete_post_org_webhook` with `ALTER TABLE` and `CREATE INDEX` statements
- Added `Post`, `Organization`, and `WebhookSubscription` to `SOFT_DELETE_MODELS` in `backend/src/lib/prisma.ts` so the shared Prisma extension intercepts `delete`/`deleteMany`/`findUnique`/`findMany` operations and rewrites them to use `deletedAt` instead of hard deletes

### #844 — Fix CohortService to use the shared Prisma singleton
- Removed `import { PrismaClient } from '@prisma/client'` and `const prisma = new PrismaClient()` from `backend/src/services/CohortService.ts`
- Replaced with `import { prisma } from '../lib/prisma'` so the service now uses the shared singleton that carries soft-delete middleware, org-scoping extensions, and OTel tracing

### #845 — Add HPA scaling on BullMQ queue depth
- `k8s/base/hpa.yaml` already contains the External metric targeting `bullmq_queue_waiting` with `averageValue: "50"`
- `k8s/base/prometheus-adapter-config.yaml` already exposes the metric via an `externalRules` entry mapping the `bullmq_queue_waiting` Prometheus gauge to the HPA external metric name
- No code changes required; confirming the implementation is in place

### #846 — Increase terminationGracePeriodSeconds for long video jobs
- Changed `terminationGracePeriodSeconds` from `60` to `300` in `k8s/base/deployment.yaml` to accommodate FFmpeg transcoding jobs that can run for 5+ minutes
- Aligned the application-level graceful shutdown timeout in `backend/src/server.ts` from `30000ms` to `270000ms` (270 s), leaving a 30 s buffer before Kubernetes force-kills the pod; the existing SIGTERM handler calls `queueManager.closeAll()` which invokes `worker.close()` on every BullMQ worker and waits for in-flight jobs to drain

## Files changed
| File | Change |
|------|--------|
| `backend/prisma/schema.prisma` | Added `deletedAt` field + index to `Post`, `Organization`, `WebhookSubscription` |
| `backend/prisma/migrations/20260530000000_add_soft_delete_post_org_webhook/migration.sql` | New migration |
| `backend/src/lib/prisma.ts` | Extended `SOFT_DELETE_MODELS` with three new models |
| `backend/src/services/CohortService.ts` | Replaced `new PrismaClient()` with shared singleton |
| `k8s/base/deployment.yaml` | `terminationGracePeriodSeconds` 60 → 300 |
| `backend/src/server.ts` | Shutdown timeout 30 000 ms → 270 000 ms |

Closes #843
Closes #844
Closes #845
Closes #846