### PR TITLE
Test/soroban hook config coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
           fi
           echo "✓ Production overlay uses correct cert-manager issuer"
 
+      - name: Reject dev namespace references in non-dev overlays
+        run: |
+          if grep -n "socialflow-dev" /tmp/prod-manifests.yaml; then
+            echo "ERROR: prod overlay's rendered manifests reference the socialflow-dev namespace"
+            exit 1
+          fi
+          echo "✓ No non-dev overlay references the socialflow-dev namespace"
+
   security:
     name: Security Vulnerability Scan
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,11 +12,13 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-# Compile TypeScript — skipLibCheck tolerates pre-existing third-party type
-# issues; noEmitOnError=false ensures output is produced despite them
+# Compile TypeScript — type errors must fail the build. tsc --noEmit runs
+# first as a strict, failing typecheck gate; the real emit only runs (and is
+# trusted) once that gate passes.
 COPY tsconfig.json ./
 COPY src ./src
-RUN node_modules/.bin/tsc --skipLibCheck 2>/dev/null || true && \
+RUN node_modules/.bin/tsc --noEmit --skipLibCheck
+RUN node_modules/.bin/tsc --skipLibCheck && \
     test -d dist && echo "Build succeeded" || (echo "Build failed: dist/ not created" && exit 1)
 
 # ── Stage 2: production image ─────────────────────────────────────────────────

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -11,9 +11,13 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
+# Compile TypeScript — type errors must fail the build. tsc --noEmit runs
+# first as a strict, failing typecheck gate; the real emit only runs (and is
+# trusted) once that gate passes.
 COPY tsconfig.json ./
 COPY src ./src
-RUN node_modules/.bin/tsc --skipLibCheck 2>/dev/null || true && \
+RUN node_modules/.bin/tsc --noEmit --skipLibCheck
+RUN node_modules/.bin/tsc --skipLibCheck && \
     test -d dist && echo "Build succeeded" || (echo "Build failed: dist/ not created" && exit 1)
 
 # ── Stage 2: production image ─────────────────────────────────────────────────

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -62,6 +62,21 @@ patches:
         template:
           spec:
             terminationGracePeriodSeconds: 90
+  # ClusterSecretStore's serviceAccountRef is not namespaced by kustomize's
+  # top-level `namespace:` field (it only rewrites metadata.namespace), so it
+  # must be patched explicitly or prod would auth as the dev service account.
+  - patch: |-
+      apiVersion: external-secrets.io/v1beta1
+      kind: ClusterSecretStore
+      metadata:
+        name: aws-secrets-manager
+      spec:
+        provider:
+          aws:
+            auth:
+              jwt:
+                serviceAccountRef:
+                  namespace: socialflow-prod
   # Prod hostname + TLS
   - patch: |-
       apiVersion: networking.k8s.io/v1

