### PR TITLE
Fix/billing url allowlist terraform cycle state exposure dead code

### DIFF
--- a/backend/src/__tests__/billingCheckoutUrlAllowlist.test.ts
+++ b/backend/src/__tests__/billingCheckoutUrlAllowlist.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Billing checkout/portal redirect URL allow-list tests.
+ *
+ * Stripe's success_url/cancel_url/return_url are handed straight to Stripe
+ * and used to redirect the payer's browser after checkout. If they aren't
+ * restricted to the app's own origins, an attacker can point them at an
+ * external phishing domain (open redirect after a real payment completes).
+ */
+import request from 'supertest';
+import express, { Response, NextFunction } from 'express';
+import billingRouter from '../routes/billing';
+
+jest.mock('../middleware/authenticate', () => ({
+  authenticate: (req: any, _res: Response, next: NextFunction) => {
+    req.user = { id: 'user-1' };
+    next();
+  },
+}));
+
+jest.mock('../models/User', () => ({
+  UserStore: { findById: jest.fn().mockResolvedValue({ id: 'user-1', email: 'user@example.com' }) },
+}));
+
+const mockCreateCheckoutSession = jest.fn();
+const mockCreatePortalSession = jest.fn();
+
+jest.mock('../services/BillingService', () => ({
+  billingService: {
+    createCheckoutSession: (...args: unknown[]) => mockCreateCheckoutSession(...args),
+    createPortalSession: (...args: unknown[]) => mockCreatePortalSession(...args),
+  },
+}));
+
+jest.mock('../config/cors', () => ({
+  allowedOrigins: ['https://socialflow.app', 'https://www.socialflow.app'],
+}));
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/billing', billingRouter);
+  return app;
+}
+
+describe('Billing redirect URL allow-list', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects /billing/checkout with an external successUrl domain', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/billing/checkout').send({
+      priceId: 'price_123',
+      successUrl: 'https://evil-phishing-site.example/success',
+      cancelUrl: 'https://socialflow.app/cancel',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects /billing/checkout with an external cancelUrl domain', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/billing/checkout').send({
+      priceId: 'price_123',
+      successUrl: 'https://socialflow.app/success',
+      cancelUrl: 'https://evil-phishing-site.example/cancel',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it('allows /billing/checkout when both URLs are on an allowed origin', async () => {
+    mockCreateCheckoutSession.mockResolvedValue('https://checkout.stripe.com/session/abc');
+    const app = buildApp();
+    const res = await request(app).post('/billing/checkout').send({
+      priceId: 'price_123',
+      successUrl: 'https://socialflow.app/success',
+      cancelUrl: 'https://www.socialflow.app/cancel',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+      'user-1',
+      'price_123',
+      'https://socialflow.app/success',
+      'https://www.socialflow.app/cancel',
+    );
+  });
+
+  it('rejects /billing/portal with an external returnUrl domain', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/billing/portal').send({
+      returnUrl: 'https://evil-phishing-site.example/return',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockCreatePortalSession).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -11,7 +11,16 @@ const envSchema = z.object({
   BACKEND_PORT: z.coerce.number().int().positive().default(3001),
 
   // ── Database ──────────────────────────────────────────────────────────────
-  DATABASE_URL: z.string().url('DATABASE_URL must be a valid URL'),
+  // DATABASE_URL can be provided directly (local/test) or assembled at
+  // runtime from discrete DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD values
+  // (production — see infra), so the DB password is never stored as part of
+  // one combined Terraform-tracked SSM parameter.
+  DATABASE_URL: z.string().url('DATABASE_URL must be a valid URL').optional(),
+  DB_HOST: z.string().optional(),
+  DB_PORT: z.coerce.number().int().positive().default(5432),
+  DB_NAME: z.string().optional(),
+  DB_USER: z.string().optional(),
+  DB_PASSWORD: z.string().optional(),
   DATABASE_REPLICA_URL: z.string().url('DATABASE_REPLICA_URL must be a valid URL').optional(),
   // Connection pool — defaults tuned per environment in src/lib/prisma.ts
   // Override here to hard-pin values regardless of NODE_ENV.
@@ -179,7 +188,31 @@ const envSchema = z.object({
         'ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED cannot be "false" in production — disabling TLS verification exposes Elasticsearch traffic to MITM attacks',
     });
   }
+
+  if (!data.DATABASE_URL && !(data.DB_HOST && data.DB_NAME && data.DB_USER && data.DB_PASSWORD)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['DATABASE_URL'],
+      message:
+        'Either DATABASE_URL or the full set of DB_HOST/DB_NAME/DB_USER/DB_PASSWORD must be set',
+    });
+  }
 });
+
+/**
+ * Builds the Postgres connection string at runtime. Prefers an explicit
+ * DATABASE_URL (local/test); otherwise assembles it from discrete
+ * DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD values, which is how
+ * production is configured — see terraform/modules/ecs, which injects these
+ * as separate SSM parameters instead of one pre-assembled connection string
+ * so the password is never stored as part of a single combined attribute.
+ */
+function buildDatabaseUrl(data: Env): string {
+  if (data.DATABASE_URL) return data.DATABASE_URL;
+  const user = encodeURIComponent(data.DB_USER!);
+  const password = encodeURIComponent(data.DB_PASSWORD!);
+  return `postgresql://${user}:${password}@${data.DB_HOST}:${data.DB_PORT}/${data.DB_NAME}`;
+}
 
 export type Env = z.infer<typeof envSchema>;
 
@@ -221,7 +254,13 @@ function validateEnv(env: NodeJS.ProcessEnv = process.env): Env {
     console.warn('[Startup Warning] No TTS provider configured — TTS features will be unavailable');
   }
 
-  return result.data;
+  // Assemble DATABASE_URL from discrete parts when it wasn't provided
+  // directly, and keep process.env.DATABASE_URL in sync for code paths
+  // (e.g. Prisma) that read it straight from the environment.
+  const databaseUrl = buildDatabaseUrl(result.data);
+  process.env.DATABASE_URL = databaseUrl;
+
+  return { ...result.data, DATABASE_URL: databaseUrl };
 }
 
 // Lazily validated so test files can import `validateEnv` without a valid

