### PR TITLE
Fix credit overdraft, socket broadcast leak, TTS job scoping, unbounded median query (#1172–#1175)

### DIFF
--- a/backend/src/controllers/tts.ts
+++ b/backend/src/controllers/tts.ts
@@ -28,9 +28,14 @@ export async function getTTSJob(req: AuthRequest, res: Response, next: NextFunct
   }
 }
 
-export async function listTTSJobs(_req: AuthRequest, res: Response, next: NextFunction) {
+export async function listTTSJobs(req: AuthRequest, res: Response, next: NextFunction) {
   try {
-    res.json(await ttsService.getAllJobs());
+    const userId = req.user?.id;
+    if (!userId) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+    res.json(await ttsService.getAllJobs(userId));
   } catch (err) {
     next(err);
   }

--- a/backend/src/jobs/platformMedianJob.ts
+++ b/backend/src/jobs/platformMedianJob.ts
@@ -19,10 +19,16 @@ const CACHE_TTL_SECONDS = 3600; // 1 hour
 let queue: Queue | null = null;
 let worker: Worker | null = null;
 
-/** Compute per-platform medians from AnalyticsEntry rows. */
+/** Compute per-platform medians from AnalyticsEntry rows within a 90-day rolling window. */
 export async function computePlatformMedians(): Promise<PlatformMedians> {
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
   const rows = await prisma.analyticsEntry.findMany({
-    where: { metric: { in: ['reach', 'engagement'] } },
+    where: {
+      metric: { in: ['reach', 'engagement'] },
+      recordedAt: { gte: ninetyDaysAgo },
+    },
     select: { platform: true, metric: true, value: true },
   });
 

--- a/backend/src/services/BillingService.ts
+++ b/backend/src/services/BillingService.ts
@@ -135,7 +135,9 @@ export class BillingService {
   }
 
   /**
-   * Atomically deduct credits for an action inside a per-user lock.
+   * Atomically deduct credits for an action using a compare-and-swap transaction.
+   * The UPDATE only proceeds when creditsRemaining >= cost at commit time, preventing
+   * concurrent requests from overdrafting the balance.
    * Throws if the subscription is missing, inactive, or has insufficient credits.
    * Returns updated balance.
    */
@@ -154,16 +156,29 @@ export class BillingService {
     }
 
     const newBalance = sub.creditsRemaining - cost;
-    await prisma.subscription.update({ where: { userId }, data: { creditsRemaining: newBalance } });
-    await prisma.creditLog.create({
-      data: { userId, action, delta: -cost, balanceAfter: newBalance },
-    });
 
+    const [updated, log] = await prisma.$transaction([
+      prisma.subscription.updateMany({
+        where: { userId, creditsRemaining: { gte: cost } },
+        data: { creditsRemaining: { decrement: cost } },
+      }),
+      prisma.creditLog.create({
+        data: { userId, action, delta: -cost, balanceAfter: newBalance },
+      }),
+    ]);
+
+    if (updated.count === 0) {
+      throw new Error('Insufficient credits (concurrent request exhausted balance)');
+    }
+
+    void log;
     return newBalance;
   }
 
   /**
-   * Atomically deduct credits proportional to actual token usage (1 credit per token).
+   * Atomically deduct credits proportional to actual token usage using a
+   * compare-and-swap transaction. The UPDATE only proceeds when
+   * creditsRemaining >= tokens at commit time, preventing overdraft.
    * Throws if the user has insufficient credits.
    * Returns updated balance.
    */
@@ -181,11 +196,22 @@ export class BillingService {
     }
 
     const newBalance = sub.creditsRemaining - tokens;
-    await prisma.subscription.update({ where: { userId }, data: { creditsRemaining: newBalance } });
-    await prisma.creditLog.create({
-      data: { userId, action: 'ai:generate', delta: -tokens, balanceAfter: newBalance },
-    });
 
+    const [updated, log] = await prisma.$transaction([
+      prisma.subscription.updateMany({
+        where: { userId, creditsRemaining: { gte: tokens } },
+        data: { creditsRemaining: { decrement: tokens } },
+      }),
+      prisma.creditLog.create({
+        data: { userId, action: 'ai:generate', delta: -tokens, balanceAfter: newBalance },
+      }),
+    ]);
+
+    if (updated.count === 0) {
+      throw new Error('Insufficient credits (concurrent request exhausted balance)');
+    }
+
+    void log;
     return newBalance;
   }
 

--- a/backend/src/services/SocketService.ts
+++ b/backend/src/services/SocketService.ts
@@ -104,11 +104,13 @@ export class SocketService {
       // Handle message events dynamically
       socket.on('message', (payload) => {
         logger.info(`Message from ${socket.id}`, { payload });
-        // Relay message or process it
         if (orgId) {
           this.io?.to(`org:${orgId}`).emit('message', { ...payload, from: socket.user });
+        } else if (userId) {
+          // Scope to sender's own user room — never broadcast globally without an org
+          socket.to(`user:${userId}`).emit('message', { ...payload, from: socket.user });
         } else {
-          this.io?.emit('message', { ...payload, from: socket.user });
+          logger.warn(`Message dropped — no orgId or userId for socket ${socket.id}`);
         }
       });
 
@@ -118,7 +120,7 @@ export class SocketService {
           // Broadcast to everyone in the room except the sender
           socket.to(`org:${orgId}`).emit('collaboration:update', payload);
         } else {
-          socket.broadcast.emit('collaboration:update', payload);
+          logger.warn(`collaboration:update dropped — no orgId for socket ${socket.id}`);
         }
       });
 

