### PR TITLE
fix: persist billing data, harden auth/webhook, validate Stripe key at startup

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -230,3 +230,36 @@ model PayoutTransaction {
   @@index([transactionHash])
   @@index([jobId])
 }
+
+model Subscription {
+  id                     String      @id @default(uuid())
+  userId                 String      @unique
+  plan                   String      @default("free")
+  status                 String      @default("active")
+  stripeCustomerId       String
+  stripeSubscriptionId   String?
+  creditsRemaining       Int
+  creditsMonthly         Int
+  currentPeriodEnd       DateTime?
+  createdAt              DateTime    @default(now())
+  updatedAt              DateTime    @updatedAt
+  creditLogs             CreditLog[]
+
+  @@index([userId])
+  @@index([stripeCustomerId])
+  @@index([stripeSubscriptionId])
+}
+
+model CreditLog {
+  id             String       @id @default(uuid())
+  userId         String
+  action         String
+  delta          Int
+  balanceAfter   Int
+  metadata       Json?
+  createdAt      DateTime     @default(now())
+  subscription   Subscription @relation(fields: [userId], references: [userId], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([createdAt])
+}

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -74,7 +74,7 @@ const envSchema = z.object({
   GOOGLE_TTS_API_KEY: z.string().optional(),
 
   // ── Billing ───────────────────────────────────────────────────────────────
-  STRIPE_SECRET_KEY: z.string().optional(),
+  STRIPE_SECRET_KEY: z.string().min(1, 'STRIPE_SECRET_KEY is required'),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
 
   // ── Observability ─────────────────────────────────────────────────────────

--- a/backend/src/models/Subscription.ts
+++ b/backend/src/models/Subscription.ts
@@ -1,5 +1,6 @@
 /**
- * Subscription & CreditLog models (in-memory — swap Map for DB in production)
+ * Subscription & CreditLog types and constants.
+ * Persistence is handled by Prisma (see schema.prisma).
  */
 
 export type SubscriptionStatus = 'active' | 'canceled' | 'past_due' | 'trialing';
@@ -49,51 +50,4 @@ export const ACTION_COST: Record<string, number> = {
   'ai:generate': 5,
   'ai:analyze': 2,
   'post:publish': 1,
-};
-
-// ── In-memory stores ──────────────────────────────────────────────────────────
-
-const subscriptions = new Map<string, Subscription>(); // keyed by userId
-const creditLogs: CreditLog[] = [];
-let logIdCounter = 0;
-
-export const SubscriptionStore = {
-  findByUserId: (userId: string): Subscription | undefined => subscriptions.get(userId),
-
-  findByStripeCustomerId: (customerId: string): Subscription | undefined =>
-    [...subscriptions.values()].find((s) => s.stripeCustomerId === customerId),
-
-  findByStripeSubscriptionId: (subId: string): Subscription | undefined =>
-    [...subscriptions.values()].find((s) => s.stripeSubscriptionId === subId),
-
-  upsert: (sub: Subscription): Subscription => {
-    subscriptions.set(sub.userId, sub);
-    return sub;
-  },
-
-  patch: (userId: string, patch: Partial<Subscription>): Subscription | undefined => {
-    const sub = subscriptions.get(userId);
-    if (!sub) return undefined;
-    const updated = { ...sub, ...patch, updatedAt: new Date() };
-    subscriptions.set(userId, updated);
-    return updated;
-  },
-};
-
-export const CreditLogStore = {
-  append: (entry: Omit<CreditLog, 'id' | 'createdAt'>): CreditLog => {
-    const log: CreditLog = {
-      ...entry,
-      id: String(++logIdCounter),
-      createdAt: new Date(),
-    };
-    creditLogs.push(log);
-    return log;
-  },
-
-  forUser: (userId: string, limit = 50): CreditLog[] =>
-    creditLogs
-      .filter((l) => l.userId === userId)
-      .slice(-limit)
-      .reverse(),
 };

--- a/backend/src/services/AuthBlacklistService.ts
+++ b/backend/src/services/AuthBlacklistService.ts
@@ -6,6 +6,32 @@ const logger = createLogger('AuthBlacklistService');
 
 const BLACKLIST_PREFIX = 'jwt:blacklist:';
 
+// In-memory LRU fallback for recently blacklisted tokens
+const LRU_MAX = 1000;
+const lruCache = new Map<string, number>(); // key -> expiry epoch ms
+
+function lruSet(key: string, ttlSeconds: number): void {
+  if (lruCache.size >= LRU_MAX) {
+    const firstKey = lruCache.keys().next().value;
+    if (firstKey !== undefined) lruCache.delete(firstKey);
+  }
+  lruCache.set(key, Date.now() + ttlSeconds * 1000);
+}
+
+function lruHas(key: string): boolean {
+  const expiry = lruCache.get(key);
+  if (expiry === undefined) return false;
+  if (Date.now() > expiry) {
+    lruCache.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function incrementRedisErrorCounter(): void {
+  logger.warn('metric: auth_blacklist_redis_errors_total +1');
+}
+
 /**
  * Parses a JWT expiry string (e.g. "15m", "7d", "1h") into seconds.
  * Falls back to the provided default if parsing fails.
@@ -32,6 +58,7 @@ export const AuthBlacklistService = {
    */
   blacklistToken: async (tokenKey: string, ttlSeconds: number): Promise<void> => {
     if (ttlSeconds <= 0) return; // already expired, nothing to store
+    lruSet(tokenKey, ttlSeconds);
     try {
       await getRedis().set(`${BLACKLIST_PREFIX}${tokenKey}`, '1', 'EX', ttlSeconds);
     } catch (err) {
@@ -41,15 +68,17 @@ export const AuthBlacklistService = {
 
   /**
    * Returns true if the token has been blacklisted.
-   * Fails closed on Redis error: denies the request to prevent revoked tokens from passing.
+   * On Redis error, logs a warning, increments the error counter, and falls
+   * back to the in-memory LRU cache so valid tokens are not blocked.
    */
   isBlacklisted: async (tokenKey: string): Promise<boolean> => {
     try {
       const result = await getRedis().get(`${BLACKLIST_PREFIX}${tokenKey}`);
       return result !== null;
     } catch (err) {
-      logger.error('Redis unavailable for blacklist check — failing closed', { tokenKey, err });
-      return true; // deny on error (fail-closed)
+      incrementRedisErrorCounter();
+      logger.warn('Redis unavailable for blacklist check — falling back to LRU cache', { tokenKey, err });
+      return lruHas(tokenKey);
     }
   },
 

--- a/backend/src/services/BillingService.ts
+++ b/backend/src/services/BillingService.ts
@@ -1,10 +1,9 @@
 import Stripe from 'stripe';
 import { randomUUID } from 'crypto';
+import { prisma } from '../lib/prisma';
 import { createLogger } from '../lib/logger';
 import {
   Subscription,
-  SubscriptionStore,
-  CreditLogStore,
   PLAN_CREDITS,
   SubscriptionPlan,
   ACTION_COST,
@@ -14,9 +13,35 @@ import {
 const logger = createLogger('billing-service');
 
 function stripe(): Stripe {
-  const key = process.env.STRIPE_SECRET_KEY;
-  if (!key) throw new Error('STRIPE_SECRET_KEY is not set');
-  return new Stripe(key, { apiVersion: '2026-02-25.clover' });
+  return new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2026-02-25.clover' });
+}
+
+function toSubscription(row: {
+  id: string;
+  userId: string;
+  plan: string;
+  status: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string | null;
+  creditsRemaining: number;
+  creditsMonthly: number;
+  currentPeriodEnd: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): Subscription {
+  return {
+    id: row.id,
+    userId: row.userId,
+    plan: row.plan as SubscriptionPlan,
+    status: row.status as Subscription['status'],
+    stripeCustomerId: row.stripeCustomerId,
+    stripeSubscriptionId: row.stripeSubscriptionId,
+    creditsRemaining: row.creditsRemaining,
+    creditsMonthly: row.creditsMonthly,
+    currentPeriodEnd: row.currentPeriodEnd,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
 }
 
 export class BillingService {
@@ -26,42 +51,41 @@ export class BillingService {
 
   /** Create or retrieve a Stripe customer and provision a free subscription */
   public async provisionUser(userId: string, email: string): Promise<Subscription> {
-    const existing = SubscriptionStore.findByUserId(userId);
-    if (existing) return existing;
+    const existing = await prisma.subscription.findUnique({ where: { userId } });
+    if (existing) return toSubscription(existing);
 
-    // Search for an existing Stripe customer by email before creating a new one
-    // to prevent duplicate customers when provisionUser is called more than once.
     const existingCustomers = await stripe().customers.list({ email, limit: 1 });
     const customer =
       existingCustomers.data.length > 0
         ? existingCustomers.data[0]
         : await stripe().customers.create({ email, metadata: { userId } });
 
-    const sub: Subscription = {
-      id: randomUUID(),
-      userId,
-      plan: 'free',
-      status: 'active',
-      stripeCustomerId: customer.id,
-      stripeSubscriptionId: null,
-      creditsRemaining: PLAN_CREDITS.free,
-      creditsMonthly: PLAN_CREDITS.free,
-      currentPeriodEnd: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    const sub = await prisma.subscription.create({
+      data: {
+        id: randomUUID(),
+        userId,
+        plan: 'free',
+        status: 'active',
+        stripeCustomerId: customer.id,
+        stripeSubscriptionId: null,
+        creditsRemaining: PLAN_CREDITS.free,
+        creditsMonthly: PLAN_CREDITS.free,
+        currentPeriodEnd: null,
+      },
+    });
 
-    SubscriptionStore.upsert(sub);
-    CreditLogStore.append({
-      userId,
-      action: 'credit:reset',
-      delta: PLAN_CREDITS.free,
-      balanceAfter: PLAN_CREDITS.free,
-      metadata: { reason: 'initial_provision' },
+    await prisma.creditLog.create({
+      data: {
+        userId,
+        action: 'credit:reset',
+        delta: PLAN_CREDITS.free,
+        balanceAfter: PLAN_CREDITS.free,
+        metadata: { reason: 'initial_provision' },
+      },
     });
 
     logger.info('User provisioned', { userId, customerId: customer.id });
-    return sub;
+    return toSubscription(sub);
   }
 
   /** Create a Stripe Checkout session for upgrading to a paid plan */
@@ -71,7 +95,7 @@ export class BillingService {
     successUrl: string,
     cancelUrl: string,
   ): Promise<string> {
-    const sub = SubscriptionStore.findByUserId(userId);
+    const sub = await prisma.subscription.findUnique({ where: { userId } });
     if (!sub) throw new Error('User not provisioned for billing');
 
     // Explicitly list accepted payment methods to prevent unexpected changes
@@ -98,7 +122,7 @@ export class BillingService {
 
   /** Create a Stripe Customer Portal session for managing billing */
   public async createPortalSession(userId: string, returnUrl: string): Promise<string> {
-    const sub = SubscriptionStore.findByUserId(userId);
+    const sub = await prisma.subscription.findUnique({ where: { userId } });
     if (!sub) throw new Error('User not provisioned for billing');
 
     const session = await stripe().billingPortal.sessions.create({
@@ -113,8 +137,8 @@ export class BillingService {
    * Deduct credits for an action. Throws if insufficient balance.
    * Returns updated balance.
    */
-  public deductCredits(userId: string, action: CreditAction): number {
-    const sub = SubscriptionStore.findByUserId(userId);
+  public async deductCredits(userId: string, action: CreditAction): Promise<number> {
+    const sub = await prisma.subscription.findUnique({ where: { userId } });
     if (!sub) throw new Error('No subscription found for user');
     if (sub.status !== 'active' && sub.status !== 'trialing') {
       throw new Error('Subscription is not active');
@@ -128,8 +152,10 @@ export class BillingService {
     }
 
     const newBalance = sub.creditsRemaining - cost;
-    SubscriptionStore.patch(userId, { creditsRemaining: newBalance });
-    CreditLogStore.append({ userId, action, delta: -cost, balanceAfter: newBalance });
+    await prisma.subscription.update({ where: { userId }, data: { creditsRemaining: newBalance } });
+    await prisma.creditLog.create({
+      data: { userId, action, delta: -cost, balanceAfter: newBalance },
+    });
 
     return newBalance;
   }
@@ -139,8 +165,8 @@ export class BillingService {
    * Throws if the user has insufficient credits.
    * Returns updated balance.
    */
-  public deductCreditsForTokens(userId: string, tokens: number): number {
-    const sub = SubscriptionStore.findByUserId(userId);
+  public async deductCreditsForTokens(userId: string, tokens: number): Promise<number> {
+    const sub = await prisma.subscription.findUnique({ where: { userId } });
     if (!sub) throw new Error('No subscription found for user');
     if (sub.status !== 'active' && sub.status !== 'trialing') {
       throw new Error('Subscription is not active');
@@ -153,31 +179,34 @@ export class BillingService {
     }
 
     const newBalance = sub.creditsRemaining - tokens;
-    SubscriptionStore.patch(userId, { creditsRemaining: newBalance });
-    CreditLogStore.append({ userId, action: 'ai:generate', delta: -tokens, balanceAfter: newBalance });
+    await prisma.subscription.update({ where: { userId }, data: { creditsRemaining: newBalance } });
+    await prisma.creditLog.create({
+      data: { userId, action: 'ai:generate', delta: -tokens, balanceAfter: newBalance },
+    });
 
     return newBalance;
   }
 
   /**
    * Refund credits for a previously deducted action (compensating transaction).
-   * Used when a downstream operation (e.g. platform publish) fails after credits
-   * have already been deducted, so the user is not left short-changed.
+   * Used when a downstream operation fails after credits have already been deducted.
    * Returns the restored balance.
    */
-  public refundCredits(userId: string, action: CreditAction, reason?: string): number {
-    const sub = SubscriptionStore.findByUserId(userId);
+  public async refundCredits(userId: string, action: CreditAction, reason?: string): Promise<number> {
+    const sub = await prisma.subscription.findUnique({ where: { userId } });
     if (!sub) throw new Error('No subscription found for user');
 
     const cost = ACTION_COST[action] ?? 1;
     const newBalance = sub.creditsRemaining + cost;
-    SubscriptionStore.patch(userId, { creditsRemaining: newBalance });
-    CreditLogStore.append({
-      userId,
-      action: 'credit:topup',
-      delta: cost,
-      balanceAfter: newBalance,
-      metadata: { reason: reason ?? 'refund', refundedAction: action },
+    await prisma.subscription.update({ where: { userId }, data: { creditsRemaining: newBalance } });
+    await prisma.creditLog.create({
+      data: {
+        userId,
+        action: 'credit:topup',
+        delta: cost,
+        balanceAfter: newBalance,
+        metadata: { reason: reason ?? 'refund', refundedAction: action },
+      },
     });
 
     logger.info('Credits refunded', { userId, action, cost, newBalance, reason });
@@ -207,9 +236,14 @@ export class BillingService {
       }
       case 'customer.subscription.deleted': {
         const stripeSub = event.data.object as Stripe.Subscription;
-        const sub = SubscriptionStore.findByStripeSubscriptionId(stripeSub.id);
+        const sub = await prisma.subscription.findFirst({
+          where: { stripeSubscriptionId: stripeSub.id },
+        });
         if (sub) {
-          SubscriptionStore.patch(sub.userId, { status: 'canceled', stripeSubscriptionId: null });
+          await prisma.subscription.update({
+            where: { userId: sub.userId },
+            data: { status: 'canceled', stripeSubscriptionId: null },
+          });
         }
         break;
       }
@@ -220,8 +254,15 @@ export class BillingService {
       }
       case 'invoice.payment_failed': {
         const invoice = event.data.object as Stripe.Invoice;
-        const sub = SubscriptionStore.findByStripeCustomerId(invoice.customer as string);
-        if (sub) SubscriptionStore.patch(sub.userId, { status: 'past_due' });
+        const sub = await prisma.subscription.findFirst({
+          where: { stripeCustomerId: invoice.customer as string },
+        });
+        if (sub) {
+          await prisma.subscription.update({
+            where: { userId: sub.userId },
+            data: { status: 'past_due' },
+          });
+        }
         break;
       }
     }
@@ -229,43 +270,51 @@ export class BillingService {
 
   private async syncSubscription(stripeSub: Stripe.Subscription): Promise<void> {
     const customerId = stripeSub.customer as string;
-    const sub = SubscriptionStore.findByStripeCustomerId(customerId);
+    const sub = await prisma.subscription.findFirst({ where: { stripeCustomerId: customerId } });
     if (!sub) {
       logger.warn('No local subscription for Stripe customer', { customerId });
       return;
     }
 
-    // Derive plan from price metadata or product name (convention: metadata.plan)
     const priceId = stripeSub.items.data[0]?.price.id ?? '';
     const price = await stripe().prices.retrieve(priceId, { expand: ['product'] });
     const product = price.product as Stripe.Product;
     const plan = (product.metadata?.plan as SubscriptionPlan) ?? 'starter';
 
-    SubscriptionStore.patch(sub.userId, {
-      plan,
-      status: stripeSub.status as Subscription['status'],
-      stripeSubscriptionId: stripeSub.id,
-      currentPeriodEnd: stripeSub.items.data[0]?.current_period_end
-        ? new Date(stripeSub.items.data[0].current_period_end * 1000)
-        : null,
+    await prisma.subscription.update({
+      where: { userId: sub.userId },
+      data: {
+        plan,
+        status: stripeSub.status,
+        stripeSubscriptionId: stripeSub.id,
+        currentPeriodEnd: stripeSub.items.data[0]?.current_period_end
+          ? new Date(stripeSub.items.data[0].current_period_end * 1000)
+          : null,
+      },
     });
   }
 
   private async onPaymentSucceeded(invoice: Stripe.Invoice): Promise<void> {
-    // Only reset credits on subscription renewals (not one-off invoices)
     if (invoice.billing_reason !== 'subscription_cycle') return;
 
-    const sub = SubscriptionStore.findByStripeCustomerId(invoice.customer as string);
+    const sub = await prisma.subscription.findFirst({
+      where: { stripeCustomerId: invoice.customer as string },
+    });
     if (!sub) return;
 
-    const monthly = PLAN_CREDITS[sub.plan];
-    SubscriptionStore.patch(sub.userId, { creditsRemaining: monthly, creditsMonthly: monthly });
-    CreditLogStore.append({
-      userId: sub.userId,
-      action: 'credit:reset',
-      delta: monthly,
-      balanceAfter: monthly,
-      metadata: { reason: 'billing_cycle_renewal', invoiceId: invoice.id },
+    const monthly = PLAN_CREDITS[sub.plan as SubscriptionPlan];
+    await prisma.subscription.update({
+      where: { userId: sub.userId },
+      data: { creditsRemaining: monthly, creditsMonthly: monthly },
+    });
+    await prisma.creditLog.create({
+      data: {
+        userId: sub.userId,
+        action: 'credit:reset',
+        delta: monthly,
+        balanceAfter: monthly,
+        metadata: { reason: 'billing_cycle_renewal', invoiceId: invoice.id },
+      },
     });
 
     logger.info('Credits reset on renewal', { userId: sub.userId, credits: monthly });

--- a/backend/src/services/WebhookDispatcher.ts
+++ b/backend/src/services/WebhookDispatcher.ts
@@ -1,9 +1,66 @@
 import crypto from 'crypto';
+import { isIP } from 'net';
+import dns from 'dns/promises';
 import { prisma } from '../lib/prisma';
 import { createLogger } from '../lib/logger';
 import { WebhookEventType } from '../schemas/webhooks';
 
 const logger = createLogger('WebhookDispatcher');
+
+// RFC 1918 + loopback + link-local CIDRs blocked to prevent SSRF
+const BLOCKED_CIDRS: Array<{ base: number; mask: number }> = [
+  { base: ipToInt('10.0.0.0'), mask: 0xff000000 },
+  { base: ipToInt('172.16.0.0'), mask: 0xfff00000 },
+  { base: ipToInt('192.168.0.0'), mask: 0xffff0000 },
+  { base: ipToInt('127.0.0.0'), mask: 0xff000000 },
+  { base: ipToInt('169.254.0.0'), mask: 0xffff0000 },
+  { base: ipToInt('0.0.0.0'), mask: 0xff000000 },
+];
+
+function ipToInt(ip: string): number {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) | parseInt(octet, 10), 0) >>> 0;
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  if (isIP(ip) !== 4) return false;
+  const n = ipToInt(ip);
+  return BLOCKED_CIDRS.some(({ base, mask }) => (n & mask) === base);
+}
+
+async function assertSafeUrl(url: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid webhook URL: ${url}`);
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Webhook URL must use https (got ${parsed.protocol}): ${url}`);
+  }
+
+  const hostname = parsed.hostname;
+
+  if (isIP(hostname) === 4) {
+    if (isPrivateIPv4(hostname)) {
+      throw new Error(`Webhook URL resolves to a blocked address: ${url}`);
+    }
+    return;
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await dns.resolve4(hostname);
+  } catch {
+    throw new Error(`Webhook URL hostname could not be resolved: ${hostname}`);
+  }
+
+  for (const addr of addresses) {
+    if (isPrivateIPv4(addr)) {
+      throw new Error(`Webhook URL resolves to a blocked address (${addr}): ${url}`);
+    }
+  }
+}
 
 const MAX_ATTEMPTS = 5;
 const TIMEOUT_MS = 10_000; // 10 s per request
@@ -79,6 +136,18 @@ export async function attemptDelivery(
   payload: string,
   attempt: number,
 ): Promise<void> {
+  try {
+    await assertSafeUrl(url);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    logger.error(`Delivery ${deliveryId} blocked — unsafe URL`, { url, errorMessage });
+    await prisma.webhookDelivery.update({
+      where: { id: deliveryId },
+      data: { status: 'failed', attempts: attempt, nextRetryAt: null, errorMessage },
+    });
+    return;
+  }
+
   const signature = sign(secret, payload);
 
   let responseStatus: number | undefined;


### PR DESCRIPTION
## Summary

- **#805** — Replaced in-memory `SubscriptionStore`/`CreditLogStore` with Prisma queries; added `Subscription` and `CreditLog` models to `schema.prisma` so data survives pod restarts and is consistent across replicas.
- **#806** — Changed `AuthBlacklistService.isBlacklisted` to fail-open on Redis errors: logs a warning, emits a `auth_blacklist_redis_errors_total` metric, and falls back to an in-memory LRU cache (1 000 entries) seeded on every `blacklistToken` call.
- **#807** — Added SSRF protection to `WebhookDispatcher`: validates scheme is `https`, resolves the hostname via DNS, and blocks delivery to RFC 1918, loopback (`127.x`), and link-local (`169.254.x`) addresses before making any HTTP request.
- **#808** — Promoted `STRIPE_SECRET_KEY` from `optional()` to `required` in the Zod env schema (`config.ts`) so a misconfigured pod fails at startup instead of at the first billing call; removed the redundant runtime throw from the `stripe()` factory.

## Files changed

| File | Change |
|---|---|
| `backend/prisma/schema.prisma` | Add `Subscription` + `CreditLog` Prisma models |
| `backend/src/models/Subscription.ts` | Remove in-memory stores; keep types/constants |
| `backend/src/services/BillingService.ts` | Replace all store calls with `prisma.*`; make credit methods `async` |
| `backend/src/config/config.ts` | `STRIPE_SECRET_KEY` now required in Zod schema |
| `backend/src/services/AuthBlacklistService.ts` | Fail-open on Redis error with LRU fallback + metric counter |
| `backend/src/services/WebhookDispatcher.ts` | `assertSafeUrl` validates https + blocks private IPs before dispatch |

Closes #805
Closes #806
Closes #807
Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)