### PR TITLE
fix: use read replica in JSON export methods and add queue unit tests

### DIFF
--- a/backend/src/__tests__/queue.test.ts
+++ b/backend/src/__tests__/queue.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for src/utils/queue.ts
+ * Closes #1110
+ */
+
+jest.mock('../queues/queueManager', () => ({
+  queueManager: {
+    addJob: jest.fn(),
+  },
+}));
+
+import { enqueue } from '../utils/queue';
+import { queueManager } from '../queues/queueManager';
+
+const mockAddJob = queueManager.addJob as jest.MockedFunction<typeof queueManager.addJob>;
+
+beforeEach(() => {
+  mockAddJob.mockReset();
+});
+
+describe('enqueue', () => {
+  it('calls queueManager.addJob with correct queue, name, and data', async () => {
+    mockAddJob.mockResolvedValue('job-1');
+    const id = await enqueue('myQueue', 'myJob', { foo: 'bar' });
+    expect(mockAddJob).toHaveBeenCalledWith('myQueue', 'myJob', { foo: 'bar' }, expect.any(Object));
+    expect(id).toBe('job-1');
+  });
+
+  it('forwards priority option to BullMQ job options', async () => {
+    mockAddJob.mockResolvedValue('job-2');
+    await enqueue('q', 'n', {}, { priority: 3 });
+    expect(mockAddJob).toHaveBeenCalledWith('q', 'n', {}, expect.objectContaining({ priority: 3 }));
+  });
+
+  it('forwards delay option to BullMQ job options', async () => {
+    mockAddJob.mockResolvedValue('job-3');
+    await enqueue('q', 'n', {}, { delay: 5000 });
+    expect(mockAddJob).toHaveBeenCalledWith('q', 'n', {}, expect.objectContaining({ delay: 5000 }));
+  });
+
+  it('sets exponential backoff when attempts is provided', async () => {
+    mockAddJob.mockResolvedValue('job-4');
+    await enqueue('q', 'n', {}, { attempts: 5 });
+    expect(mockAddJob).toHaveBeenCalledWith('q', 'n', {}, expect.objectContaining({
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 2000 },
+    }));
+  });
+
+  it('does not set attempts/backoff when attempts is omitted', async () => {
+    mockAddJob.mockResolvedValue('job-5');
+    await enqueue('q', 'n', {});
+    const opts = mockAddJob.mock.calls[0][3];
+    expect(opts).not.toHaveProperty('attempts');
+    expect(opts).not.toHaveProperty('backoff');
+  });
+
+  it('propagates errors thrown by queueManager.addJob', async () => {
+    mockAddJob.mockRejectedValue(new Error('dead-letter'));
+    await expect(enqueue('q', 'n', {})).rejects.toThrow('dead-letter');
+  });
+});

--- a/backend/src/services/ExportService.ts
+++ b/backend/src/services/ExportService.ts
@@ -1,6 +1,5 @@
 import { Response } from 'express';
 import { Readable } from 'stream';
-import { prisma } from '../lib/prisma';
 import { replicaClient } from '../lib/readReplica';
 import { paginatedQuery } from '../lib/paginatedQuery';
 
@@ -61,7 +60,7 @@ export const ExportService = {
       'Content-Type': 'application/x-ndjson; charset=utf-8',
       'Content-Disposition': 'attachment; filename="analytics.jsonl"',
     });
-    await pump(stream, (args) => prisma.analyticsEntry.findMany({ where, ...args }), (row) =>
+    await pump(stream, (args) => replicaClient.analyticsEntry.findMany({ where, ...args }), (row) =>
       JSON.stringify(row) + '\n',
     );
   },
@@ -98,7 +97,7 @@ export const ExportService = {
       'Content-Type': 'application/x-ndjson; charset=utf-8',
       'Content-Disposition': 'attachment; filename="posts.jsonl"',
     });
-    await pump(stream, (args) => prisma.post.findMany({ where, ...args }), (row) =>
+    await pump(stream, (args) => replicaClient.post.findMany({ where, ...args }), (row) =>
       JSON.stringify(row) + '\n',
     );
   },


### PR DESCRIPTION
- ExportService.streamAnalyticsAsJSON and streamPostsAsJSON were calling prisma (primary DB) instead of replicaClient; replaced both to match the already-correct CSV variants. Removed unused prisma import. Closes #1171

- Add unit tests for enqueue() covering correct addJob args, priority, delay, attempts/exponential-backoff, and error propagation. Closes #1110