### PR TITLE
fix: video cleanup, ElastiCache failover, pod anti-affinity, email dedup

### DIFF
--- a/backend/src/queues/emailQueue.ts
+++ b/backend/src/queues/emailQueue.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { queueManager } from './queueManager';
 
 // Queue names
@@ -38,14 +39,10 @@ export const emailQueue = queueManager.createQueue(EMAIL_QUEUE_NAME, {
   removeOnFail: 500,
 });
 
-/**
- * Build a deterministic job ID to deduplicate transactional emails.
- * Same recipient + template on the same UTC date will produce the same ID,
- * so a second enqueue is a no-op in BullMQ.
- */
+// 5-minute deduplication window: same recipient + template within the same bucket maps to the same job ID
 function transactionalJobId(to: string, templateId: string): string {
-  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  return `${to}:${templateId}:${date}`;
+  const bucket = Math.floor(Date.now() / (5 * 60 * 1000));
+  return createHash('sha256').update(`${to}:${templateId}:${bucket}`).digest('hex');
 }
 
 /**

--- a/backend/src/services/VideoService.ts
+++ b/backend/src/services/VideoService.ts
@@ -121,31 +121,35 @@ async function processVideoJob(bullJob: Job<VideoJobPayload>): Promise<void> {
   let completedTasks = 0;
   const outputs: TranscodedOutput[] = [];
 
-  for (const quality of qualities) {
-    for (const format of formats) {
-      const outputPath = path.join(outputDir, `video_${quality.name}.${format.extension}`);
-      try {
-        const output = await transcodeVideo(job, quality, format);
-        outputs.push(output);
-        completedTasks++;
-        const progress = Math.round((completedTasks / totalTasks) * 100);
-        await bullJob.updateProgress(progress);
-        if (userId) {
-          eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'processing', progress, message: `Transcoding ${progress}%` });
+  try {
+    for (const quality of qualities) {
+      for (const format of formats) {
+        const outputPath = path.join(outputDir, `video_${quality.name}.${format.extension}`);
+        try {
+          const output = await transcodeVideo(job, quality, format);
+          outputs.push(output);
+          completedTasks++;
+          const progress = Math.round((completedTasks / totalTasks) * 100);
+          await bullJob.updateProgress(progress);
+          if (userId) {
+            eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'processing', progress, message: `Transcoding ${progress}%` });
+          }
+        } catch (error) {
+          await fs.rm(outputPath, { force: true }).catch(() => {});
+          logger.error(`Failed to transcode ${quality.name} ${format.extension}:`, { error });
         }
-      } catch (error) {
-        await fs.rm(outputPath, { force: true }).catch(() => {});
-        logger.error(`Failed to transcode ${quality.name} ${format.extension}:`, { error });
       }
     }
-  }
 
-  if (outputs.length === 0) {
-    throw new Error('All transcoding attempts failed');
-  }
+    if (outputs.length === 0) {
+      throw new Error('All transcoding attempts failed');
+    }
 
-  if (userId) {
-    eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'completed', progress: 100, message: 'Job completed' });
+    if (userId) {
+      eventBus.emitJobProgress({ jobId, userId, type: 'video_transcoding', status: 'completed', progress: 100, message: 'Job completed' });
+    }
+  } finally {
+    await fs.unlink(inputPath).catch(() => {});
   }
 }
 

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -19,6 +19,21 @@ spec:
     spec:
       serviceAccountName: socialflow-backend
       terminationGracePeriodSeconds: 300
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: socialflow-backend
+                topologyKey: kubernetes.io/hostname
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: socialflow-backend
+                topologyKey: topology.kubernetes.io/zone
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/terraform/modules/elasticache/main.tf
+++ b/terraform/modules/elasticache/main.tf
@@ -34,5 +34,6 @@ resource "aws_elasticache_replication_group" "main" {
   security_group_ids   = [aws_security_group.redis.id]
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
-  tags                 = { Env = var.env }
+  automatic_failover_enabled = var.env == "prod" ? true : false
+  tags                       = { Env = var.env }
 }


### PR DESCRIPTION
- Delete temporary input file after transcoding (success or failure) via try/finally in processVideoJob — fixes pod ephemeral storage leak (#827)
- Enable ElastiCache automatic failover for prod to survive Redis primary node failure (#822)
- Add pod anti-affinity rules to spread replicas across nodes and AZs (#818)
- Deduplicate email queue jobs within a 5-minute window using SHA-256 hash jobId (#828)

Closes #827
 Closes #822
  Closes #818
   Closes #828