### PR TITLE
fix: derive export and search organizationId from auth context

### DIFF
--- a/backend/src/__tests__/exportOrgScoping.test.ts
+++ b/backend/src/__tests__/exportOrgScoping.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Export org-scoping tests — Closes #8
+ *
+ * Verifies that the export routes derive organizationId exclusively from
+ * req.activeOrgId (set by orgMiddleware) and never from a user-supplied
+ * query parameter.
+ */
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import exportRouter from '../routes/exports';
+import { ExportService } from '../services/ExportService';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../middleware/authenticate', () => ({
+  authenticate: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../middleware/orgMiddleware', () => ({
+  orgMiddleware: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../middleware/checkPermission', () => ({
+  checkPermission: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../services/ExportService', () => ({
+  ExportService: {
+    streamAnalyticsAsCSV: jest.fn(),
+    streamAnalyticsAsJSON: jest.fn(),
+    streamPostsAsCSV: jest.fn(),
+    streamPostsAsJSON: jest.fn(),
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+const VALID_QUERY = 'format=csv&startDate=2025-01-01T00:00:00Z&endDate=2025-12-31T23:59:59Z';
+
+/** Build an app where a middleware sets activeOrgId to `orgId`. */
+function buildApp(orgId: string | undefined) {
+  const app = express();
+  app.use((req: any, _res: Response, next: NextFunction) => {
+    req.activeOrgId = orgId;
+    next();
+  });
+  app.use('/exports', exportRouter);
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Export org-scoping (Closes #8)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ExportService.streamAnalyticsAsCSV as jest.Mock).mockImplementation(
+      (_orgId: string, _start: Date, _end: Date, res: Response) => res.status(200).end(),
+    );
+    (ExportService.streamPostsAsCSV as jest.Mock).mockImplementation(
+      (_orgId: string, _start: Date, _end: Date, res: Response) => res.status(200).end(),
+    );
+  });
+
+  describe('GET /exports/analytics', () => {
+    it('uses req.activeOrgId, not a user-supplied organizationId', async () => {
+      const app = buildApp(ORG_A);
+
+      // Attacker supplies ORG_B in the query string.
+      await request(app)
+        .get(`/exports/analytics?organizationId=${ORG_B}&${VALID_QUERY}`)
+        .expect(200);
+
+      expect(ExportService.streamAnalyticsAsCSV).toHaveBeenCalledWith(
+        ORG_A, // must be the auth-context org, not ORG_B
+        expect.any(Date),
+        expect.any(Date),
+        expect.anything(),
+      );
+      expect(ExportService.streamAnalyticsAsCSV).not.toHaveBeenCalledWith(
+        ORG_B,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('returns 403 when activeOrgId is not set', async () => {
+      const app = buildApp(undefined);
+
+      await request(app).get(`/exports/analytics?${VALID_QUERY}`).expect(403);
+      expect(ExportService.streamAnalyticsAsCSV).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /exports/posts', () => {
+    it('uses req.activeOrgId, not a user-supplied organizationId', async () => {
+      const app = buildApp(ORG_A);
+
+      await request(app)
+        .get(`/exports/posts?organizationId=${ORG_B}&${VALID_QUERY}`)
+        .expect(200);
+
+      expect(ExportService.streamPostsAsCSV).toHaveBeenCalledWith(
+        ORG_A,
+        expect.any(Date),
+        expect.any(Date),
+        expect.anything(),
+      );
+      expect(ExportService.streamPostsAsCSV).not.toHaveBeenCalledWith(
+        ORG_B,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/backend/src/__tests__/searchOrgScoping.test.ts
+++ b/backend/src/__tests__/searchOrgScoping.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Search org-scoping tests — Closes #7
+ *
+ * Verifies that search results are always scoped to req.activeOrgId and that
+ * a user from org B cannot see posts belonging to org A.
+ */
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import searchRouter from '../routes/search';
+import * as SearchService from '../services/SearchService';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../middleware/authenticate', () => ({
+  authenticate: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../middleware/orgMiddleware', () => ({
+  orgMiddleware: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+jest.mock('../middleware/validate', () => ({
+  validate: () => (req: any, _res: Response, next: NextFunction) => {
+    req.query.limit = req.query.limit ?? 20;
+    req.query.offset = req.query.offset ?? 0;
+    next();
+  },
+}));
+
+jest.mock('../services/SearchService', () => ({
+  searchPosts: jest.fn(),
+}));
+
+jest.mock('../config/config', () => ({
+  config: { MEILISEARCH_SEARCH_KEY: 'test-key', MEILISEARCH_HOST: 'http://localhost:7700' },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+function buildApp(activeOrgId: string) {
+  const app = express();
+  app.use((req: any, _res: Response, next: NextFunction) => {
+    req.activeOrgId = activeOrgId;
+    next();
+  });
+  app.use('/search', searchRouter);
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Search org-scoping (Closes #7)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (SearchService.searchPosts as jest.Mock).mockResolvedValue({ hits: [] });
+  });
+
+  it('always passes req.activeOrgId to searchPosts, ignoring any user-supplied organizationId', async () => {
+    const app = buildApp(ORG_A);
+
+    // Attacker supplies ORG_B in the query string.
+    await request(app)
+      .get(`/search/posts?q=hello&organizationId=${ORG_B}`)
+      .expect(200);
+
+    expect(SearchService.searchPosts).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({ organizationId: ORG_A }),
+    );
+    expect(SearchService.searchPosts).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: ORG_B }),
+    );
+  });
+
+  it('org B user cannot see org A posts', async () => {
+    const orgAPost = { id: 'post-1', organizationId: ORG_A, content: 'secret' };
+    const orgBPost = { id: 'post-2', organizationId: ORG_B, content: 'public' };
+
+    (SearchService.searchPosts as jest.Mock).mockImplementation(
+      (_q: string, opts: { organizationId: string }) =>
+        Promise.resolve({
+          hits: opts.organizationId === ORG_B ? [orgBPost] : [orgAPost],
+        }),
+    );
+
+    const app = buildApp(ORG_B);
+    const res = await request(app).get('/search/posts?q=secret').expect(200);
+
+    expect(res.body.hits).toEqual([orgBPost]);
+    expect(res.body.hits).not.toContainEqual(orgAPost);
+  });
+
+  it('searchPosts is always called with organizationId as a required field', async () => {
+    const app = buildApp(ORG_A);
+    await request(app).get('/search/posts?q=test').expect(200);
+
+    const [, opts] = (SearchService.searchPosts as jest.Mock).mock.calls[0];
+    expect(opts.organizationId).toBe(ORG_A);
+  });
+});

--- a/backend/src/routes/exports.ts
+++ b/backend/src/routes/exports.ts
@@ -1,9 +1,20 @@
-import { Router, Request, Response } from 'express';
+import { Router, Response, NextFunction } from 'express';
 import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { orgMiddleware } from '../middleware/orgMiddleware';
 import { checkPermission } from '../middleware/checkPermission';
 import { ExportService } from '../services/ExportService';
+import { AuthRequest } from '../middleware/authMiddleware';
 
 const router = Router();
+
+/** Asserts req.activeOrgId is set — orgMiddleware must run first. */
+function requireActiveOrg(req: AuthRequest, res: Response, next: NextFunction): void {
+  if (!req.activeOrgId) {
+    res.status(403).json({ error: 'No active organization' });
+    return;
+  }
+  next();
+}
 
 /**
  * @openapi
@@ -12,11 +23,6 @@ const router = Router();
  *     tags: [Exports]
  *     summary: Stream analytics data as CSV or JSON
  *     parameters:
- *       - in: query
- *         name: organizationId
- *         required: true
- *         schema:
- *           type: string
  *       - in: query
  *         name: format
  *         required: true
@@ -42,45 +48,49 @@ const router = Router();
  *         description: Validation error
  */
 // Required permission: analytics:export
-router.get('/analytics', authMiddleware, checkPermission('analytics:export'), async (req: Request, res: Response) => {
-  try {
-    const { organizationId, format, startDate, endDate } = req.query;
+router.get(
+  '/analytics',
+  authMiddleware,
+  orgMiddleware,
+  requireActiveOrg,
+  checkPermission('analytics:export'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { format, startDate, endDate } = req.query;
+      const organizationId = req.activeOrgId!;
 
-    if (!organizationId || typeof organizationId !== 'string') {
-      return res.status(400).json({ error: 'organizationId is required' });
-    }
+      if (!format || !['csv', 'json'].includes(format as string)) {
+        return res.status(400).json({ error: 'format must be "csv" or "json"' });
+      }
 
-    if (!format || !['csv', 'json'].includes(format as string)) {
-      return res.status(400).json({ error: 'format must be "csv" or "json"' });
-    }
+      if (!startDate || typeof startDate !== 'string') {
+        return res.status(400).json({ error: 'startDate is required (ISO format)' });
+      }
 
-    if (!startDate || typeof startDate !== 'string') {
-      return res.status(400).json({ error: 'startDate is required (ISO format)' });
-    }
+      if (!endDate || typeof endDate !== 'string') {
+        return res.status(400).json({ error: 'endDate is required (ISO format)' });
+      }
 
-    if (!endDate || typeof endDate !== 'string') {
-      return res.status(400).json({ error: 'endDate is required (ISO format)' });
-    }
+      const start = new Date(startDate);
+      const end = new Date(endDate);
 
-    const start = new Date(startDate);
-    const end = new Date(endDate);
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        return res.status(400).json({ error: 'Invalid date format' });
+      }
 
-    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-      return res.status(400).json({ error: 'Invalid date format' });
+      if (format === 'csv') {
+        await ExportService.streamAnalyticsAsCSV(organizationId, start, end, res);
+      } else {
+        await ExportService.streamAnalyticsAsJSON(organizationId, start, end, res);
+      }
+    } catch (error) {
+      console.error('Export error:', error);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Export failed' });
+      }
     }
-
-    if (format === 'csv') {
-      await ExportService.streamAnalyticsAsCSV(organizationId, start, end, res);
-    } else {
-      await ExportService.streamAnalyticsAsJSON(organizationId, start, end, res);
-    }
-  } catch (error) {
-    console.error('Export error:', error);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'Export failed' });
-    }
-  }
-});
+  },
+);
 
 /**
  * @openapi
@@ -89,11 +99,6 @@ router.get('/analytics', authMiddleware, checkPermission('analytics:export'), as
  *     tags: [Exports]
  *     summary: Stream posts data as CSV or JSON
  *     parameters:
- *       - in: query
- *         name: organizationId
- *         required: true
- *         schema:
- *           type: string
  *       - in: query
  *         name: format
  *         required: true
@@ -119,44 +124,48 @@ router.get('/analytics', authMiddleware, checkPermission('analytics:export'), as
  *         description: Validation error
  */
 // Required permission: analytics:export
-router.get('/posts', authMiddleware, checkPermission('analytics:export'), async (req: Request, res: Response) => {
-  try {
-    const { organizationId, format, startDate, endDate } = req.query;
+router.get(
+  '/posts',
+  authMiddleware,
+  orgMiddleware,
+  requireActiveOrg,
+  checkPermission('analytics:export'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { format, startDate, endDate } = req.query;
+      const organizationId = req.activeOrgId!;
 
-    if (!organizationId || typeof organizationId !== 'string') {
-      return res.status(400).json({ error: 'organizationId is required' });
-    }
+      if (!format || !['csv', 'json'].includes(format as string)) {
+        return res.status(400).json({ error: 'format must be "csv" or "json"' });
+      }
 
-    if (!format || !['csv', 'json'].includes(format as string)) {
-      return res.status(400).json({ error: 'format must be "csv" or "json"' });
-    }
+      if (!startDate || typeof startDate !== 'string') {
+        return res.status(400).json({ error: 'startDate is required (ISO format)' });
+      }
 
-    if (!startDate || typeof startDate !== 'string') {
-      return res.status(400).json({ error: 'startDate is required (ISO format)' });
-    }
+      if (!endDate || typeof endDate !== 'string') {
+        return res.status(400).json({ error: 'endDate is required (ISO format)' });
+      }
 
-    if (!endDate || typeof endDate !== 'string') {
-      return res.status(400).json({ error: 'endDate is required (ISO format)' });
-    }
+      const start = new Date(startDate);
+      const end = new Date(endDate);
 
-    const start = new Date(startDate);
-    const end = new Date(endDate);
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        return res.status(400).json({ error: 'Invalid date format' });
+      }
 
-    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-      return res.status(400).json({ error: 'Invalid date format' });
+      if (format === 'csv') {
+        await ExportService.streamPostsAsCSV(organizationId, start, end, res);
+      } else {
+        await ExportService.streamPostsAsJSON(organizationId, start, end, res);
+      }
+    } catch (error) {
+      console.error('Export error:', error);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Export failed' });
+      }
     }
-
-    if (format === 'csv') {
-      await ExportService.streamPostsAsCSV(organizationId, start, end, res);
-    } else {
-      await ExportService.streamPostsAsJSON(organizationId, start, end, res);
-    }
-  } catch (error) {
-    console.error('Export error:', error);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'Export failed' });
-    }
-  }
-});
+  },
+);
 
 export default router;

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -1,33 +1,40 @@
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { orgMiddleware } from '../middleware/orgMiddleware';
 import { validate } from '../middleware/validate';
 import { searchPosts } from '../services/SearchService';
 import { config } from '../config/config';
