### PR TITLE
fix(sli): measure latency at writeHead, not body flush

### DIFF
--- a/backend/src/__tests__/sliMiddleware.test.ts
+++ b/backend/src/__tests__/sliMiddleware.test.ts
@@ -20,14 +20,16 @@ jest.mock('../lib/logger', () => ({
 
 function makeRes(statusCode: number) {
   const listeners: Record<string, (() => void)[]> = {};
-  return {
+  const res = {
     statusCode,
+    writeHead: jest.fn(),
     on: (event: string, cb: () => void) => {
       listeners[event] = listeners[event] ?? [];
       listeners[event].push(cb);
     },
     emit: (event: string) => listeners[event]?.forEach(cb => cb()),
   };
+  return res;
 }
 
 function makeReq() {
@@ -90,5 +92,23 @@ describe('sliMiddleware', () => {
     const res = makeRes(200);
     sliMiddleware(makeReq(), res as unknown as Response, next as NextFunction);
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('measures duration up to writeHead, not body flush', async () => {
+    jest.useFakeTimers();
+    const res = makeRes(200);
+    sliMiddleware(makeReq(), res as unknown as Response, jest.fn() as NextFunction);
+
+    jest.advanceTimersByTime(50);
+    // simulate headers sent after 50 ms of server processing
+    (res as any).writeHead(200);
+
+    // slow client: body flushes 500 ms later
+    jest.advanceTimersByTime(500);
+    res.emit('finish');
+
+    const [, durationMs] = mockObserveSuccess.mock.calls[0];
+    expect(durationMs).toBeLessThan(200); // ~50 ms, not ~550 ms
+    jest.useRealTimers();
   });
 });

--- a/backend/src/middleware/sliMiddleware.ts
+++ b/backend/src/middleware/sliMiddleware.ts
@@ -6,9 +6,17 @@ const logger = createLogger('sli');
 
 export function sliMiddleware(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
+  let headersSentAt: number | undefined;
+
+  const originalWriteHead = res.writeHead.bind(res);
+  // @ts-expect-error — overloaded signatures; we forward all args unchanged
+  res.writeHead = (...args) => {
+    headersSentAt ??= Date.now();
+    return originalWriteHead(...args);
+  };
 
   res.on('finish', () => {
-    const durationMs = Date.now() - start;
+    const durationMs = (headersSentAt ?? Date.now()) - start;
     const path = req.route?.path ?? req.path;
     const category = resolveCategory(req.originalUrl);
     const labels = {


### PR DESCRIPTION
i Monkey-patch res.writeHead to capture headersSentAt timestamp. durationMs is now end-of-server-processing time, not slow-client write time. Fixes inflated P99 on streaming/large responses.

Closes #1130