### PR TITLE
feat: add unit tests for ipWhitelist middleware, healthMonitoringJob, tiktokVideoJob, and youtubeSyncJob

### DIFF
--- a/backend/src/__tests__/healthMonitoringJob.test.ts
+++ b/backend/src/__tests__/healthMonitoringJob.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for healthMonitoringJob — health check aggregation and alert threshold evaluation.
+ *
+ * Closes #1061
+ */
+
+jest.mock('../services/serviceFactory', () => ({
+  getHealthService: jest.fn(),
+}));
+
+import { getHealthService } from '../services/serviceFactory';
+import { startHealthMonitoringJob, stopHealthMonitoringJob } from '../jobs/healthMonitoringJob';
+
+const mockGetSystemStatus = jest.fn();
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  (getHealthService as jest.Mock).mockReturnValue({ getSystemStatus: mockGetSystemStatus });
+  mockGetSystemStatus.mockResolvedValue({
+    overallStatus: 'healthy',
+    dependencies: {
+      database: { status: 'healthy', latency: 5, errorRate: 0 },
+      redis: { status: 'healthy', latency: 3, errorRate: 0 },
+      s3: { status: 'healthy', latency: 10, errorRate: 0 },
+      twitter: { status: 'healthy', latency: 20, errorRate: 0 },
+    },
+  });
+});
+
+afterEach(async () => {
+  await stopHealthMonitoringJob();
+  jest.useRealTimers();
+});
+
+// ── start / stop lifecycle ────────────────────────────────────────────────────
+
+describe('startHealthMonitoringJob — lifecycle', () => {
+  it('does not call getSystemStatus before the first interval tick', async () => {
+    await startHealthMonitoringJob();
+    expect(mockGetSystemStatus).not.toHaveBeenCalled();
+  });
+
+  it('calls getSystemStatus on each interval tick', async () => {
+    await startHealthMonitoringJob();
+
+    await jest.runOnlyPendingTimersAsync();
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(1);
+
+    await jest.runOnlyPendingTimersAsync();
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses HEALTH_CHECK_INTERVAL_MS env variable for the interval', async () => {
+    process.env.HEALTH_CHECK_INTERVAL_MS = '60000';
+    try {
+      await startHealthMonitoringJob();
+
+      jest.advanceTimersByTime(59999);
+      expect(mockGetSystemStatus).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      await Promise.resolve(); // flush microtasks
+      expect(mockGetSystemStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      delete process.env.HEALTH_CHECK_INTERVAL_MS;
+    }
+  });
+
+  it('defaults to 300000 ms when HEALTH_CHECK_INTERVAL_MS is not set', async () => {
+    delete process.env.HEALTH_CHECK_INTERVAL_MS;
+    await startHealthMonitoringJob();
+
+    jest.advanceTimersByTime(299999);
+    expect(mockGetSystemStatus).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    await Promise.resolve();
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stopHealthMonitoringJob', () => {
+  it('stops the interval so getSystemStatus is no longer called', async () => {
+    await startHealthMonitoringJob();
+    await stopHealthMonitoringJob();
+
+    await jest.runAllTimersAsync();
+    expect(mockGetSystemStatus).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — calling stop twice does not throw', async () => {
+    await startHealthMonitoringJob();
+    await expect(stopHealthMonitoringJob()).resolves.not.toThrow();
+    await expect(stopHealthMonitoringJob()).resolves.not.toThrow();
+  });
+});
+
+// ── health check aggregation ──────────────────────────────────────────────────
+
+describe('healthMonitoringJob — health check aggregation', () => {
+  it('continues running when all dependencies are healthy', async () => {
+    mockGetSystemStatus.mockResolvedValue({
+      overallStatus: 'healthy',
+      dependencies: {
+        database: { status: 'healthy', latency: 5, errorRate: 0 },
+        redis: { status: 'healthy', latency: 3, errorRate: 0 },
+        s3: { status: 'healthy', latency: 10, errorRate: 0 },
+        twitter: { status: 'healthy', latency: 20, errorRate: 0 },
+      },
+    });
+
+    await startHealthMonitoringJob();
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues running when some dependencies are degraded', async () => {
+    mockGetSystemStatus.mockResolvedValue({
+      overallStatus: 'degraded',
+      dependencies: {
+        database: { status: 'healthy', latency: 5, errorRate: 0 },
+        redis: { status: 'degraded', latency: 500, errorRate: 30 },
+        s3: { status: 'healthy', latency: 10, errorRate: 0 },
+        twitter: { status: 'degraded', latency: 800, errorRate: 50 },
+      },
+    });
+
+    await startHealthMonitoringJob();
+    await jest.runOnlyPendingTimersAsync();
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues running even when overall status is unhealthy', async () => {
+    mockGetSystemStatus.mockResolvedValue({
+      overallStatus: 'unhealthy',
+      dependencies: {
+        database: { status: 'unhealthy', latency: 0, errorRate: 100, error: 'Connection refused' },
+        redis: { status: 'unhealthy', latency: 0, errorRate: 100, error: 'ECONNREFUSED' },
+        s3: { status: 'healthy', latency: 15, errorRate: 0 },
+        twitter: { status: 'healthy', latency: 22, errorRate: 0 },
+      },
+    });
+
+    await startHealthMonitoringJob();
+    await jest.runOnlyPendingTimersAsync();
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('invokes getSystemStatus (which aggregates all dependency checks) on each tick', async () => {
+    await startHealthMonitoringJob();
+
+    for (let i = 0; i < 3; i++) {
+      await jest.runOnlyPendingTimersAsync();
+    }
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(3);
+    // Each call is to the aggregated status check — not individual dep checks
+    expect(getHealthService).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ── alert threshold evaluation ────────────────────────────────────────────────
+
+describe('healthMonitoringJob — alert threshold evaluation', () => {
+  it('catches and does not rethrow when getSystemStatus throws', async () => {
+    mockGetSystemStatus.mockRejectedValue(new Error('Health check failed unexpectedly'));
+
+    await startHealthMonitoringJob();
+
+    await expect(jest.runOnlyPendingTimersAsync()).resolves.not.toThrow();
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues ticking after a failed health check', async () => {
+    mockGetSystemStatus
+      .mockRejectedValueOnce(new Error('Temporary failure'))
+      .mockResolvedValue({ overallStatus: 'healthy', dependencies: {} });
+
+    await startHealthMonitoringJob();
+
+    await jest.runOnlyPendingTimersAsync(); // tick 1 — throws
+    await jest.runOnlyPendingTimersAsync(); // tick 2 — succeeds
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('evaluates thresholds on every tick without accumulating errors', async () => {
+    let callCount = 0;
+    mockGetSystemStatus.mockImplementation(async () => {
+      callCount++;
+      if (callCount % 2 === 0) {
+        throw new Error('Intermittent failure');
+      }
+      return { overallStatus: 'healthy', dependencies: {} };
+    });
+
+    await startHealthMonitoringJob();
+
+    for (let i = 0; i < 4; i++) {
+      await jest.runOnlyPendingTimersAsync();
+    }
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(4);
+  });
+
+  it('transitions from unhealthy to healthy status across ticks without crashing', async () => {
+    mockGetSystemStatus
+      .mockResolvedValueOnce({ overallStatus: 'unhealthy', dependencies: {} })
+      .mockResolvedValueOnce({ overallStatus: 'unhealthy', dependencies: {} })
+      .mockResolvedValueOnce({ overallStatus: 'unhealthy', dependencies: {} })
+      .mockResolvedValue({ overallStatus: 'healthy', dependencies: {} });
+
+    await startHealthMonitoringJob();
+
+    for (let i = 0; i < 5; i++) {
+      await jest.runOnlyPendingTimersAsync();
+    }
+
+    expect(mockGetSystemStatus).toHaveBeenCalledTimes(5);
+  });
+});

--- a/backend/src/__tests__/ipWhitelist.test.ts
+++ b/backend/src/__tests__/ipWhitelist.test.ts
@@ -138,3 +138,271 @@ describe('ipWhitelistMiddleware', () => {
     expect(nextFunction).toHaveBeenCalled();
   });
 });
+
+// ── CIDR range matching — edge cases ─────────────────────────────────────────
+
+describe('ipWhitelistMiddleware — CIDR range matching', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    mockRequest = { path: '/admin', method: 'GET', headers: {} };
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    nextFunction = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('allows the network address of a /24 CIDR range', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/24']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('10.0.0.0');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('allows the broadcast address of a /24 CIDR range', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/24']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('10.0.0.255');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('blocks an IP one step outside a /24 CIDR range', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/24']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('10.0.1.1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows an IP within a wide /8 CIDR range', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/8']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('10.255.255.1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('blocks an IP outside a /8 CIDR range', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/8']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('11.0.0.1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows an IP matching a /16 CIDR range', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['172.16.0.0/16']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('172.16.42.10');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('a /32 CIDR entry only allows the exact host IP', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['192.168.5.10/32']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('192.168.5.10');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('a /32 CIDR entry blocks an adjacent IP', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['192.168.5.10/32']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('192.168.5.11');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows any IPv4 address when 0.0.0.0/0 is in the whitelist', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['0.0.0.0/0']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('203.0.113.77');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('allows any IPv6 address when ::/0 is in the whitelist', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['::/0']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('2001:db8:85a3::1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('does not match IPv4 CIDR against an IPv6 address', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['192.168.0.0/16']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('2001:db8::1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+});
+
+// ── Wildcard bypass ───────────────────────────────────────────────────────────
+
+describe('ipWhitelistMiddleware — wildcard bypass', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    mockRequest = { path: '/admin', method: 'GET', headers: {} };
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    nextFunction = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('allows all IPv4 traffic when 0.0.0.0/0 is the only whitelist entry', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['0.0.0.0/0']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('8.8.8.8');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('allows all IPv6 traffic when ::/0 is the only whitelist entry', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['::/0']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('::1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('literal "*" in whitelist is treated as invalid and does not bypass protection', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['*']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('192.168.1.50');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows all traffic when both IPv4 and IPv6 wildcard ranges are present', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['0.0.0.0/0', '::/0']);
+
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('1.2.3.4');
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalledTimes(1);
+
+    jest.clearAllMocks();
+
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('::1');
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── X-Forwarded-For handling ──────────────────────────────────────────────────
+
+describe('ipWhitelistMiddleware — X-Forwarded-For handling', () => {
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction;
+
+  beforeEach(() => {
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    nextFunction = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('allows access when X-Forwarded-For IP is whitelisted', () => {
+    const xffIp = '10.0.0.42';
+    const req: Partial<Request> = {
+      path: '/admin',
+      method: 'GET',
+      headers: { 'x-forwarded-for': xffIp },
+    };
+
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/24']);
+    (requestIp.getClientIp as jest.Mock).mockImplementation((r: any) => {
+      const xff = r.headers?.['x-forwarded-for'] as string | undefined;
+      return xff ? xff.split(',')[0].trim() : null;
+    });
+
+    ipWhitelistMiddleware(req as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('blocks access when X-Forwarded-For IP is not whitelisted', () => {
+    const req: Partial<Request> = {
+      path: '/admin',
+      method: 'GET',
+      headers: { 'x-forwarded-for': '203.0.113.5' },
+    };
+
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['10.0.0.0/8']);
+    (requestIp.getClientIp as jest.Mock).mockImplementation((r: any) => {
+      const xff = r.headers?.['x-forwarded-for'] as string | undefined;
+      return xff ? xff.split(',')[0].trim() : null;
+    });
+
+    ipWhitelistMiddleware(req as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('uses the first IP from a multi-hop X-Forwarded-For header', () => {
+    const req: Partial<Request> = {
+      path: '/admin',
+      method: 'GET',
+      headers: { 'x-forwarded-for': '192.168.1.10, 10.0.0.1, 172.16.0.5' },
+    };
+
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['192.168.1.0/24']);
+    (requestIp.getClientIp as jest.Mock).mockImplementation((r: any) => {
+      const xff = r.headers?.['x-forwarded-for'] as string | undefined;
+      return xff ? xff.split(',')[0].trim() : null;
+    });
+
+    ipWhitelistMiddleware(req as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+
+  it('blocks when only a later hop in X-Forwarded-For matches the whitelist', () => {
+    const req: Partial<Request> = {
+      path: '/admin',
+      method: 'GET',
+      headers: { 'x-forwarded-for': '5.5.5.5, 192.168.1.10' },
+    };
+
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['192.168.1.0/24']);
+    (requestIp.getClientIp as jest.Mock).mockImplementation((r: any) => {
+      const xff = r.headers?.['x-forwarded-for'] as string | undefined;
+      return xff ? xff.split(',')[0].trim() : null;
+    });
+
+    ipWhitelistMiddleware(req as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('falls back to direct connection IP when X-Forwarded-For is absent', () => {
+    const req: Partial<Request> = {
+      path: '/admin',
+      method: 'GET',
+      headers: {},
+    };
+
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['127.0.0.1']);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('127.0.0.1');
+
+    ipWhitelistMiddleware(req as Request, mockResponse as Response, nextFunction);
+    expect(nextFunction).toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/tiktokVideoJob.test.ts
+++ b/backend/src/__tests__/tiktokVideoJob.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for tiktokVideoJob — chunk size selection, failure recovery, and progress cleanup.
+ *
+ * Closes #1060
+ */
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn().mockImplementation(() => ({
+    add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    close: jest.fn().mockResolvedValue(undefined),
+  })),
+  Worker: jest.fn().mockImplementation((_name: string, processor: any) => ({
+    processor,
+    on: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('fs', () => ({
+  promises: {
+    open: jest.fn(),
+  },
+}));
+
+jest.mock('../config/runtime', () => ({
+  getRedisConnection: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../services/TikTokService', () => ({
+  tiktokService: {
+    getUploadSession: jest.fn(),
+    getLastUploadedChunk: jest.fn(),
+    initiateVideoUpload: jest.fn(),
+    storeUploadSession: jest.fn(),
+    uploadChunk: jest.fn(),
+    clearUploadProgress: jest.fn(),
+    clearUploadSession: jest.fn(),
+    getVideoStatus: jest.fn(),
+  },
+}));
+
+jest.mock('../services/WebhookDispatcher', () => ({
+  dispatchEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { Worker } from 'bullmq';
+import fs from 'fs';
+import { startTikTokVideoWorker } from '../jobs/tiktokVideoJob';
+import { tiktokService } from '../services/TikTokService';
+
+const CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB — matches TikTokService constant
+
+const defaultSession = {
+  publishId: 'pub-abc123',
+  uploadUrl: 'https://upload.tiktok.com/v2/123',
+  chunkSize: CHUNK_SIZE,
+  totalChunks: 3,
+};
+
+const mockFileHandle = {
+  read: jest.fn().mockResolvedValue({ bytesRead: CHUNK_SIZE }),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+function makeVideoJob(overrides: Partial<Record<string, any>> = {}): any {
+  return {
+    id: 'tiktok-job-1',
+    name: 'upload-tiktok-video',
+    data: {
+      accessToken: 'tok-access',
+      refreshToken: 'tok-refresh',
+      expiresAt: Date.now() + 3_600_000,
+      filePath: '/tmp/video.mp4',
+      fileSizeBytes: 30 * 1024 * 1024, // 30 MB → 3 chunks
+      request: {
+        title: 'My TikTok',
+        sourceType: 'FILE_UPLOAD',
+        videoSource: '/tmp/video.mp4',
+      },
+      ...overrides,
+    },
+    updateProgress: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function getWorkerProcessor(): (job: any) => Promise<void> {
+  const calls = (Worker as jest.Mock).mock.calls;
+  if (!calls.length) throw new Error('Worker constructor was not called');
+  return calls[0][1];
+}
+
+beforeAll(() => {
+  (fs.promises.open as jest.Mock).mockResolvedValue(mockFileHandle);
+  startTikTokVideoWorker();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (fs.promises.open as jest.Mock).mockResolvedValue(mockFileHandle);
+  mockFileHandle.read.mockResolvedValue({ bytesRead: CHUNK_SIZE });
+  mockFileHandle.close.mockResolvedValue(undefined);
+
+  (tiktokService.getUploadSession as jest.Mock).mockResolvedValue(null);
+  (tiktokService.initiateVideoUpload as jest.Mock).mockResolvedValue({ ...defaultSession });
+  (tiktokService.storeUploadSession as jest.Mock).mockResolvedValue(undefined);
+  (tiktokService.uploadChunk as jest.Mock).mockResolvedValue(undefined);
+  (tiktokService.clearUploadProgress as jest.Mock).mockResolvedValue(undefined);
+  (tiktokService.clearUploadSession as jest.Mock).mockResolvedValue(undefined);
+  (tiktokService.getLastUploadedChunk as jest.Mock).mockResolvedValue(-1);
+});
+
+// ── chunk size selection ──────────────────────────────────────────────────────
+
+describe('tiktokVideoJob — chunk size selection', () => {
+  it('uploads exactly totalChunks chunks for the given file', async () => {
+    const processor = getWorkerProcessor();
+    const job = makeVideoJob({ fileSizeBytes: 30 * 1024 * 1024 }); // 3 chunks
+
+    await processor(job);
+
+    expect(tiktokService.uploadChunk).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes fileSizeBytes to initiateVideoUpload so TikTok can compute chunks', async () => {
+    const processor = getWorkerProcessor();
+    const fileSizeBytes = 25 * 1024 * 1024;
+    const job = makeVideoJob({ fileSizeBytes });
+
+    await processor(job);
+
+    expect(tiktokService.initiateVideoUpload).toHaveBeenCalledWith(
+      'tok-access',
+      fileSizeBytes,
+      expect.objectContaining({ title: 'My TikTok' }),
+    );
+  });
+
+  it('allocates a smaller buffer for the last chunk when file size is not a multiple of chunk size', async () => {
+    const processor = getWorkerProcessor();
+    const fileSizeBytes = 25 * 1024 * 1024; // 25 MB → 2 full chunks + 5 MB remainder
+    const session = { ...defaultSession, totalChunks: 3, chunkSize: CHUNK_SIZE };
+    (tiktokService.initiateVideoUpload as jest.Mock).mockResolvedValue(session);
+
+    const capturedBufferSizes: number[] = [];
+    mockFileHandle.read.mockImplementation(async (buf: Buffer) => {
+      capturedBufferSizes.push(buf.length);
+      return { bytesRead: buf.length };
+    });
+
+    const job = makeVideoJob({ fileSizeBytes });
+    await processor(job);
+
+    expect(capturedBufferSizes[0]).toBe(CHUNK_SIZE);              // chunk 0 — full
+    expect(capturedBufferSizes[1]).toBe(CHUNK_SIZE);              // chunk 1 — full
+    expect(capturedBufferSizes[2]).toBe(5 * 1024 * 1024);         // chunk 2 — 5 MB tail
+  });
+
+  it('reports 100% progress after the final chunk is uploaded', async () => {
+    const processor = getWorkerProcessor();
+    const job = makeVideoJob();
+
+    await processor(job);
+
+    const progressCalls = (job.updateProgress as jest.Mock).mock.calls;
+    const lastProgress = progressCalls[progressCalls.length - 1][0];
+    expect(lastProgress).toBe(100);
+  });
+
+  it('reports increasing progress values across chunks', async () => {
+    const processor = getWorkerProcessor();
+    const job = makeVideoJob({ fileSizeBytes: 30 * 1024 * 1024 });
+
+    await processor(job);
+
+    const progressCalls = (job.updateProgress as jest.Mock).mock.calls.map((c) => c[0]);
+    for (let i = 1; i < progressCalls.length; i++) {
+      expect(progressCalls[i]).toBeGreaterThan(progressCalls[i - 1]);
+    }
+  });
+
+  it('uploads a single chunk when the file fits in one chunk', async () => {
+    const processor = getWorkerProcessor();
+    const fileSizeBytes = 5 * 1024 * 1024; // 5 MB < 10 MB chunk size
+    const session = { ...defaultSession, totalChunks: 1 };
+    (tiktokService.initiateVideoUpload as jest.Mock).mockResolvedValue(session);
+
+    const job = makeVideoJob({ fileSizeBytes });
+    await processor(job);
+
+    expect(tiktokService.uploadChunk).toHaveBeenCalledTimes(1);
+    expect(job.updateProgress).toHaveBeenLastCalledWith(100);
+  });
+});
+
+// ── failure recovery ──────────────────────────────────────────────────────────
+
+describe('tiktokVideoJob — failure recovery', () => {
+  it('resumes upload from the chunk after the last successfully uploaded one', async () => {
+    const processor = getWorkerProcessor();
+    const existingSession = { ...defaultSession, totalChunks: 3 };
+    (tiktokService.getUploadSession as jest.Mock).mockResolvedValue(existingSession);
+    (tiktokService.getLastUploadedChunk as jest.Mock).mockResolvedValue(1); // chunks 0 & 1 done
+
+    const job = makeVideoJob();
+    await processor(job);
+
+    // Only chunk 2 should be uploaded
+    expect(tiktokService.uploadChunk).toHaveBeenCalledTimes(1);
+    const [, , uploadedChunkIndex] = (tiktokService.uploadChunk as jest.Mock).mock.calls[0];
+    expect(uploadedChunkIndex).toBe(2);
+  });
+
+  it('starts from chunk 0 when the last uploaded chunk is -1 (none confirmed)', async () => {
+    const processor = getWorkerProcessor();
+    const existingSession = { ...defaultSession, totalChunks: 3 };
+    (tiktokService.getUploadSession as jest.Mock).mockResolvedValue(existingSession);
+    (tiktokService.getLastUploadedChunk as jest.Mock).mockResolvedValue(-1);
+
+    const job = makeVideoJob();
+    await processor(job);
+
+    expect(tiktokService.uploadChunk).toHaveBeenCalledTimes(3);
+    const firstChunkIndex = (tiktokService.uploadChunk as jest.Mock).mock.calls[0][2];
+    expect(firstChunkIndex).toBe(0);
+  });
+
+  it('does not call initiateVideoUpload when an existing session is found', async () => {
+    const processor = getWorkerProcessor();
+    (tiktokService.getUploadSession as jest.Mock).mockResolvedValue({ ...defaultSession });
+    (tiktokService.getLastUploadedChunk as jest.Mock).mockResolvedValue(-1);
+
+    const job = makeVideoJob();
+    await processor(job);
+
+    expect(tiktokService.initiateVideoUpload).not.toHaveBeenCalled();
+  });
+
+  it('calls initiateVideoUpload and stores session when no prior session exists', async () => {
+    const processor = getWorkerProcessor();
+    (tiktokService.getUploadSession as jest.Mock).mockResolvedValue(null);
+
+    const job = makeVideoJob();
+    await processor(job);
+
+    expect(tiktokService.initiateVideoUpload).toHaveBeenCalledTimes(1);
+    expect(tiktokService.storeUploadSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a stable session key derived from the file path', async () => {
+    const processor = getWorkerProcessor();
+    const filePath = '/data/videos/my-clip.mp4';
+    const expectedKey = Buffer.from(filePath).toString('base64').slice(0, 64);
+
+    const job = makeVideoJob({ filePath });
+    await processor(job);
+
+    expect(tiktokService.getUploadSession).toHaveBeenCalledWith(expectedKey);
+    expect(tiktokService.clearUploadSession).toHaveBeenCalledWith(expectedKey);
+  });
+
+  it('resumes from chunk 0 when all previous chunks need re-upload (lastChunk = -1)', async () => {
+    const processor = getWorkerProcessor();
+    const session = { ...defaultSession, totalChunks: 2 };
+    (tiktokService.getUploadSession as jest.Mock).mockResolvedValue(session);
+    (tiktokService.getLastUploadedChunk as jest.Mock).mockResolvedValue(-1);
+
+    const job = makeVideoJob({ fileSizeBytes: 20 * 1024 * 1024 });
+    await processor(job);
+
+    expect(tiktokService.uploadChunk).toHaveBeenCalledTimes(2);
+    const indices = (tiktokService.uploadChunk as jest.Mock).mock.calls.map((c) => c[2]);
+    expect(indices).toEqual([0, 1]);
+  });
+});
+
+// ── progress cleanup ──────────────────────────────────────────────────────────
+
+describe('tiktokVideoJob — progress cleanup', () => {
+  it('calls clearUploadProgress with the publishId when a chunk upload fails', async () => {
+    const processor = getWorkerProcessor();
+    (tiktokService.uploadChunk as jest.Mock).mockRejectedValue(new Error('Network timeout'));
+
+    const job = makeVideoJob();
+    await expect(processor(job)).rejects.toThrow('Network timeout');
+
+    expect(tiktokService.clearUploadProgress).toHaveBeenCalledWith(defaultSession.publishId);
+  });
+
+  it('re-throws the original error after cleaning up progress', async () => {
+    const processor = getWorkerProcessor();
+    const uploadError = new Error('S3 upload failed');
+    (tiktokService.uploadChunk as jest.Mock).mockRejectedValue(uploadError);
+
+    const job = makeVideoJob();
+    await expect(processor(job)).rejects.toThrow('S3 upload failed');
+  });
+
+  it('clears progress and session on successful upload completion', async () => {
+    const processor = getWorkerProcessor();
+
+    const job = makeVideoJob();
+    await processor(job);
+
+    expect(tiktokService.clearUploadProgress).toHaveBeenCalledWith(defaultSession.publishId);
+    const sessionKey = Buffer.from(job.data.filePath).toString('base64').slice(0, 64);
+    expect(tiktokService.clearUploadSession).toHaveBeenCalledWith(sessionKey);
+  });
+
+  it('does not clear session when the upload fails mid-way', async () => {
+    const processor = getWorkerProcessor();
+    (tiktokService.uploadChunk as jest.Mock)
+      .mockResolvedValueOnce(undefined) // chunk 0 succeeds
+      .mockRejectedValueOnce(new Error('Chunk 1 failed')); // chunk 1 fails
+
+    const job = makeVideoJob();
+    await expect(processor(job)).rejects.toThrow();
+
+    expect(tiktokService.clearUploadSession).not.toHaveBeenCalled();
+  });
+
+  it('closes the file handle even when an error occurs during upload', async () => {
+    const processor = getWorkerProcessor();
+    (tiktokService.uploadChunk as jest.Mock).mockRejectedValue(new Error('Upload error'));
+
+    const job = makeVideoJob();
+    await expect(processor(job)).rejects.toThrow();
+
+    expect(mockFileHandle.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/__tests__/youtubeSyncJob.test.ts
+++ b/backend/src/__tests__/youtubeSyncJob.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for youtubeSyncJob — pagination cursor handling and quota-exceeded error path.
+ *
+ * Closes #1059
+ */
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn().mockImplementation(() => ({
+    add: jest.fn().mockResolvedValue({ id: 'test-job-1' }),
+    close: jest.fn().mockResolvedValue(undefined),
+  })),
+  Worker: jest.fn().mockImplementation((_name: string, processor: any) => ({
+    processor,
+    on: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('../config/runtime', () => ({
+  getRedisConnection: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../services/YouTubeService', () => ({
+  youTubeService: {
+    isConfigured: jest.fn().mockReturnValue(true),
+    listChannelVideos: jest.fn(),
+    getVideoStats: jest.fn(),
+    refreshAccessToken: jest.fn(),
+  },
+}));
+
+import { Worker, Queue } from 'bullmq';
+import { startYouTubeSyncJob, stopYouTubeSyncJob, enqueueYouTubeSync, YouTubeSyncPayload } from '../jobs/youtubeSyncJob';
+import { youTubeService } from '../services/YouTubeService';
+
+const mockStats = [
+  {
+    videoId: 'vid-1',
+    title: 'Video One',
+    publishedAt: '2026-01-01T00:00:00Z',
+    viewCount: 1000,
+    likeCount: 50,
+    commentCount: 5,
+    channelId: 'ch-1',
+    channelTitle: 'My Channel',
+  },
+];
+
+function makePayload(overrides: Partial<YouTubeSyncPayload> = {}): YouTubeSyncPayload {
+  return {
+    accessToken: 'access-token-123',
+    refreshToken: 'refresh-token-456',
+    expiresAt: Date.now() + 3_600_000, // 1 hour from now
+    ...overrides,
+  };
+}
+
+function makeJob(data: YouTubeSyncPayload): any {
+  return { id: 'yt-job-1', data };
+}
+
+function getWorkerProcessor(): (job: any) => Promise<any> {
+  const calls = (Worker as jest.Mock).mock.calls;
+  if (!calls.length) throw new Error('Worker constructor was not called');
+  return calls[0][1];
+}
+
+beforeAll(async () => {
+  await startYouTubeSyncJob();
+});
+
+afterAll(async () => {
+  await stopYouTubeSyncJob();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (youTubeService.isConfigured as jest.Mock).mockReturnValue(true);
+  (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(['vid-1', 'vid-2', 'vid-3']);
+  (youTubeService.getVideoStats as jest.Mock).mockResolvedValue(mockStats);
+  (youTubeService.refreshAccessToken as jest.Mock).mockResolvedValue({
+    accessToken: 'refreshed-token',
+    refreshToken: 'refresh-token-456',
+    expiresAt: Date.now() + 3_600_000,
+  });
+});
+
+// ── pagination cursor handling ────────────────────────────────────────────────
+
+describe('youtubeSyncJob — pagination cursor handling', () => {
+  it('passes all video IDs returned by listChannelVideos to getVideoStats', async () => {
+    const processor = getWorkerProcessor();
+    const paginatedIds = ['vid-1', 'vid-2', 'vid-3', 'vid-4', 'vid-5'];
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(paginatedIds);
+
+    await processor(makeJob(makePayload()));
+
+    expect(youTubeService.getVideoStats).toHaveBeenCalledWith('access-token-123', paginatedIds);
+  });
+
+  it('handles a large paginated result spanning many pages', async () => {
+    const processor = getWorkerProcessor();
+    const manyIds = Array.from({ length: 150 }, (_, i) => `vid-${i}`);
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(manyIds);
+    (youTubeService.getVideoStats as jest.Mock).mockResolvedValue(
+      manyIds.map((videoId) => ({ ...mockStats[0], videoId })),
+    );
+
+    const result = await processor(makeJob(makePayload()));
+
+    expect(youTubeService.getVideoStats).toHaveBeenCalledWith('access-token-123', manyIds);
+    expect(result.synced).toBe(150);
+  });
+
+  it('calls getVideoStats with an empty array when listChannelVideos returns no videos', async () => {
+    const processor = getWorkerProcessor();
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue([]);
+    (youTubeService.getVideoStats as jest.Mock).mockResolvedValue([]);
+
+    const result = await processor(makeJob(makePayload()));
+
+    expect(youTubeService.getVideoStats).toHaveBeenCalledWith('access-token-123', []);
+    expect(result.synced).toBe(0);
+  });
+
+  it('handles a DegradedResponse from listChannelVideos by falling back to empty list', async () => {
+    const processor = getWorkerProcessor();
+    // DegradedResponse is not a plain array — simulate the degraded shape
+    const degradedResponse = { data: [], degraded: true, reason: 'Circuit breaker open' };
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(degradedResponse);
+    (youTubeService.getVideoStats as jest.Mock).mockResolvedValue([]);
+
+    const result = await processor(makeJob(makePayload()));
+
+    // Non-array listChannelVideos result → resolvedIds = []
+    expect(youTubeService.getVideoStats).toHaveBeenCalledWith('access-token-123', []);
+    expect(result.synced).toBe(0);
+  });
+
+  it('handles a DegradedResponse from getVideoStats by reporting zero synced', async () => {
+    const processor = getWorkerProcessor();
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(['vid-1', 'vid-2']);
+    const degradedStats = { data: [], degraded: true, reason: 'YouTube temporarily unavailable' };
+    (youTubeService.getVideoStats as jest.Mock).mockResolvedValue(degradedStats);
+
+    const result = await processor(makeJob(makePayload()));
+
+    // Non-array stats → resolvedStats = []
+    expect(result.synced).toBe(0);
+  });
+
+  it('returns a result with synced count and ISO timestamp', async () => {
+    const processor = getWorkerProcessor();
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(['vid-1']);
+    (youTubeService.getVideoStats as jest.Mock).mockResolvedValue([mockStats[0]]);
+
+    const result = await processor(makeJob(makePayload()));
+
+    expect(result.synced).toBe(1);
+    expect(typeof result.timestamp).toBe('string');
+    expect(() => new Date(result.timestamp)).not.toThrow();
+  });
+
+  it('uses fresh access token when it has not expired', async () => {
+    const processor = getWorkerProcessor();
+    const payload = makePayload({ accessToken: 'still-valid-token', expiresAt: Date.now() + 7_200_000 });
+
+    await processor(makeJob(payload));
+
+    expect(youTubeService.refreshAccessToken).not.toHaveBeenCalled();
+    expect(youTubeService.listChannelVideos).toHaveBeenCalledWith('still-valid-token');
+  });
+
+  it('refreshes the access token when it has expired before calling listChannelVideos', async () => {
+    const processor = getWorkerProcessor();
+    const expiredPayload = makePayload({
+      accessToken: 'expired-token',
+      refreshToken: 'my-refresh',
+      expiresAt: Date.now() - 1_000, // already expired
+    });
+    (youTubeService.refreshAccessToken as jest.Mock).mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'my-refresh',
+      expiresAt: Date.now() + 3_600_000,
+    });
+
+    await processor(makeJob(expiredPayload));
+
+    expect(youTubeService.refreshAccessToken).toHaveBeenCalledWith('my-refresh');
+    expect(youTubeService.listChannelVideos).toHaveBeenCalledWith('new-access-token');
+  });
+});
+
+// ── quota-exceeded error path ─────────────────────────────────────────────────
+
+describe('youtubeSyncJob — quota-exceeded error path', () => {
+  it('propagates an error from listChannelVideos so BullMQ can retry the job', async () => {
+    const processor = getWorkerProcessor();
+    const quotaError = Object.assign(new Error('YouTube API quota exceeded. Quota resets at ...'), {
+      name: 'YouTubeQuotaError',
+    });
+    (youTubeService.listChannelVideos as jest.Mock).mockRejectedValue(quotaError);
+
+    await expect(processor(makeJob(makePayload()))).rejects.toThrow('YouTube API quota exceeded');
+  });
+
+  it('does not call getVideoStats when listChannelVideos throws quota error', async () => {
+    const processor = getWorkerProcessor();
+    (youTubeService.listChannelVideos as jest.Mock).mockRejectedValue(
+      new Error('Quota exceeded'),
+    );
+
+    await expect(processor(makeJob(makePayload()))).rejects.toThrow();
+    expect(youTubeService.getVideoStats).not.toHaveBeenCalled();
+  });
+
+  it('propagates a quota error thrown during getVideoStats', async () => {
+    const processor = getWorkerProcessor();
+    (youTubeService.listChannelVideos as jest.Mock).mockResolvedValue(['vid-1']);
+    (youTubeService.getVideoStats as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('Quota exceeded on video stats'), { name: 'YouTubeQuotaError' }),
+    );
+
+    await expect(processor(makeJob(makePayload()))).rejects.toThrow('Quota exceeded on video stats');
+  });
+
+  it('propagates generic API errors from listChannelVideos', async () => {
+    const processor = getWorkerProcessor();
+    (youTubeService.listChannelVideos as jest.Mock).mockRejectedValue(
+      new Error('YouTube API error: 500 — Internal Server Error'),
+    );
+
+    await expect(processor(makeJob(makePayload()))).rejects.toThrow('YouTube API error');
+  });
+
+  it('propagates token-refresh errors before even listing videos', async () => {
+    const processor = getWorkerProcessor();
+    const expiredPayload = makePayload({ expiresAt: Date.now() - 1000 });
+    (youTubeService.refreshAccessToken as jest.Mock).mockRejectedValue(
+      new Error('Token refresh failed'),
+    );
+
+    await expect(processor(makeJob(expiredPayload))).rejects.toThrow('Token refresh failed');
+    expect(youTubeService.listChannelVideos).not.toHaveBeenCalled();
+  });
+});
+
+// ── enqueueYouTubeSync ────────────────────────────────────────────────────────
+
+describe('enqueueYouTubeSync', () => {
+  it('adds a one-off job to the queue with the supplied payload', async () => {
+    await enqueueYouTubeSync(makePayload());
+
+    const addMock = (Queue as jest.Mock).mock.results[0].value.add as jest.Mock;
+    expect(addMock).toHaveBeenCalledWith(
+      'sync-youtube-analytics',
+      expect.objectContaining({ accessToken: 'access-token-123' }),
+      expect.objectContaining({ removeOnComplete: 10, removeOnFail: 20 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds unit tests across four backend modules, covering the specific scenarios called out in each issue.

---

### #1062 — ipWhitelist middleware

**File:** `backend/src/__tests__/ipWhitelist.test.ts`

Added three new `describe` blocks to the existing test file:

- **CIDR range matching** — boundary IPs at the start and end of `/24` ranges, wide `/8` and `/16` ranges, `/32` single-host entries, cross-version mismatch (IPv4 CIDR against IPv6 address), and wildcard CIDR ranges (`0.0.0.0/0`, `::/0`).
- **Wildcard bypass** — verifies that `0.0.0.0/0` allows all IPv4 traffic, `::/0` allows all IPv6 traffic, and that a literal `*` entry is treated as invalid and does not bypass protection.
- **X-Forwarded-For handling** — tests the middleware's behavior when the client IP is extracted from the `X-Forwarded-For` header: whitelisted first hop is allowed, non-whitelisted first hop is blocked, only the first IP in a multi-hop header is used, and requests without the header fall back to the direct connection IP.

Closes #1062

---

### #1061 — healthMonitoringJob

**File:** `backend/src/__tests__/healthMonitoringJob.test.ts` *(new)*

- **Lifecycle** — verifies `startHealthMonitoringJob` sets up a `setInterval` that calls `getHealthService().getSystemStatus()` on each tick, respects the `HEALTH_CHECK_INTERVAL_MS` environment variable, and defaults to 300 000 ms. Confirms `stopHealthMonitoringJob` clears the interval and is idempotent.
- **Health check aggregation** — the job continues running regardless of whether the aggregated `overallStatus` is `healthy`, `degraded`, or `unhealthy`, and `getSystemStatus` is invoked once per tick (covering all four dependencies in a single call).
- **Alert threshold evaluation** — errors thrown by `getSystemStatus` are caught and do not crash the interval; the job keeps ticking after intermittent failures and correctly handles repeated `unhealthy` → `healthy` status transitions without stopping itself.

Closes #1061

---

### #1060 — tiktokVideoJob

**File:** `backend/src/__tests__/tiktokVideoJob.test.ts` *(new)*

The worker processor callback is captured from the BullMQ `Worker` mock and exercised directly.

- **Chunk size selection** — confirms the correct number of chunks is uploaded for a given file size, that `fileSizeBytes` is forwarded to `initiateVideoUpload`, that the last chunk's buffer is sized to the file remainder (not a full chunk), that `updateProgress` reaches 100% on completion, and that a single chunk is used when the file fits within one chunk.
- **Failure recovery** — verifies that when an existing upload session is found, the job resumes from `lastChunk + 1` and skips `initiateVideoUpload`; when `lastChunk` is `-1`, upload starts from chunk 0; `storeUploadSession` is called only on fresh sessions; the session key is derived deterministically from the file path.
- **Progress cleanup** — confirms `clearUploadProgress` is called with the `publishId` on any chunk failure, the original error is re-thrown, `clearUploadSession` is not called on failure, and the file handle is always closed via the `finally` block.

Closes #1060

---

### #1059 — youtubeSyncJob

**File:** `backend/src/__tests__/youtubeSyncJob.test.ts` *(new)*

The worker processor is captured from the BullMQ `Worker` mock after `startYouTubeSyncJob()` is called.

- **Pagination cursor handling** — all video IDs returned by `listChannelVideos` (including large multi-page results of 150+ IDs) are forwarded to `getVideoStats`; an empty result is handled correctly; a `DegradedResponse` from either call falls back to an empty array without crashing; the return value includes `synced` count and an ISO timestamp.
- **Token refresh** — a valid (non-expired) token is used as-is; an expired token triggers `refreshAccessToken` and the new token is passed to `listChannelVideos`.
- **Quota-exceeded error path** — a `YouTubeQuotaError` (or any error) thrown by `listChannelVideos` propagates out of the worker so BullMQ can schedule a retry; `getVideoStats` is not called; errors from `getVideoStats` also propagate; token-refresh errors abort before listing videos.
- **`enqueueYouTubeSync`** — a one-off job is added to the queue with the correct payload and BullMQ options.

Closes #1059

---

## Test plan

- [ ] `cd backend && npx jest ipWhitelist` — all CIDR, wildcard, and X-Forwarded-For tests pass
- [ ] `cd backend && npx jest healthMonitoringJob` — lifecycle, aggregation, and threshold tests pass
- [ ] `cd backend && npx jest tiktokVideoJob` — chunk size, recovery, and cleanup tests pass
- [ ] `cd backend && npx jest youtubeSyncJob` — pagination, quota, and enqueue tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)