### PR TITLE
fix: handle HTTP 429 Retry-After on LinkedIn API rate-limit responses

### DIFF
--- a/backend/src/services/LinkedInService.ts
+++ b/backend/src/services/LinkedInService.ts
@@ -1,6 +1,28 @@
 import { circuitBreakerService } from './CircuitBreakerService';
 import { createLogger } from '../lib/logger';
-import { ValidationError } from '../lib/errors';
+import { ValidationError, RateLimitError } from '../lib/errors';
+
+/**
+ * Parse a `Retry-After` header value into seconds.
+ * Per HTTP spec it's either an integer number of seconds, or an HTTP-date.
+ */
+function parseRetryAfterSeconds(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const asSeconds = Number(header);
+  if (!Number.isNaN(asSeconds)) return Math.max(0, asSeconds);
+  const asDate = Date.parse(header);
+  if (!Number.isNaN(asDate)) {
+    return Math.max(0, Math.round((asDate - Date.now()) / 1000));
+  }
+  return undefined;
+}
+
+/** Throw a RateLimitError (with parsed Retry-After) for 429 responses; no-op otherwise. */
+function throwIfRateLimited(response: Response): void {
+  if (response.status !== 429) return;
+  const retryAfter = parseRetryAfterSeconds(response.headers.get('retry-after'));
+  throw new RateLimitError('LinkedIn API rate limit exceeded', retryAfter, 'LINKEDIN_RATE_LIMIT');
+}
 
 const logger = createLogger('linkedin-service');
 
@@ -112,6 +134,7 @@ class LinkedInService {
     });
 
     if (!response.ok) {
+      throwIfRateLimited(response);
       const err = await response.json();
       throw new Error(`LinkedIn token exchange failed: ${JSON.stringify(err)}`);
     }
@@ -138,6 +161,7 @@ class LinkedInService {
         );
 
         if (!response.ok) {
+          throwIfRateLimited(response);
           throw new Error(`LinkedIn profile fetch failed: ${response.status}`);
         }
 
@@ -209,6 +233,7 @@ class LinkedInService {
         });
 
         if (!response.ok) {
+          throwIfRateLimited(response);
           const err = await response.json();
           throw new Error(`LinkedIn share failed: ${JSON.stringify(err)}`);
         }
@@ -310,6 +335,7 @@ class LinkedInService {
         );
 
         if (!response.ok) {
+          throwIfRateLimited(response);
           throw new Error(`LinkedIn stats fetch failed: ${response.status}`);
         }
 

--- a/backend/src/services/__tests__/LinkedInService.test.ts
+++ b/backend/src/services/__tests__/LinkedInService.test.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from '../../lib/errors';
+import { ValidationError, RateLimitError } from '../../lib/errors';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -29,12 +29,16 @@ function okResponse(headers: Record<string, string> = {}): Response {
   } as unknown as Response;
 }
 
-function errorResponse(body: object, status = 400): Response {
+function errorResponse(
+  body: object,
+  status = 400,
+  headers: Record<string, string> = {},
+): Response {
   return {
     ok: false,
     status,
     json: () => Promise.resolve(body),
-    headers: { get: () => null },
+    headers: { get: (key: string) => headers[key.toLowerCase()] ?? null },
   } as unknown as Response;
 }
 
@@ -314,6 +318,40 @@ describe('LinkedInService.shareContent — network', () => {
     await expect(
       linkedInService.shareContent('bad-token', BASE_REQUEST),
     ).rejects.toThrow('LinkedIn share failed');
+  });
+
+  it('throws a RateLimitError with the parsed Retry-After (seconds) on a 429', async () => {
+    mockFetch.mockResolvedValueOnce(
+      errorResponse({ message: 'Too Many Requests' }, 429, { 'retry-after': '30' }),
+    );
+
+    const promise = linkedInService.shareContent('my-token', BASE_REQUEST);
+    await expect(promise).rejects.toBeInstanceOf(RateLimitError);
+    await expect(promise.catch((e) => e.retryAfter)).resolves.toBe(30);
+  });
+
+  it('parses an HTTP-date Retry-After header into seconds', async () => {
+    const retryDate = new Date(Date.now() + 60_000).toUTCString();
+    mockFetch.mockResolvedValueOnce(
+      errorResponse({ message: 'Too Many Requests' }, 429, { 'retry-after': retryDate }),
+    );
+
+    const err = await linkedInService
+      .shareContent('my-token', BASE_REQUEST)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.retryAfter).toBeGreaterThan(0);
+    expect(err.retryAfter).toBeLessThanOrEqual(60);
+  });
+
+  it('throws a RateLimitError with undefined retryAfter when the header is missing', async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse({ message: 'Too Many Requests' }, 429));
+
+    const err = await linkedInService
+      .shareContent('my-token', BASE_REQUEST)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.retryAfter).toBeUndefined();
   });
 
   it('sends the correct Authorization and protocol headers', async () => {


### PR DESCRIPTION
Closes #1081

## Summary
`LinkedInService` had no special handling for HTTP 429s — every failure response (including rate limits) fell through to a generic `Error`, discarding the `Retry-After` header entirely.

Added `throwIfRateLimited()` (parses `Retry-After` as either integer seconds or an HTTP-date) and applied it before the generic error at every real LinkedIn API call site: token exchange, profile fetch, share content, and post stats. Throws the existing `RateLimitError` (from `lib/errors.ts`) with the parsed `retryAfter` in seconds so callers/queues can actually back off correctly, instead of a plain `Error` that throws the retry timing away. Left `validateMediaAssetUrls`'s HEAD check alone since that's validating arbitrary external image URLs, not a LinkedIn API rate limit.

## Test plan
Added to `LinkedInService.test.ts`: 429 with integer `Retry-After` → `RateLimitError` with `retryAfter` seconds parsed correctly; 429 with HTTP-date `Retry-After` → parsed to a positive second count; 429 with no header → `RateLimitError` with `retryAfter: undefined`.

No dependency changes; couldn't run the suite in this environment (no `node_modules`), so please run CI/jest to confirm.