--- a/src/blockchain/config/networks.test.ts
+++ b/src/blockchain/config/networks.test.ts
@@ -1,0 +1,39 @@
+import { NETWORKS, DEFAULT_NETWORK, NetworkConfig } from './networks';
+
+describe('networks config', () => {
+  it('defines TESTNET, MAINNET, and FUTURENET', () => {
+    expect(Object.keys(NETWORKS).sort()).toEqual(['FUTURENET', 'MAINNET', 'TESTNET']);
+  });
+
+  it('each network config has the required fields', () => {
+    Object.values(NETWORKS).forEach((config: NetworkConfig) => {
+      expect(typeof config.horizonUrl).toBe('string');
+      expect(config.horizonUrl.startsWith('https://')).toBe(true);
+      expect(typeof config.networkPassphrase).toBe('string');
+      expect(config.networkPassphrase.length).toBeGreaterThan(0);
+      expect(typeof config.name).toBe('string');
+    });
+  });
+
+  it('TESTNET points at the Stellar testnet horizon', () => {
+    expect(NETWORKS.TESTNET.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(NETWORKS.TESTNET.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    expect(NETWORKS.TESTNET.name).toBe('Testnet');
+  });
+
+  it('MAINNET points at the Stellar public network', () => {
+    expect(NETWORKS.MAINNET.horizonUrl).toBe('https://horizon.stellar.org');
+    expect(NETWORKS.MAINNET.networkPassphrase).toBe('Public Global Stellar Network ; September 2015');
+    expect(NETWORKS.MAINNET.name).toBe('Mainnet');
+  });
+
+  it('FUTURENET points at the Stellar futurenet', () => {
+    expect(NETWORKS.FUTURENET.horizonUrl).toBe('https://horizon-futurenet.stellar.org');
+    expect(NETWORKS.FUTURENET.networkPassphrase).toBe('Test SDF Future Network ; October 2022');
+    expect(NETWORKS.FUTURENET.name).toBe('Futurenet');
+  });
+
+  it('DEFAULT_NETWORK is TESTNET', () => {
+    expect(DEFAULT_NETWORK).toBe(NETWORKS.TESTNET);
+  });
+});

--- a/src/blockchain/config/soroban.config.test.ts
+++ b/src/blockchain/config/soroban.config.test.ts
@@ -1,0 +1,39 @@
+import { SOROBAN_NETWORKS, DEFAULT_TIMEOUT, STELLAR_POLL_TIMEOUT_MS, SorobanConfig } from './soroban.config';
+
+describe('soroban.config', () => {
+  it('defines TESTNET, MAINNET, and FUTURENET RPC configs', () => {
+    expect(Object.keys(SOROBAN_NETWORKS).sort()).toEqual(['FUTURENET', 'MAINNET', 'TESTNET']);
+  });
+
+  it('each network config has an rpcUrl and networkPassphrase', () => {
+    Object.values(SOROBAN_NETWORKS).forEach((config: SorobanConfig) => {
+      expect(typeof config.rpcUrl).toBe('string');
+      expect(config.rpcUrl.startsWith('https://')).toBe(true);
+      expect(typeof config.networkPassphrase).toBe('string');
+      expect(config.networkPassphrase.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('TESTNET uses the Soroban testnet RPC endpoint', () => {
+    expect(SOROBAN_NETWORKS.TESTNET.rpcUrl).toBe('https://soroban-testnet.stellar.org');
+    expect(SOROBAN_NETWORKS.TESTNET.networkPassphrase).toBe('Test SDF Network ; September 2015');
+  });
+
+  it('MAINNET uses the Soroban mainnet RPC endpoint', () => {
+    expect(SOROBAN_NETWORKS.MAINNET.rpcUrl).toBe('https://soroban-mainnet.stellar.org');
+    expect(SOROBAN_NETWORKS.MAINNET.networkPassphrase).toBe('Public Global Stellar Network ; September 2015');
+  });
+
+  it('FUTURENET uses the Soroban futurenet RPC endpoint', () => {
+    expect(SOROBAN_NETWORKS.FUTURENET.rpcUrl).toBe('https://soroban-futurenet.stellar.org');
+    expect(SOROBAN_NETWORKS.FUTURENET.networkPassphrase).toBe('Test SDF Future Network ; October 2022');
+  });
+
+  it('DEFAULT_TIMEOUT is 30 seconds', () => {
+    expect(DEFAULT_TIMEOUT).toBe(30);
+  });
+
+  it('STELLAR_POLL_TIMEOUT_MS defaults to 120000ms when no override is present', () => {
+    expect(STELLAR_POLL_TIMEOUT_MS).toBe(120000);
+  });
+});

--- a/src/blockchain/hooks/useSorobanContract.test.ts
+++ b/src/blockchain/hooks/useSorobanContract.test.ts
@@ -1,0 +1,220 @@
+import { renderHook, act } from '@testing-library/react';
+
+const mockInvoke = jest.fn();
+const mockSimulate = jest.fn();
+const mockGetContractEvents = jest.fn();
+
+jest.mock('../services/SmartContractService', () => ({
+  SmartContractService: jest.fn().mockImplementation(() => ({
+    invoke: mockInvoke,
+    simulate: mockSimulate,
+    getContractEvents: mockGetContractEvents,
+  })),
+}));
+
+const mockAutoConnect = jest.fn();
+const mockDisconnect = jest.fn();
+const mockIsConnected = jest.fn();
+const mockSignTransaction = jest.fn();
+let disconnectCallback: (() => void) | null = null;
+
+jest.mock('../services/WalletService', () => ({
+  walletService: {
+    autoConnect: (...args: any[]) => mockAutoConnect(...args),
+    disconnect: (...args: any[]) => mockDisconnect(...args),
+    isConnected: (...args: any[]) => mockIsConnected(...args),
+    signTransaction: (...args: any[]) => mockSignTransaction(...args),
+    onDisconnect: (listener: () => void) => {
+      disconnectCallback = listener;
+      return jest.fn();
+    },
+  },
+}));
+
+import { useSorobanContract } from './useSorobanContract';
+import { ContractCallType } from '../types/soroban';
+
+const WALLET = { publicKey: 'GABC123', name: 'Freighter', isConnected: true };
+
+afterEach(() => {
+  jest.clearAllMocks();
+  disconnectCallback = null;
+});
+
+describe('useSorobanContract', () => {
+  it('initializes with no wallet connected', () => {
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    expect(result.current.wallet).toBeNull();
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('connects a wallet successfully', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.wallet).toEqual(WALLET);
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets an error when no wallet is available to connect', async () => {
+    mockAutoConnect.mockResolvedValue(null);
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.wallet).toBeNull();
+    expect(result.current.error).toMatch(/No wallet available/);
+  });
+
+  it('disconnects the wallet', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    act(() => {
+      result.current.disconnectWallet();
+    });
+
+    expect(mockDisconnect).toHaveBeenCalled();
+    expect(result.current.wallet).toBeNull();
+  });
+
+  it('clears the wallet when the wallet service reports a disconnect event', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    act(() => {
+      disconnectCallback?.();
+    });
+
+    expect(result.current.wallet).toBeNull();
+    expect(result.current.error).toMatch(/Wallet disconnected/);
+  });
+
+  it('throws when calling readContract without a connected wallet', async () => {
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await expect(result.current.readContract('getBalance')).rejects.toThrow();
+  });
+
+  it('reads from a contract when wallet is connected', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    mockInvoke.mockResolvedValue({ success: true, result: '42' });
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    let value: any;
+    await act(async () => {
+      value = await result.current.readContract('getBalance');
+    });
+
+    expect(value).toBe('42');
+    expect(mockInvoke).toHaveBeenCalledWith(
+      { contractId: 'CONTRACT_ID', method: 'getBalance', args: [] },
+      WALLET.publicKey,
+      ContractCallType.READ_ONLY
+    );
+  });
+
+  it('propagates an error when the read call fails', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    mockInvoke.mockResolvedValue({ success: false, error: 'boom' });
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    await expect(result.current.readContract('getBalance')).rejects.toThrow('boom');
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('writes to a contract when wallet is connected', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    mockInvoke.mockResolvedValue({ success: true, result: 'ok' });
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    let value: any;
+    await act(async () => {
+      value = await result.current.writeContract('transfer');
+    });
+
+    expect(value).toEqual({ success: true, result: 'ok' });
+    expect(mockInvoke).toHaveBeenCalledWith(
+      { contractId: 'CONTRACT_ID', method: 'transfer', args: [] },
+      WALLET.publicKey,
+      ContractCallType.STATE_CHANGING,
+      expect.any(Function)
+    );
+  });
+
+  it('surfaces a user-friendly error when a write runs out of gas', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    mockInvoke.mockResolvedValue({ success: false, error: 'gas', errorType: 'OUT_OF_GAS' });
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    await expect(result.current.writeContract('transfer')).rejects.toThrow(/out of gas/i);
+  });
+
+  it('simulates a contract call', async () => {
+    mockAutoConnect.mockResolvedValue(WALLET);
+    mockSimulate.mockResolvedValue({ success: true, result: 'sim' });
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    let value: any;
+    await act(async () => {
+      value = await result.current.simulateContract('preview');
+    });
+
+    expect(value).toEqual({ success: true, result: 'sim' });
+    expect(mockSimulate).toHaveBeenCalledWith(
+      { contractId: 'CONTRACT_ID', method: 'preview', args: [] },
+      WALLET.publicKey
+    );
+  });
+
+  it('fetches contract events without requiring a wallet', async () => {
+    mockGetContractEvents.mockResolvedValue([{ id: 'evt1' }]);
+    const { result } = renderHook(() => useSorobanContract('CONTRACT_ID'));
+
+    let events: any;
+    await act(async () => {
+      events = await result.current.getEvents(10, 20);
+    });
+
+    expect(events).toEqual([{ id: 'evt1' }]);
+    expect(mockGetContractEvents).toHaveBeenCalledWith('CONTRACT_ID', 10, 20);
+  });
+});

--- a/src/utils/AppError.test.ts
+++ b/src/utils/AppError.test.ts
@@ -1,0 +1,63 @@
+import { AppError } from './AppError';
+import { ErrorCode, ErrorStatusMap } from '../constants/ErrorCodes';
+
+describe('AppError', () => {
+  it('constructs with a code and a custom message', () => {
+    const error = new AppError(ErrorCode.ERR_WALLET_NOT_CONNECTED, 'Please connect your wallet');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AppError);
+    expect(error.name).toBe('AppError');
+    expect(error.code).toBe(ErrorCode.ERR_WALLET_NOT_CONNECTED);
+    expect(error.message).toBe('Please connect your wallet');
+    expect(error.statusCode).toBe(ErrorStatusMap[ErrorCode.ERR_WALLET_NOT_CONNECTED]);
+  });
+
+  it('falls back to the error code as the message when none is provided', () => {
+    const error = new AppError(ErrorCode.ERR_TRANSACTION_FAILED);
+
+    expect(error.message).toBe(ErrorCode.ERR_TRANSACTION_FAILED);
+  });
+
+  it('maps every ErrorCode to its configured status code', () => {
+    Object.values(ErrorCode).forEach((code) => {
+      const error = new AppError(code as ErrorCode);
+      expect(error.statusCode).toBe(ErrorStatusMap[code as ErrorCode]);
+    });
+  });
+
+  it('defaults to a 500 status code for an unmapped code', () => {
+    const error = new AppError('ERR_UNKNOWN' as ErrorCode);
+    expect(error.statusCode).toBe(500);
+  });
+
+  it('serializes to a JSON-friendly response via toResponse()', () => {
+    const error = new AppError(ErrorCode.ERR_NOT_FOUND, 'Resource missing');
+
+    expect(error.toResponse()).toEqual({
+      success: false,
+      error: {
+        code: ErrorCode.ERR_NOT_FOUND,
+        message: 'Resource missing',
+        statusCode: ErrorStatusMap[ErrorCode.ERR_NOT_FOUND],
+      },
+    });
+  });
+
+  describe('isAppError', () => {
+    it('returns true for an AppError instance', () => {
+      expect(AppError.isAppError(new AppError(ErrorCode.ERR_BAD_REQUEST))).toBe(true);
+    });
+
+    it('returns false for a plain Error', () => {
+      expect(AppError.isAppError(new Error('oops'))).toBe(false);
+    });
+
+    it('returns false for non-error values', () => {
+      expect(AppError.isAppError(null)).toBe(false);
+      expect(AppError.isAppError(undefined)).toBe(false);
+      expect(AppError.isAppError('error string')).toBe(false);
+      expect(AppError.isAppError({ code: ErrorCode.ERR_BAD_REQUEST })).toBe(false);
+    });
+  });
+});

--- a/src/utils/hashtagGenerator.test.ts
+++ b/src/utils/hashtagGenerator.test.ts
@@ -1,0 +1,105 @@
+import {
+  generateHashtags,
+  extractHashtagKeywords,
+  normalizeHashtagPlatform,
+  DEFAULT_PLATFORM_TRENDS,
+} from './hashtagGenerator';
+
+describe('normalizeHashtagPlatform', () => {
+  it('defaults to generic when no platform is given', () => {
+    expect(normalizeHashtagPlatform(undefined)).toBe('generic');
+  });
+
+  it('maps twitter to x', () => {
+    expect(normalizeHashtagPlatform('twitter')).toBe('x');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(normalizeHashtagPlatform('  Instagram ')).toBe('instagram');
+  });
+
+  it('falls back to generic for unsupported platforms', () => {
+    expect(normalizeHashtagPlatform('myspace')).toBe('generic');
+  });
+});
+
+describe('extractHashtagKeywords', () => {
+  it('lowercases, strips punctuation, and removes stop words', () => {
+    const keywords = extractHashtagKeywords('The Creator Economy is Booming, and it is Fun!');
+    expect(keywords).toEqual(['creator', 'economy', 'booming', 'and', 'fun']);
+  });
+
+  it('filters out words shorter than 3 characters', () => {
+    const keywords = extractHashtagKeywords('go to a big ai fair');
+    expect(keywords).not.toContain('go');
+    expect(keywords).not.toContain('ai');
+  });
+});
+
+describe('generateHashtags', () => {
+  it('generates hashtags for the default generic platform', () => {
+    const result = generateHashtags({ text: 'Growing our audience with a new content strategy' });
+
+    expect(result.platform).toBe('generic');
+    expect(result.hashtags.length).toBeGreaterThan(0);
+    result.hashtags.forEach((tag) => expect(tag.startsWith('#')).toBe(true));
+  });
+
+  it('respects the maxTags option and clamps to the 1-20 range', () => {
+    const result = generateHashtags({ text: 'social media marketing content creator growth strategy', maxTags: 3 });
+    expect(result.hashtags.length).toBeLessThanOrEqual(3);
+
+    const clampedHigh = generateHashtags({ text: 'content', maxTags: 50 });
+    expect(clampedHigh.hashtags.length).toBeLessThanOrEqual(20);
+
+    const clampedLow = generateHashtags({ text: 'content', maxTags: 0 });
+    expect(clampedLow.hashtags.length).toBeLessThanOrEqual(1);
+  });
+
+  it('appends the platform hashtag for non-generic platforms', () => {
+    const result = generateHashtags({ text: 'launching a new product today', platform: 'tiktok' });
+    expect(result.platform).toBe('tiktok');
+    expect(result.hashtags.some((tag) => tag.toLowerCase() === '#tiktok')).toBe(true);
+  });
+
+  it('does not append a platform hashtag for the generic platform', () => {
+    const result = generateHashtags({ text: 'launching a new product today', platform: 'generic' });
+    expect(result.hashtags.some((tag) => tag.toLowerCase() === '#generic')).toBe(false);
+  });
+
+  it('surfaces matched trend tags when keywords align with trend signals', () => {
+    const result = generateHashtags({
+      text: 'our brand campaign for content creators is live',
+      platform: 'instagram',
+    });
+
+    expect(result.trendMatches.length).toBeGreaterThan(0);
+    expect(result.trendMatches).toContain('ContentCreator');
+  });
+
+  it('uses custom trend signals when provided instead of the platform defaults', () => {
+    const customSignal = { tag: 'CustomTrend', weight: 5, keywords: ['widget'] };
+    const result = generateHashtags({
+      text: 'our new widget launch',
+      platform: 'generic',
+      trendSignals: [customSignal],
+    });
+
+    expect(result.trendMatches).toContain('CustomTrend');
+    expect(result.hashtags).toContain('#CustomTrend');
+  });
+
+  it('returns unique, deduplicated keywords capped at 12', () => {
+    const longText = Array.from({ length: 20 }, (_, i) => `keyword${i}`).join(' ');
+    const result = generateHashtags({ text: longText });
+    expect(result.keywords.length).toBeLessThanOrEqual(12);
+    expect(new Set(result.keywords).size).toBe(result.keywords.length);
+  });
+
+  it('covers every default platform trend table', () => {
+    Object.keys(DEFAULT_PLATFORM_TRENDS).forEach((platform) => {
+      const result = generateHashtags({ text: 'general update about our work', platform });
+      expect(result.platform).toBe(platform);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1309 
Closes #1310 
Closes #1311
Closes #1312 

What changed

1. Test coverage for useSorobanContract + blockchain config (src/blockchain/**)

- Added src/blockchain/hooks/useSorobanContract.test.ts, mocking SmartContractService and WalletService to cover: initial disconnected state, wallet connect/disconnect (success + no-wallet-available error), the wallet-service disconnect event handler, readContract/writeContract/simulateContract happy paths and failure paths (including the OUT_OF_GAS friendly-error branch), and getEvents (which doesn't require a wallet).
- Added src/blockchain/config/networks.test.ts covering the NETWORKS map (TESTNET/MAINNET/FUTURENET shape and values) and DEFAULT_NETWORK.
- Added src/blockchain/config/soroban.config.test.ts covering SOROBAN_NETWORKS, DEFAULT_TIMEOUT, and STELLAR_POLL_TIMEOUT_MS.
- Brings these three files up to the same coverage standard as every file already under src/blockchain/services/tests/.

2. Test coverage for AppError and hashtagGenerator (src/utils/**)

- Added src/utils/AppError.test.ts covering: construction with and without a custom message, the full ErrorCode → ErrorStatusMap mapping (looped over every enum value), the unmapped-code fallback to 500, toResponse() JSON serialization, and the isAppError() type guard (true for AppError instances, false for plain Errors and non-error values).
- Added src/utils/hashtagGenerator.test.ts covering normalizeHashtagPlatform (default/alias/case-insensitivity/fallback), extractHashtagKeywords (stop-word and short-word filtering), and generateHashtags (default generation, maxTags clamping to 1–20, platform-hashtag appending, trend-signal matching, custom trend signals, deduplicated/capped keyword output, and a sweep over every entry in DEFAULT_PLATFORM_TRENDS).

3. Backend Dockerfiles no longer mask TypeScript compiler errors

- backend/Dockerfile and backend/Dockerfile.worker previously ran tsc --skipLibCheck 2>/dev/null || true, discarding all diagnostic output and forcing a zero exit code, then only checked whether a dist/ directory happened to exist. A PR introducing a real type error would still build and ship a production image.
- Both Dockerfiles now run tsc --noEmit --skipLibCheck first as a dedicated, failing typecheck gate with no output redirection and no swallowed exit code. Only if that gate passes does the real compile/emit step run.

4. ClusterSecretStore prod overlay no longer points at the dev service account

- k8s/base/cluster-secret-store.yaml hardcodes spec.provider.aws.auth.jwt.serviceAccountRef.namespace: socialflow-dev. Kustomize's top-level namespace: field in each overlay only rewrites a resource's own metadata.namespace — it never touched this nested field, so the prod overlay would have silently authenticated to AWS Secrets Manager as the dev service account, breaking ExternalSecret-based secret sync in production.
- Added an explicit Kustomize patch in k8s/overlays/prod/kustomization.yaml rewriting serviceAccountRef.namespace to socialflow-prod.
- Added a new step to the existing k8s-lint job in .github/workflows/ci.yml that fails if the rendered prod manifests still reference socialflow-dev.

Test plan

- [x] npm test -- useSorobanContract networks soroban.config — new hook/config tests pass
- [x] npm test -- AppError hashtagGenerator — new util tests pass
- [x] npm test — no regressions
- [x] Introduce a temporary TS type error, confirm docker build -f backend/Dockild -f backend/Dockerfile.worker backend/ both fail; revert and confirm bothsucceed
- [x] kustomize build k8s/overlays/prod — confirm the rendered ClusterSecretSto
- [x] k8s-lint CI job passes