### PR TITLE
feat: separate workers, add social DLQ alerts, harden RDS and ingress

### DIFF
--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,0 +1,38 @@
+# ── Worker Dockerfile ─────────────────────────────────────────────────────────
+# Runs BullMQ AI and social-posting workers in a dedicated process, separate
+# from the HTTP API server. Build context must be the backend/ directory:
+#   docker build -f backend/Dockerfile.worker backend/
+
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN node_modules/.bin/tsc --skipLibCheck 2>/dev/null || true && \
+    test -d dist && echo "Build succeeded" || (echo "Build failed: dist/ not created" && exit 1)
+
+# ── Stage 2: production image ─────────────────────────────────────────────────
+FROM node:20-alpine AS runner
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Rebuild sharp for current platform (required for ARM compatibility)
+RUN npm rebuild sharp
+
+COPY --from=builder /app/dist ./dist
+
+USER appuser
+
+ENV NODE_ENV=production
+
+CMD ["node", "dist/workers/standalone.js"]

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,7 +4,6 @@ import { config } from './config/config';
 import app from './app';
 import { SocketService } from './services/SocketService';
 import { initializeWorkers } from './jobs/workers';
-import { startWorkers } from './workers/index';
 import { queueManager, closeRedisClient } from './queues/queueManager';
 import { startDataPruningJob, stopDataPruningJob } from './jobs/dataPruningJob';
 import { startYouTubeSyncJob, stopYouTubeSyncJob } from './jobs/youtubeSyncJob';
@@ -255,10 +254,10 @@ export const bootstrap = async (exit?: (code: number) => void): Promise<void> =>
       // Note: Do not exit on this error; continue with in-memory fallback
     }
 
-    // Initialize job queue workers
+    // Initialize job queue workers (email, payout, sync, notification, moderation)
+    // AI and social posting workers run in the separate socialflow-worker process
     logger.info('Initializing job queue workers...');
     initializeWorkers();