+import { AuthRequest } from '../middleware/authMiddleware';
 
 const router = Router();
 
 const searchQuerySchema = z.object({
   q: z.string().min(1),
-  organizationId: z.string().uuid().optional(),
   platform: z.enum(['twitter', 'linkedin', 'instagram', 'tiktok', 'facebook', 'youtube']).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(20),
   offset: z.coerce.number().int().min(0).default(0),
 });
 
-/** GET /api/v1/search/posts — authenticated full-text search */
-router.get('/posts', authMiddleware, validate(searchQuerySchema, 'query'), async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { q, organizationId, platform, limit, offset } = req.query as unknown as z.infer<typeof searchQuerySchema>;
-    const results = await searchPosts(q, { organizationId, platform, limit, offset });
-    res.json(results);
-  } catch (err) {
-    next(err);
-  }
-});
+/** GET /api/v1/search/posts — authenticated full-text search scoped to the active org */
+router.get(
+  '/posts',
+  authMiddleware,
+  orgMiddleware,
+  validate(searchQuerySchema, 'query'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { q, platform, limit, offset } = req.query as unknown as z.infer<typeof searchQuerySchema>;
+      const results = await searchPosts(q, { organizationId: req.activeOrgId!, platform, limit, offset });
+      res.json(results);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 /** GET /api/v1/search/key — returns the public search-only API key for frontend use */
-router.get('/key', authMiddleware, (_req: Request, res: Response) => {
+router.get('/key', authMiddleware, (_req: AuthRequest, res: Response) => {
   res.json({ searchKey: config.MEILISEARCH_SEARCH_KEY, host: config.MEILISEARCH_HOST });
 });
 

--- a/backend/src/services/SearchService.ts
+++ b/backend/src/services/SearchService.ts
@@ -53,34 +53,33 @@ export async function deletePost(postId: string): Promise<void> {
   }
 }
 
-/** Full-text search across posts with optional filters. */
+/** Full-text search across posts. organizationId is required to scope results to one org. */
 export async function searchPosts(
   query: string,
   opts: {
-    organizationId?: string;
+    organizationId: string;
     platform?: string;
     limit?: number;
     offset?: number;
-  } = {},
+  },
 ) {
   const VALID_PLATFORMS = new Set(['twitter', 'instagram', 'facebook', 'linkedin', 'tiktok', 'youtube']);
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+  if (!UUID_RE.test(opts.organizationId)) {
+    throw new Error('Invalid organizationId');
+  }
   if (opts.platform && !VALID_PLATFORMS.has(opts.platform)) {
     throw new Error('Invalid platform value');
   }
-  if (opts.organizationId && !UUID_RE.test(opts.organizationId)) {
-    throw new Error('Invalid organizationId');
-  }
 
-  const filter: string[] = [];
-  if (opts.organizationId) filter.push(`organizationId = "${opts.organizationId}"`);
+  const filter: string[] = [`organizationId = "${opts.organizationId}"`];
   if (opts.platform) filter.push(`platform = "${opts.platform}"`);
 
   return getMeiliClient()
     .index(POSTS_INDEX)
     .search(query, {
-      filter: filter.length ? filter : undefined,
+      filter,
       limit: opts.limit ?? 20,
       offset: opts.offset ?? 0,
     });


### PR DESCRIPTION
closes #811 
closes #812 

- Replace user-supplied organizationId in exports routes with req.activeOrgId
- Add orgMiddleware + requireActiveOrg guard to /exports/analytics and /exports/posts
- Make organizationId required in SearchService.searchPosts, always apply filter
- Add orgMiddleware to search /posts route, remove user-supplied organizationId param
- Add tests asserting org-scoping for both exports (Closes #8) and search (Closes #7)