--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -14,7 +14,14 @@ const ALLOWED_ORIGINS: Record<string, string[]> = {
 };
 
 const env = process.env.NODE_ENV ?? 'local';
-const allowedOrigins: string[] = ALLOWED_ORIGINS[env] ?? ALLOWED_ORIGINS.local;
+
+/**
+ * Flattened list of origins allowed for the current environment. Exported so
+ * other places that need to validate an application-controlled origin
+ * (e.g. Stripe Checkout success/cancel URLs) can reuse the same allow-list
+ * instead of accepting arbitrary attacker-supplied domains.
+ */
+export const allowedOrigins: string[] = ALLOWED_ORIGINS[env] ?? ALLOWED_ORIGINS.local;
 
 export const corsOptions: CorsOptions = {
   origin: (origin, callback) => {

--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -5,6 +5,7 @@ import { validate } from '../middleware/validate';
 import { billingService } from '../services/BillingService';
 import { UserStore } from '../models/User';
 import { createLogger } from '../lib/logger';
+import { allowedOrigins } from '../config/cors';
 
 const router = Router();
 const logger = createLogger('billing-routes');
@@ -18,6 +19,35 @@ const checkoutSchema = z.object({
 const portalSchema = z.object({
   returnUrl: z.string().url(),
 });
+
+/**
+ * Redirect URLs handed to Stripe (success_url/cancel_url/return_url) must
+ * resolve to an origin we control. Without this, an attacker can point
+ * successUrl at an external phishing domain and Stripe will redirect the
+ * payer there immediately after a real payment completes (open redirect).
+ */
+function isAllowedRedirectUrl(url: string): boolean {
+  try {
+    return allowedOrigins.includes(new URL(url).origin);
+  } catch {
+    return false;
+  }
+}
+
+function rejectDisallowedUrls(
+  urls: Record<string, string>,
+  res: Response,
+): boolean {
+  for (const [field, url] of Object.entries(urls)) {
+    if (!isAllowedRedirectUrl(url)) {
+      res.status(400).json({
+        message: `${field} must be a URL on an allowed application origin`,
+      });
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * @openapi
@@ -128,6 +158,7 @@ router.post(
   validate(checkoutSchema),
   async (req: AuthRequest, res: Response) => {
     const { priceId, successUrl, cancelUrl } = req.body;
+    if (rejectDisallowedUrls({ successUrl, cancelUrl }, res)) return;
     try {
       const url = await billingService.createCheckoutSession(
         req.user!.id,
@@ -178,6 +209,7 @@ router.post(
   validate(portalSchema),
   async (req: AuthRequest, res: Response) => {
     const { returnUrl } = req.body;
+    if (rejectDisallowedUrls({ returnUrl }, res)) return;
     try {
       const url = await billingService.createPortalSession(req.user!.id, returnUrl);
       return res.json({ url });

--- a/src/blockchain/services/IPFSUploader.ts
+++ b/src/blockchain/services/IPFSUploader.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../../utils/AppError';
 import { ErrorCode } from '../../constants/ErrorCodes';
+import { withSpan } from '../../instrumentation';
 import {
   IPFSClient,
   IPFSUploadResult,
@@ -29,6 +30,14 @@ export class IPFSUploader {
   }
 
   private async uploadFileSimple(file: File, _onProgress?: (a: number, b: number) => void) {
+    return withSpan(
+      'ipfs.uploadFileSimple',
+      { 'ipfs.provider': this.client.config.provider, 'file.size': file.size },
+      () => this.doUploadFileSimple(file),
+    );
+  }
+
+  private async doUploadFileSimple(file: File) {
     const info = this.client.getProviderInfo()
     if (this.client.config.provider === 'web3') {
       const form = new FormData()

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,6 +8,9 @@
  *
  *   const result = await traceDbQuery('users.findById', async () => db.find(...));
  *   const reply  = await traceAiCall('gemini.generate', model, async () => ai.generate(...));
+ *
+ * Wired in at: PredictiveService (traceHttpCall), TranslationService
+ * (traceAiCall), transactionDB (traceDbQuery), IPFSUploader (withSpan).
  */
 
 import { trace, SpanStatusCode, SpanKind, context, Span } from '@opentelemetry/api';

--- a/src/services/PredictiveService.ts
+++ b/src/services/PredictiveService.ts
@@ -6,6 +6,7 @@
  */
 import { OpenAPI } from '../api/core/OpenAPI';
 import { request } from '../api/core/request';
+import { traceHttpCall } from '../instrumentation';
 import {
   PostAnalysisInput,
   ReachPrediction,
@@ -15,14 +16,20 @@ import {
 class PredictiveService {
   public async predictReach(input: PostAnalysisInput): Promise<ReachPrediction> {
     try {
-      return await request(OpenAPI, {
-        method: 'POST',
-        url: '/predictive/reach',
-        body: {
-          ...input,
-          scheduledTime: input.scheduledTime?.toISOString(),
-        },
-      });
+      return await traceHttpCall(
+        'predictive-backend',
+        'POST',
+        '/predictive/reach',
+        () =>
+          request(OpenAPI, {
+            method: 'POST',
+            url: '/predictive/reach',
+            body: {
+              ...input,
+              scheduledTime: input.scheduledTime?.toISOString(),
+            },
+          }),
+      );
     } catch {
       // Backend unavailable (e.g. frontend-only mode) — fall back to a
       // deterministic local heuristic so the predictive UI stays functional.
@@ -32,11 +39,17 @@ class PredictiveService {
 
   public async getModelMetrics(postId: string): Promise<{ metrics: MLModelMetrics }> {
     try {
-      return await request(OpenAPI, {
-        method: 'GET',
-        url: '/predictive/history/{postId}',
-        path: { postId },
-      });
+      return await traceHttpCall(
+        'predictive-backend',
+        'GET',
+        '/predictive/history/{postId}',
+        () =>
+          request(OpenAPI, {
+            method: 'GET',
+            url: '/predictive/history/{postId}',
+            path: { postId },
+          }),
+      );
     } catch {
       return {
         metrics: {

--- a/src/services/TranslationService.ts
+++ b/src/services/TranslationService.ts
@@ -1,4 +1,5 @@
 import { GoogleGenAI } from '@google/genai';
+import { traceAiCall } from '../instrumentation';
 import {
   TranslationRequest,
   TranslationResult,
@@ -271,10 +272,12 @@ Text to translate: "${text}"
 
 Translation:`;
 
-    const result = await this.genAI.models.generateContent({
-      model: this.model,
-      contents: prompt,
-    });
+    const result = await traceAiCall('gemini.generateContent', this.model, () =>
+      this.genAI!.models.generateContent({
+        model: this.model,
+        contents: prompt,
+      }),
+    );
     return (result.text ?? '').trim();
   }
 

--- a/src/services/transactionDB.ts
+++ b/src/services/transactionDB.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../utils/AppError';
 import { ErrorCode } from '../constants/ErrorCodes';
+import { traceDbQuery } from '../instrumentation';
 
 // IndexedDB Schema for Transaction History
 const DB_NAME = 'SocialFlowTransactions';
@@ -89,28 +90,32 @@ class TransactionDB {
 
   async getTransaction(id: string): Promise<TransactionRecord | undefined> {
     if (!this.db) throw new AppError(ErrorCode.ERR_DATABASE_NOT_INITIALIZED);
-    
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([STORE_NAME], 'readonly');
-      const store = transaction.objectStore(STORE_NAME);
-      const request = store.get(id);
-      
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
-    });
+
+    return traceDbQuery('transactions.getTransaction', 'indexeddb', () =>
+      new Promise((resolve, reject) => {
+        const transaction = this.db!.transaction([STORE_NAME], 'readonly');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.get(id);
+
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      }),
+    );
   }
 
   async getAllTransactions(): Promise<TransactionRecord[]> {
     if (!this.db) throw new AppError(ErrorCode.ERR_DATABASE_NOT_INITIALIZED);
-    
-    return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([STORE_NAME], 'readonly');
-      const store = transaction.objectStore(STORE_NAME);
-      const request = store.getAll();
-      
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
-    });
+
+    return traceDbQuery('transactions.getAllTransactions', 'indexeddb', () =>
+      new Promise((resolve, reject) => {
+        const transaction = this.db!.transaction([STORE_NAME], 'readonly');
+        const store = transaction.objectStore(STORE_NAME);
+        const request = store.getAll();
+
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      }),
+    );
   }
 
   async getTransactionsByType(type: string): Promise<TransactionRecord[]> {

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -31,6 +31,34 @@ module "s3" {
   bucket_name = "socialflow-dev-assets-${var.account_id}"
 }
 
+# App security group shared by ECS, RDS, and ElastiCache. Created here at the
+# root rather than inside the ecs module so that rds/elasticache (which need
+# to allow ingress from it) don't have to depend on the ecs module, while ecs
+# (whose database_url depends on module.rds.endpoint) doesn't have to depend
+# on rds's output either. Keeping it at the root breaks what was previously a
+# genuine module-level cycle: ecs -> rds (database_url) and rds -> ecs
+# (app_sg_id) at the same time.
+resource "aws_security_group" "app" {
+  name   = "socialflow-dev-app-sg"
+  vpc_id = module.networking.vpc_id
+
+  ingress {
+    from_port       = 3001
+    to_port         = 3001
+    protocol        = "tcp"
+    security_groups = [module.ecs.alb_sg_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "socialflow-dev-app-sg" }
+}
+
 module "ecs" {
   source              = "../../modules/ecs"
   env                 = "dev"
@@ -42,6 +70,7 @@ module "ecs" {
   memory              = 512
   desired_count       = 1
   container_port      = 3001
+  app_sg_id           = aws_security_group.app.id
   database_url        = "postgresql://${var.db_username}:${var.db_password}@${module.rds.endpoint}/${var.db_name}"
   redis_url           = "rediss://${module.elasticache.primary_endpoint}:6379"
   jwt_secret          = var.jwt_secret
@@ -59,7 +88,7 @@ module "rds" {
   db_password        = var.db_password
   instance_class     = "db.t3.micro"
   allocated_storage  = 20
-  app_sg_id          = module.ecs.app_sg_id
+  app_sg_id          = aws_security_group.app.id
 }
 
 module "elasticache" {
@@ -68,7 +97,7 @@ module "elasticache" {
   vpc_id     = module.networking.vpc_id
   subnet_ids = module.networking.private_subnet_ids
   node_type  = "cache.t3.micro"
-  app_sg_id  = module.ecs.app_sg_id
+  app_sg_id  = aws_security_group.app.id
 }
 
 module "iam" {

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -71,7 +71,14 @@ module "ecs" {
   desired_count       = 1
   container_port      = 3001
   app_sg_id           = aws_security_group.app.id
-  database_url        = "postgresql://${var.db_username}:${var.db_password}@${module.rds.endpoint}/${var.db_name}"
+  # DB connection is passed as discrete fields (not one pre-assembled
+  # database_url) so the password is never stored as part of a single
+  # combined Terraform-tracked attribute — see modules/ecs for details.
+  db_host             = module.rds.endpoint
+  db_port             = 5432
+  db_name             = var.db_name
+  db_username         = var.db_username
+  db_password         = var.db_password
   redis_url           = "rediss://${module.elasticache.primary_endpoint}:6379"
   jwt_secret          = var.jwt_secret
   s3_bucket           = module.s3.bucket_name

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -75,7 +75,14 @@ module "ecs" {
   desired_count       = 2
   container_port      = 3001
   app_sg_id           = aws_security_group.app.id
-  database_url        = "postgresql://${var.db_username}:${var.db_password}@${module.rds.endpoint}/${var.db_name}"
+  # DB connection is passed as discrete fields (not one pre-assembled
+  # database_url) so the password is never stored as part of a single
+  # combined Terraform-tracked attribute — see modules/ecs for details.
+  db_host             = module.rds.endpoint
+  db_port             = 5432
+  db_name             = var.db_name
+  db_username         = var.db_username
+  db_password         = var.db_password
   redis_url           = "rediss://${module.elasticache.primary_endpoint}:6379"
   jwt_secret          = var.jwt_secret
   s3_bucket           = module.s3.bucket_name

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -31,6 +31,34 @@ module "s3" {
   bucket_name = "socialflow-prod-assets-${var.account_id}"
 }
 
+# App security group shared by ECS, RDS, and ElastiCache. Created here at the
+# root rather than inside the ecs module so that rds/elasticache (which need
+# to allow ingress from it) don't have to depend on the ecs module, while ecs
+# (whose database_url depends on module.rds.endpoint) doesn't have to depend
+# on rds's output either. Keeping it at the root breaks what was previously a
+# genuine module-level cycle: ecs -> rds (database_url) and rds -> ecs
+# (app_sg_id) at the same time.
+resource "aws_security_group" "app" {
+  name   = "socialflow-prod-app-sg"
+  vpc_id = module.networking.vpc_id
+
+  ingress {
+    from_port       = 3001
+    to_port         = 3001
+    protocol        = "tcp"
+    security_groups = [module.ecs.alb_sg_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "socialflow-prod-app-sg" }
+}
+
 module "ecs" {
   source              = "../../modules/ecs"
   env                 = "prod"
@@ -46,6 +74,7 @@ module "ecs" {
   memory              = 1024
   desired_count       = 2
   container_port      = 3001
+  app_sg_id           = aws_security_group.app.id
   database_url        = "postgresql://${var.db_username}:${var.db_password}@${module.rds.endpoint}/${var.db_name}"
   redis_url           = "rediss://${module.elasticache.primary_endpoint}:6379"
   jwt_secret          = var.jwt_secret
@@ -63,7 +92,7 @@ module "rds" {
   db_password        = var.db_password
   instance_class     = "db.t3.small"
   allocated_storage  = 50
-  app_sg_id          = module.ecs.app_sg_id
+  app_sg_id          = aws_security_group.app.id
 }
 
 module "elasticache" {
@@ -72,7 +101,7 @@ module "elasticache" {
   vpc_id     = module.networking.vpc_id
   subnet_ids = module.networking.private_subnet_ids
   node_type  = "cache.t3.small"
-  app_sg_id  = module.ecs.app_sg_id
+  app_sg_id  = aws_security_group.app.id
 }
 
 module "iam" {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -139,27 +139,6 @@ resource "aws_security_group" "alb" {
   tags = { Name = "socialflow-${var.env}-alb-sg" }
 }
 
-resource "aws_security_group" "app" {
-  name   = "socialflow-${var.env}-app-sg"
-  vpc_id = var.vpc_id
-
-  ingress {
-    from_port       = var.container_port
-    to_port         = var.container_port
-    protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = { Name = "socialflow-${var.env}-app-sg" }
-}
-
 resource "aws_lb" "main" {
   name               = "socialflow-${var.env}-alb"
   internal           = false
@@ -204,7 +183,7 @@ resource "aws_ecs_service" "app" {
 
   network_configuration {
     subnets         = var.private_subnet_ids
-    security_groups = [aws_security_group.app.id]
+    security_groups = [var.app_sg_id]
   }
 
   load_balancer {

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -71,7 +71,15 @@ resource "aws_ecs_task_definition" "app" {
       { name = "REDIS_TLS",   value = "true" }
     ]
     secrets = [
-      { name = "DATABASE_URL", valueFrom = aws_ssm_parameter.database_url.arn },
+      # DB connection is injected as discrete fields rather than one
+      # pre-assembled DATABASE_URL so the password never lands in Terraform
+      # state as part of a single combined attribute value — the app builds
+      # the connection string itself at runtime (see backend/src/config/config.ts).
+      { name = "DB_HOST",      valueFrom = aws_ssm_parameter.db_host.arn },
+      { name = "DB_PORT",      valueFrom = aws_ssm_parameter.db_port.arn },
+      { name = "DB_NAME",      valueFrom = aws_ssm_parameter.db_name.arn },
+      { name = "DB_USER",      valueFrom = aws_ssm_parameter.db_user.arn },
+      { name = "DB_PASSWORD",  valueFrom = aws_ssm_parameter.db_password.arn },
       { name = "REDIS_URL",    valueFrom = aws_ssm_parameter.redis_url.arn },
       { name = "JWT_SECRET",   valueFrom = aws_ssm_parameter.jwt_secret.arn }
     ]
@@ -93,10 +101,37 @@ resource "aws_ecs_task_definition" "app" {
   }])
 }
 
-resource "aws_ssm_parameter" "database_url" {
-  name  = "/socialflow/${var.env}/DATABASE_URL"
+resource "aws_ssm_parameter" "db_host" {
+  name  = "/socialflow/${var.env}/DB_HOST"
+  type  = "String"
+  value = var.db_host
+}
+
+resource "aws_ssm_parameter" "db_port" {
+  name  = "/socialflow/${var.env}/DB_PORT"
+  type  = "String"
+  value = tostring(var.db_port)
+}
+
+resource "aws_ssm_parameter" "db_name" {
+  name  = "/socialflow/${var.env}/DB_NAME"
+  type  = "String"
+  value = var.db_name
+}
+
+resource "aws_ssm_parameter" "db_user" {
+  name  = "/socialflow/${var.env}/DB_USER"
+  type  = "String"
+  value = var.db_username
+}
+
+# The password is stored on its own, never concatenated into a connection
+# string with the host/user/db name — keeps a single Terraform-tracked
+# attribute from ever holding the whole secret.
+resource "aws_ssm_parameter" "db_password" {
+  name  = "/socialflow/${var.env}/DB_PASSWORD"
   type  = "SecureString"
-  value = var.database_url
+  value = var.db_password
 }
 
 resource "aws_ssm_parameter" "redis_url" {

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -1,3 +1,9 @@
 output "alb_dns_name" { value = aws_lb.main.dns_name }
-output "app_sg_id"    { value = aws_security_group.app.id }
+
+# app_sg_id is no longer created here — it's a root-level resource (see
+# environments/{dev,prod}/main.tf) shared by the ecs, rds, and elasticache
+# modules so that rds/elasticache no longer need to depend on this module's
+# output, which previously created a circular dependency (ecs depended on
+# rds.endpoint for database_url, while rds depended on ecs.app_sg_id).
+output "alb_sg_id"    { value = aws_security_group.alb.id }
 output "cluster_name" { value = aws_ecs_cluster.main.name }

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -27,7 +27,17 @@ variable "memory"           {
 
 variable "desired_count"    { type = number; default = 1 }
 variable "container_port"   { type = number; default = 3001 }
-variable "database_url"     { type = string; sensitive = true }
+
+# Split DB connection fields (replaces a single pre-assembled database_url)
+# so the password is never stored as part of one combined Terraform-tracked
+# SSM parameter value. See modules/ecs/main.tf for the SSM parameters and
+# backend/src/config/config.ts for runtime reassembly.
+variable "db_host"          { type = string }
+variable "db_port"          { type = number; default = 5432 }
+variable "db_name"          { type = string }
+variable "db_username"      { type = string }
+variable "db_password"      { type = string; sensitive = true }
+
 variable "redis_url"        { type = string; sensitive = true }
 variable "jwt_secret"       { type = string; sensitive = true }
 variable "s3_bucket"        { type = string }

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -4,6 +4,11 @@ variable "public_subnet_ids"  { type = list(string) }
 variable "private_subnet_ids" { type = list(string) }
 variable "image_uri"        { type = string }
 
+# Security group attached to the ECS service's ENIs, created outside this
+# module (see the app_sg_id note in outputs.tf) so it can be shared with the
+# rds/elasticache modules without creating a circular module dependency.
+variable "app_sg_id"        { type = string }
+
 # CPU/memory right-sizing
 # Values are set based on observed p95 usage plus 20% headroom from Container Insights metrics.
 # Fargate valid CPU/memory combinations: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html


### PR DESCRIPTION
Closes #1313
Closes #1314 
Closes #1315 
Closes #1316
---
1. Stripe checkout/portal open-redirect fix (72c230a)

Problem: backend/src/routes/billing.ts validated successUrl/cancelUrl/returnUrl with nothing more than z.string().url() — any well-formed URL on any domain passed, and BillingService.createCheckoutSession() forwarded them straight to Stripe as success_url/cancel_url. An authenticated caller could set successUrl to an attacker-controlled domain and Stripe would redirect the payer there immediately after a real payment completed.

What changed:
- backend/src/config/cors.ts — the previously module-private allowedOrigins array (already used to build corsOptions) is now exported, so it can be reused as the single source of truth for "domains this app controls."
- backend/src/routes/billing.ts:
  - Added isAllowedRedirectUrl(url) — parses the URL and checks new URL(url).origin against allowedOrigins, returning false (rejecting) on any parse failure too.
  - Added rejectDisallowedUrls(urls, res) — a small helper that walks a {field: url} map, and on the first disallowed URL responds 400 { message: "<field> must be a URL on an allowed application origin" } and returns true so the caller can early-return.
  - Wired into both POST /billing/checkout (checks successUrl and cancelUrl) and POST /billing/portal (checks returnUrl) — the check runs after existing zod validation, before any call reaches billingService.
- New test file backend/src/__tests__/billingCheckoutUrlAllowlist.test.ts — mounts the real billingRouter on a bare Express app (auth middleware and BillingService mocked, ../config/cors mocked to a fixed 2-origin allow-list) and asserts:
  - external successUrl → 400, createCheckoutSession never called
  - external cancelUrl → 400, createCheckoutSession never called
  - both URLs on an allowed origin → 200, session created
  - external returnUrl on /billing/portal → 400, createPortalSession never called

Not changed: checkoutSchema/portalSchema still require well-formed URLs via zod (422 for malformed URLs is unchanged); the new check only governs the origin, and only returns 400 (not 422) as the issue's acceptance criteria specifically required.

---
2. Terraform ecs ↔ rds/elasticache circular dependency fix (b1f12eb)

Problem: In both terraform/environments/dev/main.tf and terraform/environments/prod/main.tf:
- module.ecs's database_url input was built from module.rds.endpoint → ecs depends on rds.
- module.rds and module.elasticache took app_sg_id = module.ecs.app_sg_id (the SG was created inside the ecs module) → rds/elasticache depend on ecs.

That's a genuine two-hop module cycle; Terraform refuses to build a plan graph for it at all (Error: Cycle), so this infrastructure could never have been applied from scratch as written.

What changed:
- terraform/modules/ecs/main.tf — removed the aws_security_group "app" resource entirely; the ECS service's network_configuration now references var.app_sg_id instead of aws_security_group.app.id.
- terraform/modules/ecs/variables.tf — added variable "app_sg_id" { type = string }, documented as coming from outside the module specifically to avoid the cycle.
- terraform/modules/ecs/outputs.tf — removed the app_sg_id output (nothing creates it here anymore); added alb_sg_id output (aws_security_group.alb.id) instead, with a comment explaining why the SG moved.
- terraform/environments/dev/main.tf and terraform/environments/prod/main.tf (identical pattern in both, dev/prod naming swapped):
  - Added a new root-level resource "aws_security_group" "app" — ingress on port 3001 from module.ecs.alb_sg_id, egress all, in module.networking.vpc_id.
  - module "ecs" call now passes app_sg_id = aws_security_group.app.id.
  - module "rds" and module "elasticache" calls now pass app_sg_id = aws_security_group.app.id instead of module.ecs.app_sg_id.

Why this isn't still a cycle: Terraform's dependency graph is resource-level, not module-level. aws_security_group.alb (inside ecs) doesn't reference var.app_sg_id, so it has no dependency on the root's aws_security_group.app. The root's aws_security_group.app depends on module.ecs.alb_sg_id (i.e., specifically on aws_security_group.alb). The ECS service and rds/elasticache then depend on the root's aws_security_group.app. Chain: alb_sg → root_app_sg → {ecs_service, rds, elasticache} — a valid DAG, no back-edge. ecs still depends on rds.endpoint for database_url, but that's now one-directional only.

---
3. DB password no longer stored as one combined Terraform-tracked value (7082eba)

Problem: database_url = "postgresql://${var.db_username}:${var.db_password}@${module.rds.endpoint}/${var.db_name}" was passed into ecs and stored whole as aws_ssm_parameter.database_url's value. Terraform state tracks the full resolved value of every resource attribute in plaintext regardless of sensitive = true (which only suppresses CLI/log output, not state storage), so anyone with state-read access could recover the raw password from that single combined attribute.

What changed:
- terraform/modules/ecs/main.tf:
  - Removed aws_ssm_parameter "database_url".
  - Added five separate SSM parameters: db_host, db_port, db_name, db_user (all type = "String") and db_password (type = "SecureString", kept alone rather than concatenated with anything else).
  - Container secrets block now injects DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD as five separate env vars instead of one DATABASE_URL.
- terraform/modules/ecs/variables.tf — replaced variable "database_url" with db_host, db_port (default 5432), db_name, db_username, db_password (still sensitive = true).
- terraform/environments/dev/main.tf / prod/main.tf — module "ecs" calls now pass db_host = module.rds.endpoint, db_port = 5432, db_name, db_username, db_password individually instead of building the interpolated database_url string.
- backend/src/config/config.ts:
  - DATABASE_URL is now .optional() (previously required); added optional DB_HOST, DB_PORT (default 5432), DB_NAME, DB_USER, DB_PASSWORD.
  - superRefine now requires either DATABASE_URL or the full DB_HOST+DB_NAME+DB_USER+DB_PASSWORD set — so misconfiguration still fails startup validation with a clear message.
  - New buildDatabaseUrl(data) — returns data.DATABASE_URL if set, otherwise assembles postgresql://${encodeURIComponent(user)}:${encodeURIComponent(password)}@${host}:${port}/${dbName} at runtime.
  - validateEnv() now calls buildDatabaseUrl, sets process.env.DATABASE_URL (so code that reads it directly off process.env, e.g. readReplica.ts/shared/lib/prisma.ts, keeps working unchanged), and returns the config with DATABASE_URL populated either way.

Net effect: the app still gets everything it needs to connect to Postgres, but the password now lives in its own SSM parameter/state attribute rather than being smashed into one URL alongside host, user, and db name.

---
4. Dead instrumentation code wired into real call sites (0c3d600)

Problem: src/instrumentation.ts exported withSpan, traceDbQuery, traceAiCall, traceHttpCall as manual OTel helpers "for critical paths," but nothing in src/ or backend/src/ ever imported them — pure unused scaffolding.

What changed (chose to wire up rather than delete, per the issue's first option):
- src/services/PredictiveService.ts — predictReach() and getModelMetrics() now wrap their request(OpenAPI, …) backend calls in traceHttpCall('predictive-backend', method, url, …).
- src/services/TranslationService.ts — translateWithGemini()'s this.genAI.models.generateContent(...) call is now wrapped in traceAiCall('gemini.generateContent', this.model, …).
- src/services/transactionDB.ts — getTransaction() and getAllTransactions() (IndexedDB reads) are now wrapped in traceDbQuery('transactions.getTransaction'/'…AllTransactions', 'indexeddb', …).
- src/blockchain/services/IPFSUploader.ts — uploadFileSimple() was split: the public method now calls withSpan('ipfs.uploadFileSimple', { 'ipfs.provider', 'file.size' }, …) wrapping a new private doUploadFileSimple() that holds the original logic unchanged.
- src/instrumentation.ts — doc comment updated to list where each helper is now actually called, so it's discoverable that this is live tracing, not aspirational.

Result: all four exports have real call sites; no unused instrumentation helpers remain.