--- a/backend/src/services/TTSService.ts
+++ b/backend/src/services/TTSService.ts
@@ -52,8 +52,11 @@ class TTSService {
     return row ? rowToJob(row) : undefined;
   }
 
-  async getAllJobs(): Promise<TTSJob[]> {
-    const rows = await prisma.tTSJob.findMany({ orderBy: { createdAt: 'desc' } });
+  async getAllJobs(userId: string): Promise<TTSJob[]> {
+    const rows = await prisma.tTSJob.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
     return rows.map(rowToJob);
   }
 


### PR DESCRIPTION
## Summary

Fixes four independent security and stability issues reported in #1172, #1173, #1174, and #1175.

---

### closes #1172 — BillingService: atomic credit deduction (overdraft prevention)

**Root cause:** `deductCredits` and `deductCreditsForTokens` performed a plain `findUnique` → balance check → `update` sequence with no database transaction. Two concurrent requests could both pass the balance check before either committed, allowing the account to go negative.

**Fix:** Both methods now execute inside `prisma.$transaction([updateMany, creditLog.create])`. The `updateMany` uses `where: { userId, creditsRemaining: { gte: cost } }` as a compare-and-swap guard — the UPDATE only proceeds if the balance is still sufficient at commit time. If `updated.count === 0`, the transaction was lost to a concurrent deduction and an error is thrown.

---

### closes #1173 — SocketService: cross-user message broadcast removed

**Root cause:** The `message` event handler fell back to `this.io?.emit(...)` (global broadcast) when `orgId` was absent, leaking message payloads to all connected clients. The `collaboration:update` handler had the same flaw via `socket.broadcast.emit`.

**Fix:**
- `message` without `orgId` is now scoped to `socket.to(\`user:${userId}\`)` — only the sender's own user room. If `userId` is also absent the message is dropped with a warning log.
- `collaboration:update` without `orgId` is silently dropped (logged as a warning) instead of broadcasting globally.

---

### closes #1174 — TTSService: getAllJobs scoped to authenticated user

**Root cause:** `getAllJobs()` called `prisma.tTSJob.findMany` with no `userId` filter, returning every job on the platform to any caller.

**Fix:**
- `getAllJobs` now requires a `userId: string` parameter and applies `where: { userId }`.
- `listTTSJobs` controller passes `req.user.id` and returns `401` when the user is unauthenticated.

---

### closes #1175 — platformMedianJob: 90-day rolling window prevents unbounded query

**Root cause:** `computePlatformMedians` fetched every `analyticsEntry` row matching the metric filter with no date bound, no limit, and no pagination. On a large production table this causes OOM or a severe query timeout on every 6-hour refresh cycle.

**Fix:** Added `recordedAt: { gte: ninetyDaysAgo }` to the Prisma query, scoping the fetch to the last 90 days. The `recordedAt` column is already indexed (`@@index([recordedAt])` in the schema), so this filter uses the index efficiently.

## Files changed

| File | Change |
|------|--------|
| `backend/src/services/BillingService.ts` | Replace read-check-update with `$transaction` + compare-and-swap `updateMany` |
| `backend/src/services/SocketService.ts` | Scope `message` to user room; drop `collaboration:update` without orgId |
| `backend/src/services/TTSService.ts` | Add `userId` param to `getAllJobs`, apply as where filter |
| `backend/src/controllers/tts.ts` | Pass `req.user.id` to `getAllJobs`; return 401 when unauthenticated |
| `backend/src/jobs/platformMedianJob.ts` | Add 90-day `recordedAt` rolling window filter |

Closes #1172, #1173, #1174, #1175