### PR TITLE
test: add unit tests for auth controller token rotation and session invalidation

### DIFF
--- a/backend/src/modules/auth/controllers/__tests__/auth.test.ts
+++ b/backend/src/modules/auth/controllers/__tests__/auth.test.ts
@@ -1,0 +1,231 @@
+import { Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+
+const mockUserStore = {
+  findByEmail: jest.fn(),
+  findById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockAuditLogger = { log: jest.fn() };
+
+jest.mock('../../../../models/User', () => ({ UserStore: mockUserStore }));
+jest.mock('../../../../services/AuditLogger', () => ({ auditLogger: mockAuditLogger }));
+jest.mock('../../../../config/config', () => ({
+  config: {
+    JWT_SECRET: 'test-access-secret-at-least-32-characters-long',
+    JWT_EXPIRES_IN: '15m',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-at-least-32-characters-long',
+    JWT_REFRESH_EXPIRES_IN: '7d',
+  },
+}));
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(async (pw: string) => `hashed:${pw}`),
+  compare: jest.fn(async (pw: string, hash: string) => hash === `hashed:${pw}`),
+}));
+
+import { register, login, refresh, logout } from '../auth';
+
+function mockRes(): Response {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function mockReq(body: Record<string, unknown>): Request {
+  return { body, ip: '127.0.0.1', headers: { 'user-agent': 'jest' } } as unknown as Request;
+}
+
+const ACCESS_SECRET = 'test-access-secret-at-least-32-characters-long';
+const REFRESH_SECRET = 'test-refresh-secret-at-least-32-characters-long';
+
+function signRefreshFor(userId: string): string {
+  return jwt.sign({ sub: userId, jti: 'fixed-jti' }, REFRESH_SECRET, { expiresIn: '7d' });
+}
+
+describe('auth controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('creates a user and returns a token pair when the email is free', async () => {
+      mockUserStore.findByEmail.mockResolvedValue(null);
+      mockUserStore.create.mockResolvedValue({
+        id: 'user-1',
+        email: 'a@b.com',
+        passwordHash: 'hashed:secret123',
+        createdAt: new Date(),
+        refreshTokens: [],
+      });
+      mockUserStore.update.mockResolvedValue(null);
+      const res = mockRes();
+
+      await register(mockReq({ email: 'a@b.com', password: 'secret123' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = (res.json as jest.Mock).mock.calls[0][0];
+      expect(body.accessToken).toBeDefined();
+      expect(body.refreshToken).toBeDefined();
+      expect(jwt.verify(body.accessToken, ACCESS_SECRET)).toMatchObject({ sub: 'user-1' });
+      expect(mockUserStore.update).toHaveBeenCalledWith('user-1', {
+        refreshTokens: [body.refreshToken],
+      });
+    });
+
+    it('returns 409 without creating a user when the email is already registered', async () => {
+      mockUserStore.findByEmail.mockResolvedValue({ id: 'existing' });
+      const res = mockRes();
+
+      await register(mockReq({ email: 'a@b.com', password: 'secret123' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(mockUserStore.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('login', () => {
+    it('returns a token pair and appends the refresh token for valid credentials', async () => {
+      mockUserStore.findByEmail.mockResolvedValue({
+        id: 'user-1',
+        email: 'a@b.com',
+        passwordHash: 'hashed:secret123',
+        refreshTokens: ['old-token'],
+      });
+      mockUserStore.update.mockResolvedValue(null);
+      const res = mockRes();
+
+      await login(mockReq({ email: 'a@b.com', password: 'secret123' }), res);
+
+      expect(res.status).not.toHaveBeenCalled();
+      const body = (res.json as jest.Mock).mock.calls[0][0];
+      expect(body.accessToken).toBeDefined();
+      expect(mockUserStore.update).toHaveBeenCalledWith('user-1', {
+        refreshTokens: ['old-token', body.refreshToken],
+      });
+    });
+
+    it('returns 401 for an unknown email', async () => {
+      mockUserStore.findByEmail.mockResolvedValue(null);
+      const res = mockRes();
+
+      await login(mockReq({ email: 'nobody@b.com', password: 'x' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Invalid credentials' });
+    });
+
+    it('returns 401 for a wrong password without touching the store', async () => {
+      mockUserStore.findByEmail.mockResolvedValue({
+        id: 'user-1',
+        passwordHash: 'hashed:secret123',
+        refreshTokens: [],
+      });
+      const res = mockRes();
+
+      await login(mockReq({ email: 'a@b.com', password: 'wrong' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(mockUserStore.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refresh — token rotation', () => {
+    it('issues a new refresh token and invalidates the old one', async () => {
+      const oldRefresh = signRefreshFor('user-1');
+      mockUserStore.findById.mockResolvedValue({
+        id: 'user-1',
+        refreshTokens: [oldRefresh, 'other-device-token'],
+      });
+      mockUserStore.update.mockResolvedValue(null);
+      const res = mockRes();
+
+      await refresh(mockReq({ refreshToken: oldRefresh }), res);
+
+      const body = (res.json as jest.Mock).mock.calls[0][0];
+      expect(body.refreshToken).toBeDefined();
+      expect(body.refreshToken).not.toBe(oldRefresh);
+      expect(jwt.verify(body.accessToken, ACCESS_SECRET)).toMatchObject({ sub: 'user-1' });
+
+      // Old token is dropped from the persisted set; other sessions are preserved.
+      const updateArgs = mockUserStore.update.mock.calls[0][1];
+      expect(updateArgs.refreshTokens).toContain('other-device-token');
+      expect(updateArgs.refreshTokens).toContain(body.refreshToken);
+      expect(updateArgs.refreshTokens).not.toContain(oldRefresh);
+    });
+
+    it('rejects a malformed or expired refresh token', async () => {
+      const res = mockRes();
+
+      await refresh(mockReq({ refreshToken: 'not-a-real-jwt' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Invalid or expired refresh token' });
+      expect(mockUserStore.findById).not.toHaveBeenCalled();
+    });
+
+    it('rejects a structurally valid token that has already been revoked', async () => {
+      const revokedToken = signRefreshFor('user-1');
+      mockUserStore.findById.mockResolvedValue({ id: 'user-1', refreshTokens: ['some-other-token'] });
+      const res = mockRes();
+
+      await refresh(mockReq({ refreshToken: revokedToken }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Refresh token revoked' });
+      expect(mockUserStore.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a refresh token for a user that no longer exists', async () => {
+      mockUserStore.findById.mockResolvedValue(null);
+      const res = mockRes();
+
+      await refresh(mockReq({ refreshToken: signRefreshFor('ghost-user') }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('logout — session invalidation', () => {
+    it('removes only the presented refresh token and logs the action', async () => {
+      const target = signRefreshFor('user-1');
+      mockUserStore.findById.mockResolvedValue({
+        id: 'user-1',
+        refreshTokens: [target, 'keep-me'],
+      });
+      mockUserStore.update.mockResolvedValue(null);
+      const res = mockRes();
+
+      await logout(mockReq({ refreshToken: target }), res);
+
+      expect(mockUserStore.update).toHaveBeenCalledWith('user-1', { refreshTokens: ['keep-me'] });
+      expect(mockAuditLogger.log).toHaveBeenCalledWith(
+        expect.objectContaining({ actorId: 'user-1', action: 'auth:logout' }),
+      );
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('returns 401 for an invalid token without touching the store', async () => {
+      const res = mockRes();
+
+      await logout(mockReq({ refreshToken: 'garbage' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(mockUserStore.update).not.toHaveBeenCalled();
+    });
+
+    it('still responds 204 when the token is well-formed but the user is gone', async () => {
+      mockUserStore.findById.mockResolvedValue(null);
+      const res = mockRes();
+
+      await logout(mockReq({ refreshToken: signRefreshFor('ghost-user') }), res);
+
+      expect(mockUserStore.update).not.toHaveBeenCalled();
+      expect(mockAuditLogger.log).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+  });
+});

--- a/backend/src/modules/auth/controllers/auth.ts
+++ b/backend/src/modules/auth/controllers/auth.ts
@@ -2,9 +2,9 @@ import { Request, Response } from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { randomUUID } from 'crypto';
-import { UserStore } from '../models/User';
-import { auditLogger } from '../services/AuditLogger';
-import { config } from '../../config/config';
+import { UserStore } from '../../../models/User';
+import { auditLogger } from '../../../services/AuditLogger';
+import { config } from '../../../config/config';
 
 const SALT_ROUNDS = 12;
 
@@ -26,13 +26,13 @@ function signRefresh(userId: string): string {
 export async function register(req: Request, res: Response): Promise<void> {
   const { email, password } = req.body as { email: string; password: string };
 
-  if (UserStore.findByEmail(email)) {
+  if (await UserStore.findByEmail(email)) {
     res.status(409).json({ message: 'Email already registered' });
     return;
   }
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-  const user = UserStore.create({
+  const user = await UserStore.create({
     id: randomUUID(),
     email,
     passwordHash,
@@ -42,7 +42,7 @@ export async function register(req: Request, res: Response): Promise<void> {
 
   const accessToken = signAccess(user.id);
   const refreshToken = signRefresh(user.id);
-  UserStore.update(user.id, { refreshTokens: [refreshToken] });
+  await UserStore.update(user.id, { refreshTokens: [refreshToken] });
 
   auditLogger.log({
     actorId: user.id,
@@ -56,7 +56,7 @@ export async function register(req: Request, res: Response): Promise<void> {
 export async function login(req: Request, res: Response): Promise<void> {
   const { email, password } = req.body as { email: string; password: string };
 
-  const user = UserStore.findByEmail(email);
+  const user = await UserStore.findByEmail(email);
   if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
     res.status(401).json({ message: 'Invalid credentials' });
     return;
@@ -64,7 +64,7 @@ export async function login(req: Request, res: Response): Promise<void> {
 
   const accessToken = signAccess(user.id);
   const refreshToken = signRefresh(user.id);
-  UserStore.update(user.id, { refreshTokens: [...user.refreshTokens, refreshToken] });
+  await UserStore.update(user.id, { refreshTokens: [...user.refreshTokens, refreshToken] });
 
   auditLogger.log({
     actorId: user.id,
@@ -75,7 +75,7 @@ export async function login(req: Request, res: Response): Promise<void> {
   res.json({ accessToken, refreshToken });
 }
 
-export function refresh(req: Request, res: Response): void {
+export async function refresh(req: Request, res: Response): Promise<void> {
   const { refreshToken } = req.body as { refreshToken: string };
 
   let payload: jwt.JwtPayload;
@@ -86,7 +86,7 @@ export function refresh(req: Request, res: Response): void {
     return;
   }
 
-  const user = UserStore.findById(payload.sub as string);
+  const user = await UserStore.findById(payload.sub as string);
   if (!user || !user.refreshTokens.includes(refreshToken)) {
     res.status(401).json({ message: 'Refresh token revoked' });
     return;
@@ -94,14 +94,14 @@ export function refresh(req: Request, res: Response): void {
 
   // Rotate refresh token
   const newRefresh = signRefresh(user.id);
-  UserStore.update(user.id, {
+  await UserStore.update(user.id, {
     refreshTokens: [...user.refreshTokens.filter((t) => t !== refreshToken), newRefresh],
   });
 
   res.json({ accessToken: signAccess(user.id), refreshToken: newRefresh });
 }
 
-export function logout(req: Request, res: Response): void {
+export async function logout(req: Request, res: Response): Promise<void> {
   const { refreshToken } = req.body as { refreshToken: string };
 
   let payload: jwt.JwtPayload;
@@ -112,9 +112,9 @@ export function logout(req: Request, res: Response): void {
     return;
   }
 
-  const user = UserStore.findById(payload.sub as string);
+  const user = await UserStore.findById(payload.sub as string);
   if (user) {
-    UserStore.update(user.id, {
+    await UserStore.update(user.id, {
       refreshTokens: user.refreshTokens.filter((t) => t !== refreshToken),
     });
     auditLogger.log({


### PR DESCRIPTION
Closes #1070

## Summary
Adds unit tests for the auth controller covering token refresh rotation and session invalidation (logout). 2FA challenge issuance lives in a separate, already-tested `twoFactorService` — it isn't implemented in this controller, so no tests were added for it here.

While writing the tests I found the controller was non-functional and had to fix it first:
- **Broken imports**: `../models/User`, `../services/AuditLogger`, `../../config/config` were left stale after a prior restructure into `modules/auth/controllers/`, pointing at paths that don't exist.
- **Missing `await`s**: `UserStore` methods are Promise-returning (Prisma-backed), but were called without `await` — e.g. `if (UserStore.findByEmail(email))` is always truthy since a Promise object is truthy, so `register()` rejected every signup with 409, and `login()` would have thrown on `user.passwordHash` being undefined.

## Test plan
`backend/src/modules/auth/controllers/__tests__/auth.test.ts` — register (success + duplicate email), login (success + invalid credentials), refresh (rotates token and preserves other sessions, rejects malformed/revoked tokens, rejects unknown user), logout (removes only the presented token, logs the action, 401 on invalid token).

No dependency changes; couldn't run the suite in this environment (no `node_modules`), so please run CI/jest to confirm.