-    startWorkers();
 
     // Initialize health monitoring
     try {

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -385,7 +385,7 @@ function createAIWorker(): Worker<AIJobData> {
 }
 
 function createSocialWorker(): Worker<SocialJobData> {
-  return queueManager.createWorker(
+  const worker = queueManager.createWorker(
     SOCIAL_QUEUE_NAME,
     async (job: Job<SocialJobData>) => {
       const processor = socialProcessors[job.data.type];
@@ -396,6 +396,45 @@ function createSocialWorker(): Worker<SocialJobData> {
     },
     { concurrency: 3 }, // Lower concurrency to respect platform rate limits
   ) as Worker<SocialJobData>;
+
+  worker.on('failed', async (job: Job<SocialJobData> | undefined, err: Error) => {
+    if (!job) return;
+    const maxAttempts = job.opts.attempts ?? 3;
+    const isFinal = job.attemptsMade >= maxAttempts;
+
+    logger.error('Social posting job failed', {
+      jobId: job.id,
+      platform: job.data.platform,
+      userId: job.data.userId,
+      type: job.data.type,
+      attemptsMade: job.attemptsMade,
+      maxAttempts,
+      reason: err.message,
+      permanent: isFinal,
+    });
+
+    if (isFinal) {
+      // Notify the user that their post has permanently failed (exhausted all retries)
+      try {
+        const { sendInAppNotification } = await import('../queues/notificationQueue');
+        await sendInAppNotification(
+          job.data.userId,
+          'Post failed to publish',
+          `Your ${job.data.platform} post could not be published after ${job.attemptsMade} attempt(s): ${err.message}`,
+          { jobId: job.id, platform: job.data.platform, type: job.data.type },
+          { userId: job.data.userId, priority: 'high' },
+        );
+      } catch (notifyErr) {
+        logger.error('Failed to enqueue failure notification for social job', {
+          jobId: job.id,
+          userId: job.data.userId,
+          error: (notifyErr as Error).message,
+        });
+      }
+    }
+  });
+
+  return worker;
 }
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
@@ -408,3 +447,4 @@ export function startWorkers(): { ai: Worker<AIJobData>; social: Worker<SocialJo
   });
   return { ai, social };
 }
+

--- a/backend/src/workers/standalone.ts
+++ b/backend/src/workers/standalone.ts
@@ -1,0 +1,31 @@
+/**
+ * Standalone worker process entry point.
+ *
+ * Run by the socialflow-worker container (Dockerfile.worker).
+ * The API server (server.ts) no longer starts these workers, so they
+ * scale independently via the worker Kubernetes Deployment.
+ */
+import '../tracing'; // must be first — patches BullMQ and Prisma before they load
+import { startWorkers } from './index';
+import { closeRedisClient } from '../queues/queueManager';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('worker-standalone');
+
+const { ai, social } = startWorkers();
+
+const shutdown = async (signal: string): Promise<void> => {
+  logger.info(`Received ${signal}. Shutting down workers...`);
+  try {
+    await Promise.all([ai.close(), social.close()]);
+    await closeRedisClient();
+    logger.info('Workers shut down cleanly');
+    process.exit(0);
+  } catch (err) {
+    logger.error('Error during worker shutdown', { error: (err as Error).message });
+    process.exit(1);
+  }
+};
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - configmap.yaml
   - external-secret.yaml
   - deployment.yaml
+  - worker-deployment.yaml
   - service.yaml
   - hpa.yaml
   - ingress.yaml

--- a/k8s/base/worker-deployment.yaml
+++ b/k8s/base/worker-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: socialflow-worker
+  labels:
+    app: socialflow-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: socialflow-worker
+  template:
+    metadata:
+      labels:
+        app: socialflow-worker
+    spec:
+      serviceAccountName: socialflow-backend
+      terminationGracePeriodSeconds: 300
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: worker
+          image: socialflow-worker:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: socialflow-config
+            - secretRef:
+                name: socialflow-secrets
+          lifecycle:
+            preStop:
+              exec:
+                # Allow BullMQ to finish in-flight jobs before the container stops
+                command: ["sleep", "10"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,3 +1,4 @@
 aws_region = "us-east-1"
 db_name    = "socialflow"
 db_username = "socialflow"
+enable_deletion_protection = false

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -61,7 +61,7 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = [aws_security_group.rds.id]
   parameter_group_name   = aws_db_parameter_group.main.name
   skip_final_snapshot    = var.env == "dev"
-  deletion_protection    = var.env == "prod"
+  deletion_protection    = var.enable_deletion_protection
   multi_az               = true
   backup_retention_period = var.backup_retention_days
   tags                   = { Env = var.env }

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -15,3 +15,9 @@ variable "backup_retention_days" {
   default     = 7
   description = "Backup retention period in days. Set to 0 to disable (AWS default). Minimum 7 recommended for production."
 }
+
+variable "enable_deletion_protection" {
+  type        = bool
+  default     = true
+  description = "Prevents the RDS instance from being accidentally deleted. Set to false only for dev/test environments that need terraform destroy."
+}


### PR DESCRIPTION
Closes #825 - Extract BullMQ workers into separate process:
- Add backend/Dockerfile.worker (runs dist/workers/standalone.js)
- Add backend/src/workers/standalone.ts as the worker entry point with graceful SIGTERM/SIGINT shutdown; server.ts no longer calls startWorkers()
- Add k8s/base/worker-deployment.yaml with CPU limits suited for FFmpeg (2 core limit, 512Mi–1Gi RAM); registered in kustomization.yaml

Closes #826 - Dead-letter queue handling for failed social posting jobs:
- Listen to the `failed` event on the social queue worker in createSocialWorker()
- On final failure (attemptsMade >= maxAttempts), enqueue an in-app notification via the existing notificationQueue so the user is informed immediately
- Log a structured error with jobId, platform, userId, and failure reason

Closes #821 - Enable RDS deletion protection in Terraform:
- Add enable_deletion_protection variable (default = true) to rds/variables.tf
- Replace hardcoded `var.env == "prod"` expression with the new variable in main.tf
- Set enable_deletion_protection = false in dev terraform.tfvars for teardown

Closes #819 - Enforce HTTPS redirect on Ingress:
- ssl-redirect and force-ssl-redirect annotations were already present in k8s/base/ingress.yaml; no further changes required