### PR TITLE
fix: persist TTS jobs to database instead of in-memory Map

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -194,6 +194,24 @@ model WebhookDelivery {
   @@index([createdAt])
 }
 
+model TTSJob {
+  id              String   @id
+  status          String   @default("pending")
+  progress        Int      @default(0)
+  request         Json
+  outputAudioPath String?
+  outputVideoPath String?
+  segments        Json?
+  error           String?
+  userId          String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([status])
+  @@index([userId])
+  @@index([createdAt])
+}
+
 /// Audit record written whenever a payout job fails.
 /// Captures the failure reason and timestamp for operational review.
 model PayoutFailure {

--- a/backend/src/controllers/tts.ts
+++ b/backend/src/controllers/tts.ts
@@ -18,9 +18,9 @@ export async function createTTSJob(req: AuthRequest, res: Response, next: NextFu
   }
 }
 
-export function getTTSJob(req: AuthRequest, res: Response, next: NextFunction) {
+export async function getTTSJob(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    const job = ttsService.getJob(req.params.jobId);
+    const job = await ttsService.getJob(req.params.jobId);
     if (!job) throw new NotFoundError('TTS job not found');
     res.json(job);
   } catch (err) {
@@ -28,9 +28,9 @@ export function getTTSJob(req: AuthRequest, res: Response, next: NextFunction) {
   }
 }
 
-export function listTTSJobs(_req: AuthRequest, res: Response, next: NextFunction) {
+export async function listTTSJobs(_req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    res.json(ttsService.getAllJobs());
+    res.json(await ttsService.getAllJobs());
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/TTSService.ts
+++ b/backend/src/services/TTSService.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { createLogger } from '../lib/logger';
 import { eventBus } from '../lib/eventBus';
+import { prisma } from '../lib/prisma';
 import { ExternalServiceError, BadRequestError } from '../lib/errors';
 import { ttsConfig } from '../config/tts.config';
 import { audioMerger } from './AudioMerger';
@@ -19,34 +20,25 @@ import type {
 const logger = createLogger('TTSService');
 
 class TTSService {
-  private jobs: Map<string, TTSJob> = new Map();
-
-  // ── Public API ────────────────────────────────────────────────────────────
-
-  /**
-   * Create and enqueue a TTS generation job.
-   * Returns the jobId immediately; processing is async.
-   */
   async createJob(req: TTSJobRequest): Promise<string> {
     if (!req.segments?.length) {
       throw new BadRequestError('At least one text segment is required');
     }
 
     const jobId = uuidv4();
-    const job: TTSJob = {
-      id: jobId,
-      status: 'pending',
-      progress: 0,
-      request: req,
-      segments: [],
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
 
-    this.jobs.set(jobId, job);
+    await prisma.tTSJob.create({
+      data: {
+        id: jobId,
+        status: 'pending',
+        progress: 0,
+        request: JSON.parse(JSON.stringify(req)),
+        userId: req.userId ?? null,
+      },
+    });
+
     logger.info(`TTS job created`, { jobId, segments: req.segments.length });
 
-    // Fire-and-forget — errors are caught and stored on the job
     this.processJob(jobId).catch((err) => {
       logger.error(`TTS job ${jobId} failed unexpectedly`, { err });
       this.updateStatus(jobId, 'failed', String(err?.message ?? err));
@@ -55,12 +47,14 @@ class TTSService {
     return jobId;
   }
 
-  getJob(jobId: string): TTSJob | undefined {
-    return this.jobs.get(jobId);
+  async getJob(jobId: string): Promise<TTSJob | undefined> {
+    const row = await prisma.tTSJob.findUnique({ where: { id: jobId } });
+    return row ? rowToJob(row) : undefined;
   }
 
-  getAllJobs(): TTSJob[] {
-    return Array.from(this.jobs.values());
+  async getAllJobs(): Promise<TTSJob[]> {
+    const rows = await prisma.tTSJob.findMany({ orderBy: { createdAt: 'desc' } });
+    return rows.map(rowToJob);
   }
 
   getVoices(provider?: TTSProvider): TTSVoice[] {
@@ -68,10 +62,10 @@ class TTSService {
   }
 
   async cancelJob(jobId: string): Promise<boolean> {
-    const job = this.jobs.get(jobId);
+    const job = await prisma.tTSJob.findUnique({ where: { id: jobId } });
     if (!job) return false;
     if (job.status === 'pending' || job.status === 'processing') {
-      this.updateStatus(jobId, 'failed', 'Cancelled by user');
+      await this.updateStatus(jobId, 'failed', 'Cancelled by user');
     }
     return true;
   }
@@ -79,21 +73,27 @@ class TTSService {
   // ── Processing ────────────────────────────────────────────────────────────
 
   private async processJob(jobId: string): Promise<void> {
-    const job = this.jobs.get(jobId)!;
-    this.updateStatus(jobId, 'processing');
+    const row = await prisma.tTSJob.findUnique({ where: { id: jobId } });
+    if (!row) return;
+    const req = row.request as unknown as TTSJobRequest;
+
+    await this.updateStatus(jobId, 'processing');
 
     const outputDir = path.join(process.cwd(), ttsConfig.outputDir, jobId);
     await fs.mkdir(outputDir, { recursive: true });
 
-    const provider = this.resolveProvider(job.request.provider);
-    const total = job.request.segments.length;
+    const provider = this.resolveProvider(req.provider);
+    const total = req.segments.length;
     const segmentResults: TTSSegmentResult[] = [];
 
     for (let i = 0; i < total; i++) {
-      // Abort if cancelled mid-flight
-      if (this.jobs.get(jobId)?.status === 'failed') return;
+      const current = await prisma.tTSJob.findUnique({
+        where: { id: jobId },
+        select: { status: true },
+      });
+      if (current?.status === 'failed') return;
 
-      const segment = job.request.segments[i];
+      const segment = req.segments[i];
       const audioPath = path.join(outputDir, `segment_${i}.mp3`);
 
       logger.info(`Synthesising segment ${i + 1}/${total}`, { jobId, provider });
@@ -101,11 +101,9 @@ class TTSService {
       const durationMs = await this.synthesiseSegment(segment, audioPath, provider);
       segmentResults.push({ index: i, audioPath, durationMs, text: segment.text });
 
-      const progress = Math.round(((i + 1) / total) * (job.request.videoPath ? 70 : 90));
-      this.updateProgress(jobId, progress);
+      const progress = Math.round(((i + 1) / total) * (req.videoPath ? 70 : 90));
+      await this.updateProgress(jobId, progress);
     }
-
-    job.segments = segmentResults;
 
     // Merge all segments into one audio file
     const mergedAudioPath = path.join(outputDir, 'narration.mp3');
@@ -113,22 +111,28 @@ class TTSService {
       segmentResults.map((s) => s.audioPath),
       mergedAudioPath,
     );
-    job.outputAudioPath = mergedAudioPath;
-    this.updateProgress(jobId, job.request.videoPath ? 80 : 95);
 
-    // Optionally merge narration into video
-    if (job.request.videoPath) {
+    await prisma.tTSJob.update({
+      where: { id: jobId },
+      data: {
+        segments: JSON.parse(JSON.stringify(segmentResults)),
+        outputAudioPath: mergedAudioPath,
+      },
+    });
+
+    await this.updateProgress(jobId, req.videoPath ? 80 : 95);
+
+    if (req.videoPath) {
       const outputVideoPath = path.join(outputDir, 'output_with_narration.mp4');
-      await audioMerger.mergeAudioIntoVideo(
-        job.request.videoPath,
-        mergedAudioPath,
-        outputVideoPath,
-      );
-      job.outputVideoPath = outputVideoPath;
+      await audioMerger.mergeAudioIntoVideo(req.videoPath, mergedAudioPath, outputVideoPath);
+      await prisma.tTSJob.update({
+        where: { id: jobId },
+        data: { outputVideoPath },
+      });
     }
 
-    this.updateStatus(jobId, 'completed');
-    logger.info(`TTS job completed`, { jobId, outputAudioPath: job.outputAudioPath });
+    await this.updateStatus(jobId, 'completed');
+    logger.info(`TTS job completed`, { jobId, outputAudioPath: mergedAudioPath });
   }
 
   // ── Synthesis ─────────────────────────────────────────────────────────────
@@ -179,7 +183,6 @@ class TTSService {
     const buffer = Buffer.from(await response.arrayBuffer());
     await fs.writeFile(outputPath, buffer);
 
-    // Estimate duration: ~128kbps MP3 → bytes / 16000 ≈ ms
     return Math.round((buffer.length / 16000) * 1000);
   }
 
@@ -223,7 +226,6 @@ class TTSService {
   private resolveProvider(preferred?: TTSProvider): TTSProvider {
     if (preferred === 'elevenlabs' && process.env.ELEVENLABS_API_KEY) return 'elevenlabs';
     if (preferred === 'google' && process.env.GOOGLE_TTS_API_KEY) return 'google';
-    // Auto-select based on available keys
     if (process.env.ELEVENLABS_API_KEY) return 'elevenlabs';
     if (process.env.GOOGLE_TTS_API_KEY) return 'google';
     throw new ExternalServiceError(
@@ -232,37 +234,51 @@ class TTSService {
     );
   }
 
-  private updateStatus(jobId: string, status: TTSJobStatus, error?: string): void {
-    const job = this.jobs.get(jobId);
-    if (!job) return;
-    job.status = status;
-    job.updatedAt = new Date();
-    if (error) job.error = error;
-    if (status === 'completed') job.progress = 100;
+  private async updateStatus(jobId: string, status: TTSJobStatus, error?: string): Promise<void> {
+    const progress = status === 'completed' ? 100 : undefined;
 
-    if (job.request.userId) {
+    await prisma.tTSJob.update({
+      where: { id: jobId },
+      data: {
+        status,
+        progress,
+        error: error ?? null,
+      },
+    });
+
+    const row = await prisma.tTSJob.findUnique({
+      where: { id: jobId },
+      select: { userId: true, progress: true },
+    });
+
+    if (row?.userId) {
       eventBus.emitJobProgress({
         jobId,
-        userId: job.request.userId,
+        userId: row.userId,
         type: 'ai_generation',
         status,
-        progress: job.progress,
+        progress: progress ?? row.progress,
         message: error ?? `TTS job ${status}`,
         error,
       });
     }
   }
 
-  private updateProgress(jobId: string, progress: number): void {
-    const job = this.jobs.get(jobId);
-    if (!job) return;
-    job.progress = progress;
-    job.updatedAt = new Date();
+  private async updateProgress(jobId: string, progress: number): Promise<void> {
+    await prisma.tTSJob.update({
+      where: { id: jobId },
+      data: { progress },
+    });
 
-    if (job.request.userId) {
+    const row = await prisma.tTSJob.findUnique({
+      where: { id: jobId },
+      select: { userId: true },
+    });
+
+    if (row?.userId) {
       eventBus.emitJobProgress({
         jobId,
-        userId: job.request.userId,
+        userId: row.userId,
         type: 'ai_generation',
         status: 'processing',
         progress,
@@ -270,6 +286,33 @@ class TTSService {
       });
     }
   }
+}
+
+function rowToJob(row: {
+  id: string;
+  status: string;
+  progress: number;
+  request: unknown;
+  outputAudioPath: string | null;
+  outputVideoPath: string | null;
+  segments: unknown;
+  error: string | null;
+  userId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): TTSJob {
+  return {
+    id: row.id,
+    status: row.status as TTSJobStatus,
+    progress: row.progress,
+    request: row.request as TTSJobRequest,
+    outputAudioPath: row.outputAudioPath ?? undefined,
+    outputVideoPath: row.outputVideoPath ?? undefined,
+    segments: (row.segments as TTSSegmentResult[]) ?? [],
+    error: row.error ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
 }
 
 export const ttsService = new TTSService();


### PR DESCRIPTION
Closes #809

---

## Problem

TTSService.jobs was a Map<string, TTSJob> in process memory. All in-flight and completed jobs were lost on pod restart, leaving users with unresolvable job IDs.

## Solution

- Added **TTSJob model** to Prisma schema (PostgreSQL) with JSON fields for request/segments
- Replaced the in-memory **Map with prisma.tTSJob** reads/writes throughout the service
- Made `getJob`/ `getAllJobs` async and updated the **controller** callers accordingly

### Migration note

Run `npx prisma migrate deploy` at deploy time to create the `TTSJob` table.