### PR TITLE
Test/backend lib data layer coverage

### DIFF
--- a/backend/src/lib/__tests__/errors.test.ts
+++ b/backend/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,103 @@
+import {
+  AppError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  ValidationError,
+  RateLimitError,
+  InternalServerError,
+  ServiceUnavailableError,
+  DatabaseError,
+  ExternalServiceError,
+  isAppError,
+  isOperationalError,
+} from '../errors';
+
+describe('lib/errors', () => {
+  it('BadRequestError has status 400 and default code', () => {
+    const err = new BadRequestError();
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(400);
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.isOperational).toBe(true);
+  });
+
+  it('UnauthorizedError has status 401', () => {
+    const err = new UnauthorizedError();
+    expect(err.statusCode).toBe(401);
+    expect(err.code).toBe('UNAUTHORIZED');
+  });
+
+  it('ForbiddenError has status 403', () => {
+    const err = new ForbiddenError();
+    expect(err.statusCode).toBe(403);
+    expect(err.code).toBe('FORBIDDEN');
+  });
+
+  it('NotFoundError has status 404', () => {
+    const err = new NotFoundError();
+    expect(err.statusCode).toBe(404);
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('ConflictError has status 409', () => {
+    const err = new ConflictError();
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe('CONFLICT');
+  });
+
+  it('ValidationError has status 422 and carries field errors', () => {
+    const err = new ValidationError('Invalid', { email: ['is required'] });
+    expect(err.statusCode).toBe(422);
+    expect(err.errors).toEqual({ email: ['is required'] });
+  });
+
+  it('RateLimitError has status 429 and carries retryAfter', () => {
+    const err = new RateLimitError('Slow down', 30);
+    expect(err.statusCode).toBe(429);
+    expect(err.retryAfter).toBe(30);
+  });
+
+  it('InternalServerError has status 500 and is non-operational', () => {
+    const err = new InternalServerError();
+    expect(err.statusCode).toBe(500);
+    expect(err.isOperational).toBe(false);
+  });
+
+  it('ServiceUnavailableError has status 503', () => {
+    const err = new ServiceUnavailableError('down', 60);
+    expect(err.statusCode).toBe(503);
+    expect(err.retryAfter).toBe(60);
+  });
+
+  it('DatabaseError has status 500 and is non-operational', () => {
+    const err = new DatabaseError();
+    expect(err.statusCode).toBe(500);
+    expect(err.isOperational).toBe(false);
+  });
+
+  it('ExternalServiceError has status 502 and carries service name', () => {
+    const err = new ExternalServiceError('failed', 'stripe');
+    expect(err.statusCode).toBe(502);
+    expect(err.service).toBe('stripe');
+  });
+
+  it('isAppError distinguishes AppError instances from plain errors', () => {
+    expect(isAppError(new NotFoundError())).toBe(true);
+    expect(isAppError(new Error('plain'))).toBe(false);
+  });
+
+  it('isOperationalError reflects the isOperational flag', () => {
+    expect(isOperationalError(new BadRequestError())).toBe(true);
+    expect(isOperationalError(new InternalServerError())).toBe(false);
+    expect(isOperationalError(new Error('plain'))).toBe(false);
+  });
+
+  it('each error instance passes instanceof checks against its own class', () => {
+    expect(new BadRequestError()).toBeInstanceOf(BadRequestError);
+    expect(new ValidationError()).toBeInstanceOf(ValidationError);
+    expect(new ExternalServiceError()).toBeInstanceOf(ExternalServiceError);
+  });
+});

--- a/backend/src/lib/__tests__/eventBus.test.ts
+++ b/backend/src/lib/__tests__/eventBus.test.ts
@@ -1,0 +1,62 @@
+import { eventBus, resetEventBus, JobProgressEvent } from '../eventBus';
+
+describe('eventBus', () => {
+  afterEach(() => {
+    resetEventBus();
+  });
+
+  const sampleEvent: JobProgressEvent = {
+    jobId: 'job-1',
+    userId: 'user-1',
+    type: 'ai_generation',
+    status: 'processing',
+    progress: 50,
+  };
+
+  it('delivers job progress events to listeners scoped to the user', () => {
+    const listener = jest.fn();
+    eventBus.onUserJob('user-1', listener);
+
+    eventBus.emitJobProgress(sampleEvent);
+
+    expect(listener).toHaveBeenCalledWith(sampleEvent);
+  });
+
+  it('does not deliver events to a different user', () => {
+    const listener = jest.fn();
+    eventBus.onUserJob('user-2', listener);
+
+    eventBus.emitJobProgress(sampleEvent);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('also emits on the wildcard channel for monitoring', () => {
+    const wildcardListener = jest.fn();
+    eventBus.on('job:*', wildcardListener);
+
+    eventBus.emitJobProgress(sampleEvent);
+
+    expect(wildcardListener).toHaveBeenCalledWith(sampleEvent);
+  });
+
+  it('stops delivering events after offUserJob removes the listener', () => {
+    const listener = jest.fn();
+    eventBus.onUserJob('user-1', listener);
+    eventBus.offUserJob('user-1', listener);
+
+    eventBus.emitJobProgress(sampleEvent);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('reset removes all listeners', () => {
+    const listener = jest.fn();
+    eventBus.onUserJob('user-1', listener);
+
+    resetEventBus();
+    eventBus.emitJobProgress(sampleEvent);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lib/__tests__/logger.test.ts
+++ b/backend/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Covers createLogger's public interface — each level method should exist
+ * and forward without throwing, including with the request-scoped requestId
+ * context applied.
+ */
+import { createLogger } from '../logger';
+import { requestContext } from '../../middleware/requestId';
+
+describe('lib/logger', () => {
+  it('createLogger returns all expected log level methods', () => {
+    const log = createLogger('test-scope');
+
+    expect(typeof log.info).toBe('function');
+    expect(typeof log.warn).toBe('function');
+    expect(typeof log.error).toBe('function');
+    expect(typeof log.debug).toBe('function');
+  });
+
+  it('does not throw when logging without metadata', () => {
+    const log = createLogger('test-scope');
+
+    expect(() => log.info('hello')).not.toThrow();
+    expect(() => log.warn('careful')).not.toThrow();
+    expect(() => log.error('boom')).not.toThrow();
+    expect(() => log.debug('trace me')).not.toThrow();
+  });
+
+  it('does not throw when logging with metadata', () => {
+    const log = createLogger('test-scope');
+
+    expect(() => log.info('hello', { userId: '123' })).not.toThrow();
+  });
+
+  it('includes the active requestId from AsyncLocalStorage context when present', () => {
+    const log = createLogger('test-scope');
+
+    expect(() =>
+      requestContext.run({ requestId: 'req-abc' }, () => {
+        log.info('scoped message');
+      }),
+    ).not.toThrow();
+  });
+});

--- a/backend/src/lib/__tests__/meilisearch.test.ts
+++ b/backend/src/lib/__tests__/meilisearch.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Covers getMeiliClient's singleton behavior and localhost-in-non-dev warning.
+ */
+
+const mockMeiliSearchCtor = jest.fn();
+
+jest.mock('meilisearch', () => ({
+  MeiliSearch: jest.fn().mockImplementation((opts: any) => {
+    mockMeiliSearchCtor(opts);
+    return { __opts: opts };
+  }),
+}));
+
+describe('lib/meilisearch', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockMeiliSearchCtor.mockClear();
+  });
+
+  it('returns the same client instance on repeated calls (singleton)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getMeiliClient } = require('../meilisearch');
+
+    const first = getMeiliClient();
+    const second = getMeiliClient();
+
+    expect(first).toBe(second);
+    expect(mockMeiliSearchCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds the client from configured host and admin key', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getMeiliClient } = require('../meilisearch');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { config } = require('../../config/config');
+
+    getMeiliClient();
+
+    expect(mockMeiliSearchCtor).toHaveBeenCalledWith({
+      host: config.MEILISEARCH_HOST,
+      apiKey: config.MEILISEARCH_ADMIN_KEY,
+    });
+  });
+
+  it('warns when MEILISEARCH_HOST points to localhost outside development', () => {
+    jest.doMock('../../config/config', () => ({
+      config: {
+        MEILISEARCH_HOST: 'http://localhost:7700',
+        MEILISEARCH_ADMIN_KEY: 'key',
+        NODE_ENV: 'production',
+      },
+    }));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getMeiliClient } = require('../meilisearch');
+    getMeiliClient();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+    jest.dontMock('../../config/config');
+  });
+});

--- a/backend/src/lib/__tests__/paginatedQuery.test.ts
+++ b/backend/src/lib/__tests__/paginatedQuery.test.ts
@@ -1,0 +1,83 @@
+import { paginatedQuery } from '../paginatedQuery';
+
+const BATCH_SIZE = 1000;
+
+type Row = { id: string };
+
+function makeRows(count: number, prefix = 'id'): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${String(i).padStart(5, '0')}`,
+  }));
+}
+
+async function drain<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of gen) out.push(item);
+  return out;
+}
+
+describe('paginatedQuery', () => {
+  it('yields nothing when the first page is empty', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+
+    const results = await drain(paginatedQuery(findMany));
+
+    expect(results).toEqual([]);
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany).toHaveBeenCalledWith({
+      take: BATCH_SIZE + 1,
+      skip: 0,
+      cursor: undefined,
+      orderBy: { id: 'asc' },
+    });
+  });
+
+  it('yields all rows from a single page shorter than the batch size (last page)', async () => {
+    const rows = makeRows(3);
+    const findMany = jest.fn().mockResolvedValue(rows);
+
+    const results = await drain(paginatedQuery(findMany));
+
+    expect(results).toEqual(rows);
+    expect(findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('paginates across a middle page using the last id of the previous batch as cursor', async () => {
+    const firstPage = makeRows(BATCH_SIZE + 1, 'a'); // hasMore -> pop last
+    const secondPage = makeRows(2, 'b');
+
+    const findMany = jest
+      .fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+
+    const results = await drain(paginatedQuery(findMany));
+
+    // first page yields BATCH_SIZE rows (last one popped as the next cursor)
+    expect(results).toHaveLength(BATCH_SIZE + secondPage.length);
+    expect(findMany).toHaveBeenCalledTimes(2);
+
+    const secondCallArgs = findMany.mock.calls[1][0];
+    expect(secondCallArgs).toEqual({
+      take: BATCH_SIZE + 1,
+      skip: 1,
+      cursor: { id: firstPage[BATCH_SIZE - 1].id },
+      orderBy: { id: 'asc' },
+    });
+  });
+
+  it('stops after the final short page (last-page boundary)', async () => {
+    const firstPage = makeRows(BATCH_SIZE + 1, 'a');
+    const lastPage = makeRows(0);
+
+    const findMany = jest
+      .fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(lastPage);
+
+    const results = await drain(paginatedQuery(findMany));
+
+    expect(results).toHaveLength(BATCH_SIZE);
+    expect(findMany).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/lib/__tests__/prisma.test.ts
+++ b/backend/src/lib/__tests__/prisma.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Covers the org-scoping and soft-delete query extension in lib/prisma.ts.
+ * PrismaClient / PrismaPg are mocked so the extension logic can be exercised
+ * without a live database connection.
+ */
+
+let capturedExtension: any;
+
+const mockBaseModelClient = {
+  post: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  user: {
+    findFirst: jest.fn(),
+    findFirstOrThrow: jest.fn(),
+    updateMany: jest.fn(),
+  },
+};
+
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      ...mockBaseModelClient,
+      $extends: jest.fn((ext: any) => {
+        capturedExtension = ext;
+        return { extended: true };
+      }),
+    })),
+  };
+});
+
+jest.mock('@prisma/adapter-pg', () => ({
+  PrismaPg: jest.fn().mockImplementation(() => ({})),
+}));
+
+describe('lib/prisma query extension', () => {
+  let allOperations: (params: {
+    model: string;
+    operation: string;
+    args: Record<string, any>;
+    query: (args: Record<string, any>) => Promise<any>;
+  }) => Promise<any>;
+
+  beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../prisma');
+    allOperations = capturedExtension.query.$allModels.$allOperations;
+  });
+
+  describe('org-scoping', () => {
+    it('injects organizationId into where clause for read ops on org-scoped models', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+
+      await allOperations({
+        model: 'Post',
+        operation: 'findMany',
+        args: { __orgId: 'org-1', where: { published: true } },
+        query,
+      });
+
+      expect(query).toHaveBeenCalledWith({
+        where: { published: true, organizationId: 'org-1' },
+      });
+    });
+
+    it('injects organizationId into data on create for org-scoped models', async () => {
+      const query = jest.fn().mockResolvedValue({});
+
+      await allOperations({
+        model: 'Post',
+        operation: 'create',
+        args: { __orgId: 'org-2', data: { title: 'hello' } },
+        query,
+      });
+
+      expect(query).toHaveBeenCalledWith({
+        data: { title: 'hello', organizationId: 'org-2' },
+      });
+    });
+
+    it('does not scope models outside ORG_SCOPED_MODELS', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+
+      await allOperations({
+        model: 'Subscription',
+        operation: 'findMany',
+        args: { __orgId: 'org-1', where: {} },
+        query,
+      });
+
+      // __orgId is only stripped/applied for org-scoped models, so it is
+      // passed through untouched here.
+      expect(query).toHaveBeenCalledWith({ __orgId: 'org-1', where: {} });
+    });
+
+    it('leaves args untouched when no __orgId is present', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+
+      await allOperations({
+        model: 'Post',
+        operation: 'findMany',
+        args: { where: { published: true } },
+        query,
+      });
+
+      expect(query).toHaveBeenCalledWith({ where: { published: true } });
+    });
+  });
+
+  describe('soft delete', () => {
+    it('rewrites delete into an update setting deletedAt for soft-delete models', async () => {
+      const query = jest.fn().mockResolvedValue({});
+
+      await allOperations({
+        model: 'User',
+        operation: 'delete',
+        args: { where: { id: 'u-1' } },
+        query,
+      });
+
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'u-1' },
+          data: { deletedAt: expect.any(Date) },
+        }),
+      );
+    });
+
+    it('routes deleteMany to updateMany on the base client for soft-delete models', async () => {
+      mockBaseModelClient.user.updateMany.mockResolvedValue({ count: 2 });
+
+      const result = await allOperations({
+        model: 'User',
+        operation: 'deleteMany',
+        args: { where: { active: false } },
+        query: jest.fn(),
+      });
+
+      expect(mockBaseModelClient.user.updateMany).toHaveBeenCalledWith({
+        where: { active: false },
+        data: { deletedAt: expect.any(Date) },
+      });
+      expect(result).toEqual({ count: 2 });
+    });
+
+    it('filters out soft-deleted rows on findMany for soft-delete models', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+
+      await allOperations({
+        model: 'User',
+        operation: 'findMany',
+        args: { where: { email: 'a@b.com' } },
+        query,
+      });
+
+      expect(query).toHaveBeenCalledWith({
+        where: { email: 'a@b.com', deletedAt: null },
+      });
+    });
+
+    it('does not affect models without soft delete support', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+
+      await allOperations({
+        model: 'Subscription',
+        operation: 'findMany',
+        args: { where: { active: true } },
+        query,
+      });
+
+      expect(query).toHaveBeenCalledWith({ where: { active: true } });
+    });
+  });
+});

--- a/backend/src/lib/__tests__/readReplica.test.ts
+++ b/backend/src/lib/__tests__/readReplica.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Covers the read/write routing decision in lib/readReplica.ts:
+ * - applyReadWriteSplitting warns when DATABASE_REPLICA_URL is set (since
+ *   Prisma v7 removed middleware-based splitting).
+ * - replicaClient falls back to DATABASE_URL when no replica URL is configured.
+ */
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation((opts: any) => ({ __opts: opts })),
+}));
+
+jest.mock('@prisma/adapter-pg', () => ({
+  PrismaPg: jest.fn().mockImplementation((opts: any) => ({ __adapterOpts: opts })),
+}));
+
+describe('lib/readReplica', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('does not throw when DATABASE_REPLICA_URL is set but splitting is inactive', () => {
+    process.env.DATABASE_REPLICA_URL = 'postgresql://replica:5432/db';
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { applyReadWriteSplitting } = require('../readReplica');
+
+    expect(() => applyReadWriteSplitting({} as any)).not.toThrow();
+  });
+
+  it('does not warn when DATABASE_REPLICA_URL is unset', () => {
+    delete process.env.DATABASE_REPLICA_URL;
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { applyReadWriteSplitting } = require('../readReplica');
+
+    expect(() => applyReadWriteSplitting({} as any)).not.toThrow();
+  });
+
+  it('builds the replica adapter from DATABASE_REPLICA_URL when configured', () => {
+    process.env.DATABASE_REPLICA_URL = 'postgresql://replica:5432/db';
+    process.env.DATABASE_URL = 'postgresql://primary:5432/db';
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PrismaPg } = require('@prisma/adapter-pg');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../readReplica');
+
+    expect(PrismaPg).toHaveBeenCalledWith({
+      connectionString: 'postgresql://replica:5432/db',
+    });
+  });
+
+  it('falls back to DATABASE_URL for the replica adapter when no replica URL is set', () => {
+    delete process.env.DATABASE_REPLICA_URL;
+    process.env.DATABASE_URL = 'postgresql://primary:5432/db';
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { PrismaPg } = require('@prisma/adapter-pg');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../readReplica');
+
+    expect(PrismaPg).toHaveBeenCalledWith({
+      connectionString: 'postgresql://primary:5432/db',
+    });
+  });
+});

--- a/backend/src/lib/__tests__/redis.test.ts
+++ b/backend/src/lib/__tests__/redis.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Covers that lib/redis.ts builds its singleton ioredis client from the
+ * validated runtime config rather than raw process.env access.
+ */
+
+const mockRedisCtor = jest.fn();
+
+jest.mock('ioredis', () => {
+  return jest.fn().mockImplementation((opts: any) => {
+    mockRedisCtor(opts);
+    return { __opts: opts };
+  });
+});
+
+jest.mock('../../config/runtime', () => ({
+  getRedisConnection: jest.fn().mockReturnValue({
+    host: '127.0.0.1',
+    port: 6379,
+    db: 0,
+  }),
+}));
+
+describe('lib/redis', () => {
+  it('constructs the ioredis client using getRedisConnection()', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { redis } = require('../redis');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getRedisConnection } = require('../../config/runtime');
+
+    expect(getRedisConnection).toHaveBeenCalled();
+    expect(mockRedisCtor).toHaveBeenCalledWith({
+      host: '127.0.0.1',
+      port: 6379,
+      db: 0,
+    });
+    expect(redis).toBeDefined();
+  });
+});

--- a/backend/src/lib/__tests__/traceContext.test.ts
+++ b/backend/src/lib/__tests__/traceContext.test.ts
@@ -1,0 +1,45 @@
+import { trace, context, SpanKind } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { captureTraceContext, restoreTraceContext } from '../traceContext';
+
+describe('lib/traceContext', () => {
+  it('captureTraceContext returns undefined when there is no active span', () => {
+    const result = captureTraceContext();
+    expect(result).toBeUndefined();
+  });
+
+  it('restoreTraceContext returns the current active context when serialized is falsy', () => {
+    const ctx = restoreTraceContext(undefined);
+    expect(ctx).toBe(context.active());
+  });
+
+  it('captures a traceparent from an active span and can restore it into a remote context', () => {
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+    const tracer = trace.getTracer('test-tracer');
+
+    let captured: ReturnType<typeof captureTraceContext>;
+
+    tracer.startActiveSpan('test-span', { kind: SpanKind.INTERNAL }, (span) => {
+      captured = captureTraceContext();
+      span.end();
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured?.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+
+    const restored = restoreTraceContext(captured);
+    const remoteSpanContext = trace.getSpanContext(restored);
+
+    expect(remoteSpanContext?.traceId).toBe(
+      captured?.traceparent?.split('-')[1],
+    );
+  });
+});

--- a/backend/src/lib/__tests__/transaction.test.ts
+++ b/backend/src/lib/__tests__/transaction.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Covers commit/rollback behavior of withTransaction in lib/transaction.ts.
+ */
+
+const mockTransaction = jest.fn();
+
+jest.mock('../prisma', () => ({
+  prisma: {
+    $transaction: (...args: any[]) => mockTransaction(...args),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { withTransaction } = require('../transaction');
+
+describe('withTransaction', () => {
+  beforeEach(() => {
+    mockTransaction.mockReset();
+  });
+
+  it('commits and returns the callback result on success', async () => {
+    const tx = { organization: { create: jest.fn() } };
+    mockTransaction.mockImplementation(async (cb: any) => cb(tx));
+
+    const result = await withTransaction(async (t) => {
+      return { ok: true, tx: t };
+    });
+
+    expect(result).toEqual({ ok: true, tx });
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors thrown inside the callback so the transaction rolls back', async () => {
+    const failure = new Error('boom');
+    mockTransaction.mockImplementation(async (cb: any) => cb({}));
+
+    await expect(
+      withTransaction(async () => {
+        throw failure;
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  it('passes through transaction options', async () => {
+    mockTransaction.mockImplementation(async (cb: any) => cb({}));
+    const options = { timeout: 5000 };
+
+    await withTransaction(async () => 'done', options);
+
+    expect(mockTransaction).toHaveBeenCalledWith(expect.any(Function), options);
+  });
+});

--- a/backend/src/models/__tests__/AuditLog.test.ts
+++ b/backend/src/models/__tests__/AuditLog.test.ts
@@ -1,0 +1,63 @@
+import { AuditLogStore } from '../AuditLog';
+
+describe('AuditLogStore', () => {
+  it('append adds an entry with a generated id and createdAt timestamp', () => {
+    const log = AuditLogStore.append({
+      actorId: 'actor-1',
+      action: 'auth:login',
+    });
+
+    expect(log.id).toBeDefined();
+    expect(log.actorId).toBe('actor-1');
+    expect(log.action).toBe('auth:login');
+    expect(log.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('append assigns increasing ids across calls', () => {
+    const first = AuditLogStore.append({ actorId: 'actor-2', action: 'post:create' });
+    const second = AuditLogStore.append({ actorId: 'actor-2', action: 'post:update' });
+
+    expect(Number(second.id)).toBeGreaterThan(Number(first.id));
+  });
+
+  it('forActor returns only entries for the given actor, most recent first', () => {
+    AuditLogStore.append({ actorId: 'actor-3', action: 'post:create' });
+    AuditLogStore.append({ actorId: 'actor-3', action: 'post:update' });
+    AuditLogStore.append({ actorId: 'other-actor', action: 'post:delete' });
+
+    const entries = AuditLogStore.forActor('actor-3');
+
+    expect(entries.every((e) => e.actorId === 'actor-3')).toBe(true);
+    expect(entries[0].action).toBe('post:update');
+  });
+
+  it('forResource filters by resourceType and resourceId', () => {
+    AuditLogStore.append({
+      actorId: 'actor-4',
+      action: 'post:update',
+      resourceType: 'post',
+      resourceId: 'post-123',
+    });
+    AuditLogStore.append({
+      actorId: 'actor-4',
+      action: 'post:update',
+      resourceType: 'post',
+      resourceId: 'post-999',
+    });
+
+    const entries = AuditLogStore.forResource('post', 'post-123');
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].resourceId).toBe('post-123');
+  });
+
+  it('recent respects the limit parameter', () => {
+    for (let i = 0; i < 5; i++) {
+      AuditLogStore.append({ actorId: 'actor-5', action: 'ai:generate' });
+    }
+
+    const entries = AuditLogStore.recent(2);
+
+    expect(entries).toHaveLength(2);
+  });
+});

--- a/backend/src/models/__tests__/Role.test.ts
+++ b/backend/src/models/__tests__/Role.test.ts
@@ -1,0 +1,65 @@
+import { RoleStore, ROLES } from '../Role';
+
+describe('RoleStore', () => {
+  it('assign sets the role for a user', () => {
+    RoleStore.assign('user-1', 'editor');
+
+    expect(RoleStore.getRoleName('user-1')).toBe('editor');
+  });
+
+  it('getRole returns the full role definition for an assigned user', () => {
+    RoleStore.assign('user-2', 'admin');
+
+    expect(RoleStore.getRole('user-2')).toEqual(ROLES.admin);
+  });
+
+  it('getRole returns undefined for a user with no assignment', () => {
+    expect(RoleStore.getRole('never-assigned-user')).toBeUndefined();
+  });
+
+  it('hasPermission returns true when the assigned role includes the permission', () => {
+    RoleStore.assign('user-3', 'editor');
+
+    expect(RoleStore.hasPermission('user-3', 'posts:create')).toBe(true);
+  });
+
+  it('hasPermission returns false when the assigned role lacks the permission', () => {
+    RoleStore.assign('user-4', 'viewer');
+
+    expect(RoleStore.hasPermission('user-4', 'roles:manage')).toBe(false);
+  });
+
+  it('hasPermission returns false for a user with no role assigned', () => {
+    expect(RoleStore.hasPermission('unknown-user', 'posts:read')).toBe(false);
+  });
+
+  it('re-assigning a user updates their role', () => {
+    RoleStore.assign('user-5', 'viewer');
+    RoleStore.assign('user-5', 'admin');
+
+    expect(RoleStore.getRoleName('user-5')).toBe('admin');
+  });
+
+  it('persists role assignments across independent references to RoleStore', () => {
+    // Regression test: role assignments must be visible through any reference
+    // to RoleStore, not just the instance that performed the assignment —
+    // guards against a per-instance (rather than module-level) store.
+    RoleStore.assign('user-6', 'editor');
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { RoleStore: OtherReference } = require('../Role');
+
+    expect(OtherReference.getRoleName('user-6')).toBe('editor');
+    expect(OtherReference.hasPermission('user-6', 'posts:update')).toBe(true);
+  });
+
+  it('listAll reflects all assigned users', () => {
+    RoleStore.assign('user-7', 'viewer');
+
+    const all = RoleStore.listAll();
+
+    expect(all).toEqual(
+      expect.arrayContaining([{ userId: 'user-7', role: 'viewer' }]),
+    );
+  });
+});

--- a/backend/src/schemas/__tests__/tts.test.ts
+++ b/backend/src/schemas/__tests__/tts.test.ts
@@ -1,0 +1,87 @@
+import { createTTSJobSchema } from '../tts';
+
+describe('createTTSJobSchema', () => {
+  it('accepts a valid minimal payload', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [{ text: 'Hello world' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid full payload', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [
+        {
+          text: 'Hello world',
+          voiceId: 'voice-1',
+          language: 'en',
+          speed: 1.2,
+          stability: 0.5,
+          similarityBoost: 0.8,
+        },
+      ],
+      provider: 'elevenlabs',
+      outputFormat: 'mp3',
+      videoPath: '/tmp/video.mp4',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a payload with no segments', () => {
+    const result = createTTSJobSchema.safeParse({ segments: [] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a payload with more than 50 segments', () => {
+    const segments = Array.from({ length: 51 }, () => ({ text: 'hi' }));
+
+    const result = createTTSJobSchema.safeParse({ segments });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a segment with empty text', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [{ text: '' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a segment with text exceeding the max length', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [{ text: 'a'.repeat(5001) }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an out-of-range speed value', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [{ text: 'hi', speed: 3 }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid provider value', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [{ text: 'hi' }],
+      provider: 'not-a-real-provider',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid outputFormat value', () => {
+    const result = createTTSJobSchema.safeParse({
+      segments: [{ text: 'hi' }],
+      outputFormat: 'flac',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/utils/__tests__/initDirectories.test.ts
+++ b/backend/src/utils/__tests__/initDirectories.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Covers initDirectories' already-exists and needs-creation cases, plus
+ * error propagation when directory creation fails.
+ */
+
+jest.mock('fs/promises', () => ({
+  mkdir: jest.fn(),
+}));
+
+jest.mock('../../config/video.config', () => ({
+  videoConfig: {
+    upload: {
+      uploadDir: 'uploads/videos',
+      transcodedDir: 'uploads/transcoded',
+    },
+  },
+}));
+
+import fs from 'fs/promises';
+import { initDirectories } from '../initDirectories';
+
+describe('initDirectories', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates all required directories with recursive:true (needs-creation case)', async () => {
+    (fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+
+    await initDirectories();
+
+    expect(fs.mkdir).toHaveBeenCalledTimes(3);
+    for (const call of (fs.mkdir as jest.Mock).mock.calls) {
+      expect(call[1]).toEqual({ recursive: true });
+    }
+  });
+
+  it('succeeds without error when directories already exist (mkdir recursive is idempotent)', async () => {
+    (fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(initDirectories()).resolves.toBeUndefined();
+  });
+
+  it('propagates an error when a directory fails to be created', async () => {
+    const failure = new Error('EACCES: permission denied');
+    (fs.mkdir as jest.Mock).mockRejectedValueOnce(failure);
+
+    await expect(initDirectories()).rejects.toThrow('EACCES: permission denied');
+  });
+});


### PR DESCRIPTION
Closes #1305
Closes #1306
Closes #1307
Closes #1308


Commit 1 — 40c371b: Core data-access layer (Issue 1)
- backend/src/lib/__tests__/prisma.test.ts — mocks @prisma/client/@prisma/adapter-pg to capture the $extends query extension, then tests the org-scoping (injects organizationId into where/data, strips __orgId) and soft-delete (rewrites delete→update, deleteMany→updateMany, filters deletedAt: null on reads) logic directly.
- backend/src/lib/__tests__/readReplica.test.ts — covers applyReadWriteSplitting's no-op/warn behavior and that replicaClient builds from DATABASE_REPLICA_URL or falls back to DATABASE_URL.
- backend/src/lib/__tests__/transaction.test.ts — mocks prisma.$transaction to test withTransaction commit (returns callback result), rollback (propagates thrown errors), and options pass-through.

Commit 2 — 50723e9: Remaining lib/ modules (Issue 2)
- errors.test.ts — status code/shape for every custom error class (BadRequestError through ExternalServiceError) plus isAppError/isOperationalError guards.
- paginatedQuery.test.ts — cursor pagination boundaries: empty first page, short last page, and a full middle page verifying the cursor carries the last-seen id.
- eventBus.test.ts, logger.test.ts, meilisearch.test.ts, redis.test.ts, traceContext.test.ts — basic behavior coverage (event scoping/wildcard emit, log-level methods, client singleton construction from config, trace context capture/restore).

Commit 3 — 9aef3f5: Role and AuditLog models (Issue 3)
- Role.test.ts — assign/getRole/hasPermission, plus the regression test the issue specifically asked for: asserting a role assigned via one RoleStore reference is visible through an independently-required reference (guards against the in-memory-Map bug).
- AuditLog.test.ts — append, forActor, forResource, recent.

Commit 4 — 7fb1f21: initDirectories and tts schema (Issue 4)
- initDirectories.test.ts — mocks fs/promises to cover the already-exists/needs-creation cases and error propagation.
- tts.test.ts — valid/invalid createTTSJobSchema payloads (segment limits, text length, speed range, enum values).