### PR TITLE
fix: token refresh, lock TTL abort, SES drop handling, timestamp replay check

### DIFF
--- a/backend/src/__tests__/LockService.test.ts
+++ b/backend/src/__tests__/LockService.test.ts
@@ -103,4 +103,30 @@ describe('LockService.withLock – TTL extension', () => {
 
     expect(mockUnlock).toHaveBeenCalledTimes(1);
   });
+
+  it('aborts the operation and rejects when a TTL extension fails', async () => {
+    mockExtend.mockImplementation(() => Promise.reject(new Error('redis down')));
+
+    const LockService = getLockService();
+    const duration = 1000;
+
+    let signalAborted = false;
+    const opPromise = LockService.withLock(
+      'abort-key',
+      (signal) =>
+        new Promise((_, reject) => {
+          signal.addEventListener('abort', () => {
+            signalAborted = true;
+            reject(new Error('operation aborted'));
+          });
+        }),
+      { duration },
+    );
+
+    await jest.advanceTimersByTimeAsync(duration / 2);
+
+    await expect(opPromise).rejects.toThrow();
+    expect(signalAborted).toBe(true);
+    expect(mockUnlock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/backend/src/__tests__/emailJob.test.ts
+++ b/backend/src/__tests__/emailJob.test.ts
@@ -1,0 +1,52 @@
+import { UnrecoverableError } from 'bullmq';
+import { processEmailJob, emailDroppedTotal } from '../jobs/emailJob';
+import { EmailJobData } from '../queues/emailQueue';
+
+function makeJob(data: Partial<EmailJobData> = {}): any {
+  return {
+    id: 'job-1',
+    data: { to: 'user@example.com', subject: 'Hi', body: 'Hello', ...data },
+    updateProgress: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('processEmailJob', () => {
+  beforeEach(() => {
+    emailDroppedTotal.reset();
+  });
+
+  it('completes successfully for valid email data', async () => {
+    const job = makeJob();
+    const result = await processEmailJob(job);
+    expect(result.success).toBe(true);
+    expect(result.recipient).toBe('user@example.com');
+  });
+
+  it('rethrows a retryable error without dropping the email', async () => {
+    const job = makeJob({ to: '' });
+    await expect(processEmailJob(job)).rejects.toThrow('Failed to send email');
+    expect(job.update).not.toHaveBeenCalled();
+  });
+
+  it('drops the email and records the SES error code for a non-retryable SES error', async () => {
+    const job = makeJob();
+    const sesError: any = new Error('MessageRejected: address on suppression list');
+    sesError.name = 'MessageRejected';
+
+    // The "send" step is simulated in emailJob.ts; throwing from updateProgress
+    // exercises the same catch block a real SES rejection would hit.
+    (job.updateProgress as jest.Mock).mockImplementation(() => {
+      throw sesError;
+    });
+
+    await expect(processEmailJob(job)).rejects.toThrow(UnrecoverableError);
+    expect(job.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', sesErrorCode: 'MessageRejected' }),
+    );
+
+    const metric = emailDroppedTotal.get();
+    const sample = metric.values.find((v: { labels: { code?: string } }) => v.labels.code === 'MessageRejected');
+    expect(sample?.value).toBe(1);
+  });
+});

--- a/backend/src/__tests__/verifySignature.test.ts
+++ b/backend/src/__tests__/verifySignature.test.ts
@@ -71,9 +71,24 @@ describe('verifySignature', () => {
     const { res, status, json } = buildRes();
     await middleware(req, res, next);
     expect(status).toHaveBeenCalledWith(401);
-    expect(json).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 'MISSING_SIGNATURE_HEADERS' }),
-    );
+    expect(json).toHaveBeenCalledWith({ error: 'Missing timestamp' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing timestamp before computing the HMAC, even with a stale replayed signature', async () => {
+    // A signature computed for a timestamp far in the past must still be rejected
+    // for the *missing timestamp* reason, never reaching HMAC comparison.
+    const staleTs = makeTimestamp(-365 * 24 * 60 * 60 * 1000);
+    const body = '{"event":"test"}';
+    const sig = makeSignature(staleTs, body);
+    const req = buildReq({
+      headers: { 'x-signature': sig },
+      rawBody: Buffer.from(body),
+    } as any);
+    const { res, status, json } = buildRes();
+    await middleware(req, res, next);
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'Missing timestamp' });
     expect(next).not.toHaveBeenCalled();
   });
 

--- a/backend/src/jobs/emailJob.ts
+++ b/backend/src/jobs/emailJob.ts
@@ -1,6 +1,59 @@
-import { Job } from 'bullmq';
+import { Job, UnrecoverableError } from 'bullmq';
+import { Counter } from 'prom-client';
 import { queueManager } from '../queues/queueManager';
 import { EmailJobData } from '../queues/emailQueue';
+import { register } from '../lib/metrics';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('email-job');
+
+/**
+ * SES error codes that will never succeed on retry (bad recipient, malformed
+ * params, etc). These are dropped immediately instead of exhausting retries.
+ */
+const NON_RETRYABLE_SES_CODES = new Set([
+  'MessageRejected',
+  'InvalidParameterValue',
+  'MailFromDomainNotVerifiedException',
+  'ConfigurationSetDoesNotExistException',
+  'AccountSendingPausedException',
+]);
+
+export const emailDroppedTotal = new Counter({
+  name: 'email_dropped_total',
+  help: 'Total number of emails dropped due to a non-retryable SES error',
+  labelNames: ['code'] as const,
+  registers: [register],
+});
+
+/** Alert once the number of drops in the current process reaches this many. */
+const DROPPED_RATE_ALERT_THRESHOLD = Number(process.env.EMAIL_DROPPED_RATE_ALERT_THRESHOLD ?? 10);
+let droppedSinceLastAlert = 0;
+
+function getSesErrorCode(error: any): string | undefined {
+  return error?.Code || error?.code || error?.name;
+}
+
+function isNonRetryableSesError(error: any): boolean {
+  const code = getSesErrorCode(error);
+  return !!code && NON_RETRYABLE_SES_CODES.has(code);
+}
+
+async function dropEmail(job: Job<EmailJobData>, error: any): Promise<void> {
+  const code = getSesErrorCode(error) ?? 'Unknown';
+  emailDroppedTotal.inc({ code });
+  await job.update({ ...job.data, status: 'failed', sesErrorCode: code });
+  logger.error(`Email dropped — non-retryable SES error`, { jobId: job.id, code });
+
+  droppedSinceLastAlert++;
+  if (droppedSinceLastAlert >= DROPPED_RATE_ALERT_THRESHOLD) {
+    logger.error('ALERT: dropped-email rate threshold exceeded', {
+      droppedSinceLastAlert,
+      threshold: DROPPED_RATE_ALERT_THRESHOLD,
+    });
+    droppedSinceLastAlert = 0;
+  }
+}
 
 /**
  * Email job processor
@@ -50,6 +103,10 @@ export async function processEmailJob(job: Job<EmailJobData>) {
       metadata,
     };
   } catch (error: any) {
+    if (isNonRetryableSesError(error)) {
+      await dropEmail(job, error);
+      throw new UnrecoverableError(`Email dropped: ${getSesErrorCode(error)}`);
+    }
     console.error(`[EmailJob] Job ${job.id} failed:`, error.message);
     throw new Error(`Failed to send email: ${error.message}`);
   }

--- a/backend/src/middleware/verifySignature.ts
+++ b/backend/src/middleware/verifySignature.ts
@@ -79,21 +79,24 @@ export function verifySignature(options: VerifySignatureOptions) {
     const requestId = (req as any).requestId as string | undefined;
 
     // ── 1. Extract headers ──────────────────────────────────────────────────
+    // The timestamp must be checked before anything else (including HMAC
+    // computation) so the replay window can never be bypassed by omitting it.
     const rawTimestamp = req.headers[timestampHeader] as string | undefined;
+
+    if (!rawTimestamp) {
+      logger.warn('Missing timestamp header', { requestId, path: req.path, method: req.method });
+      res.status(401).json({ error: 'Missing timestamp' });
+      return;
+    }
+
     const rawSignature = req.headers[signatureHeader] as string | undefined;
 
-    if (!rawTimestamp || !rawSignature) {
-      logger.warn('Missing signature headers', {
-        requestId,
-        path: req.path,
-        method: req.method,
-        missingTimestamp: !rawTimestamp,
-        missingSignature: !rawSignature,
-      });
+    if (!rawSignature) {
+      logger.warn('Missing signature header', { requestId, path: req.path, method: req.method });
       res.status(401).json({
         success: false,
         code: 'MISSING_SIGNATURE_HEADERS',
-        message: `Required headers '${timestampHeader}' and '${signatureHeader}' must be present.`,
+        message: `Required header '${signatureHeader}' must be present.`,
       });
       return;
     }

--- a/backend/src/services/FacebookService.ts
+++ b/backend/src/services/FacebookService.ts
@@ -59,6 +59,23 @@ const API_BASE = `https://graph.facebook.com/${FB_API_VERSION}`;
 const _OAUTH_TOKEN_URL = `https://graph.facebook.com/${FB_API_VERSION}/oauth/access_token`;
 const FACEBOOK_AUTH_URL = `https://www.facebook.com/${FB_API_VERSION}/dialog/oauth`;
 
+/** How long before `expiresAt` a token is proactively refreshed. Default: 7 days. */
+const REFRESH_WINDOW_MS = Number(
+  process.env.FACEBOOK_TOKEN_REFRESH_WINDOW_MS ?? 7 * 24 * 60 * 60 * 1000,
+);
+
+/**
+ * Thrown when a Facebook token is past (or near) expiry and the proactive
+ * refresh attempt itself fails. Callers should treat this as a signal to
+ * prompt the user to re-authenticate, rather than a generic API failure.
+ */
+export class AuthRefreshError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'AuthRefreshError';
+  }
+}
+
 logger.info(`FacebookService using Graph API version ${FB_API_VERSION}`);
 
 class FacebookService {
@@ -142,6 +159,25 @@ class FacebookService {
       accessToken: data.access_token,
       expiresAt: Date.now() + (data.expires_in || 5184000) * 1000, // 60 days default
     };
+  }
+
+  /**
+   * Proactively refresh a long-lived token if it is within REFRESH_WINDOW_MS
+   * of expiring. Call this before any Graph API call that uses a stored
+   * user token. Throws AuthRefreshError (instead of a generic Graph API
+   * error) if the refresh attempt itself fails, so callers can prompt the
+   * user to re-authenticate.
+   */
+  public async ensureFreshToken(tokens: FacebookTokens): Promise<FacebookTokens> {
+    if (tokens.expiresAt - Date.now() >= REFRESH_WINDOW_MS) {
+      return tokens;
+    }
+    try {
+      const refreshed = await this.getLongLivedUserToken(tokens.accessToken);
+      return { ...tokens, accessToken: refreshed.accessToken, expiresAt: refreshed.expiresAt };
+    } catch (err) {
+      throw new AuthRefreshError('Failed to refresh Facebook access token', err);
+    }
   }
 
   /**
@@ -304,17 +340,24 @@ class FacebookService {
   }
 
   /**
-   * Get page access token with user token (for immediate posting)
+   * Get page access token with user token (for immediate posting).
+   * Pass the full FacebookTokens (instead of a bare string) to enable
+   * proactive refresh of a soon-to-expire token before the Graph API call.
    */
   public async postToPageWithUserToken(
-    userAccessToken: string,
+    userAccessToken: string | FacebookTokens,
     request: FacebookPostRequest,
   ): Promise<FacebookPagePost> {
+    const accessToken =
+      typeof userAccessToken === 'string'
+        ? userAccessToken
+        : (await this.ensureFreshToken(userAccessToken)).accessToken;
+
     return circuitBreakerService.execute(
       'facebook',
       async () => {
         // Get the page access token first
-        const pageAccessToken = await this.getPageAccessToken(userAccessToken, request.pageId);
+        const pageAccessToken = await this.getPageAccessToken(accessToken, request.pageId);
 
         const params = new URLSearchParams({
           message: request.message,

--- a/backend/src/services/__tests__/FacebookService.test.ts
+++ b/backend/src/services/__tests__/FacebookService.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../lib/logger', () => ({
   createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
 }));
 
-import { facebookService } from '../FacebookService';
+import { facebookService, AuthRefreshError } from '../FacebookService';
 
 describe('FacebookService', () => {
   beforeAll(() => nock.disableNetConnect());
@@ -85,5 +85,44 @@ describe('FacebookService', () => {
     await expect(
       facebookService.getPostComments('1234', 'post-123', 'page-token'),
     ).rejects.toThrow(/Failed to fetch comments/);
+  });
+
+  describe('ensureFreshToken', () => {
+    const baseTokens = {
+      accessToken: 'old-token',
+      expiresAt: 0,
+      pages: [],
+    };
+
+    it('returns the same tokens unchanged when not near expiry', async () => {
+      const tokens = { ...baseTokens, expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000 };
+      const result = await facebookService.ensureFreshToken(tokens);
+      expect(result).toEqual(tokens);
+    });
+
+    it('refreshes the token when within the refresh window', async () => {
+      const tokens = { ...baseTokens, expiresAt: Date.now() + 60 * 1000 };
+      const newExpiresAt = Date.now() + 5184000 * 1000;
+
+      nock('https://graph.facebook.com')
+        .get('/v18.0/oauth/access_token')
+        .query(true)
+        .reply(200, { access_token: 'new-token', expires_in: 5184000 });
+
+      const result = await facebookService.ensureFreshToken(tokens);
+      expect(result.accessToken).toBe('new-token');
+      expect(result.expiresAt).toBeGreaterThanOrEqual(newExpiresAt - 1000);
+    });
+
+    it('throws AuthRefreshError when the refresh attempt fails', async () => {
+      const tokens = { ...baseTokens, expiresAt: Date.now() + 60 * 1000 };
+
+      nock('https://graph.facebook.com')
+        .get('/v18.0/oauth/access_token')
+        .query(true)
+        .reply(400, { error: { message: 'Invalid token' } });
+
+      await expect(facebookService.ensureFreshToken(tokens)).rejects.toThrow(AuthRefreshError);
+    });
   });
 });

--- a/backend/src/utils/LockService.ts
+++ b/backend/src/utils/LockService.ts
@@ -89,11 +89,17 @@ export const LockService = {
    * Acquire a lock and execute a function.
    * A background interval extends the lock TTL every TTL/2 ms so the lock
    * is held for the full duration of the operation even when it exceeds the
-   * initial TTL.
+   * initial TTL. `fn` receives an AbortSignal that is aborted if a TTL
+   * extension fails (e.g. Redis down) — the operation should stop work and
+   * the overall call rejects so a second worker is never let in alongside it.
    *
    * If Redis is unavailable, falls back to a local in-process AsyncMutex.
    */
-  async withLock<T>(key: string, fn: () => Promise<T>, options: LockOptions = {}): Promise<T> {
+  async withLock<T>(
+    key: string,
+    fn: (signal: AbortSignal) => Promise<T>,
+    options: LockOptions = {},
+  ): Promise<T> {
     const duration = options.duration || 30000; // 30 seconds default
     const lockKey = `lock:${key}`;
 
@@ -104,7 +110,7 @@ export const LockService = {
       const mutex = getLocalMutex(key);
       const release = await mutex.acquire();
       try {
-        return await fn();
+        return await fn(new AbortController().signal);
       } finally {
         release();
       }
@@ -116,6 +122,9 @@ export const LockService = {
       logger.info(`Lock acquired: ${lockKey}`);
 
       // Extend the lock TTL every TTL/2 ms while the operation is running.
+      // If an extension fails, abort the operation rather than letting it
+      // keep running after the lock may have already expired in Redis.
+      const abortController = new AbortController();
       let currentLock = lock;
       const extendInterval = setInterval(async () => {
         try {
@@ -125,11 +134,18 @@ export const LockService = {
           logger.warn(`Failed to extend lock: ${lockKey}`, {
             error: extErr instanceof Error ? extErr.message : String(extErr),
           });
+          abortController.abort(extErr);
         }
       }, Math.floor(duration / 2));
 
+      const aborted = new Promise<never>((_, reject) => {
+        abortController.signal.addEventListener('abort', () =>
+          reject(new Error(`Lock TTL refresh failed for ${key}; operation aborted`)),
+        );
+      });
+
       try {
-        return await fn();
+        return await Promise.race([fn(abortController.signal), aborted]);
       } finally {
         clearInterval(extendInterval);
         await currentLock.unlock().catch((err) => {


### PR DESCRIPTION
## Summary
- **FacebookService** (`backend/src/services/FacebookService.ts`): added `ensureFreshToken()` and `AuthRefreshError` so long-lived tokens are proactively refreshed once `expiresAt` is within `FACEBOOK_TOKEN_REFRESH_WINDOW_MS` (default 7 days) of expiry; `postToPageWithUserToken` now uses this when given full token info. A failed refresh throws `AuthRefreshError` carrying the original error as `cause`.
- **LockService** (`backend/src/utils/LockService.ts`): `withLock` now passes an `AbortSignal` to the wrapped function and aborts (rejecting the call) if a TTL extension fails, so a worker can never keep running unguarded after Redis stops renewing its lock.
- **emailJob** (`backend/src/jobs/emailJob.ts`): non-retryable SES error codes (`MessageRejected`, `InvalidParameterValue`, etc.) now increment an `email_dropped_total{code}` Prometheus counter, mark the job record `failed` with the SES code, log an alert once the drop count crosses a threshold, and throw `UnrecoverableError` so BullMQ stops retrying.
- **verifySignature** (`backend/src/middleware/verifySignature.ts`): a missing `X-Timestamp` header now returns `401 { error: 'Missing timestamp' }` immediately, before any HMAC computation, closing the replay-window bypass.

Closes #1122
Closes #1123
Closes #1124
Closes #1125

## Test plan
- [ ] `npm test` in `backend/` (unit suite) — added/updated tests in `__tests__/verifySignature.test.ts`, `__tests__/LockService.test.ts`, `__tests__/emailJob.test.ts`, `services/__tests__/FacebookService.test.ts`
- [ ] Manually verify a webhook replay without `X-Timestamp` is rejected with the new error shape
- [ ] Manually verify a long-running `withLock` operation aborts when Redis stops renewing the lock