### PR TITLE
Fix/security and config hardening

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,9 @@
+# ─── Server ────────────────────────────────────────────────────────────────────
+# NODE_ENV must be one of: development | test | production
+# (also set further below, kept here as the canonical declaration)
+NODE_ENV=development
+BACKEND_PORT=3001
+
 # PostgreSQL connection string
 # Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public
 DATABASE_URL="postgresql://postgres:password@localhost:5432/socialflow?schema=public"
@@ -12,6 +18,9 @@ DATABASE_REPLICA_URL=
 # Uncomment to override:
 # DB_CONNECTION_LIMIT=10
 # DB_POOL_TIMEOUT=20
+# Set to 'true' when a PgBouncer proxy sits in front of Postgres (transaction
+# mode requires DB_CONNECTION_LIMIT=1 per application process).
+PGBOUNCER_MODE=false
 
 # JWT secrets (keep these strong and secret in production)
 JWT_SECRET=
@@ -40,7 +49,6 @@ ALERT_COOLDOWN_MS=300000
 # ─── OpenTelemetry Distributed Tracing ───────────────────────────────────────
 # Service identity
 OTEL_SERVICE_NAME=socialflow-backend
-NODE_ENV=development
 
 # Exporter: 'jaeger' | 'honeycomb' | 'otlp'  (default: jaeger)
 OTEL_EXPORTER=jaeger
@@ -66,9 +74,42 @@ YOUTUBE_REDIRECT_URI=http://localhost:3000/api/youtube/callback
 # Cron schedule for periodic analytics sync (default: every 6 hours)
 YOUTUBE_SYNC_CRON=0 */6 * * *
 
+# ─── Twitter/X API v2 ─────────────────────────────────────────────────────────
+# REQUIRED — the backend refuses to start without these two.
+TWITTER_API_KEY=your_twitter_api_key
+TWITTER_API_SECRET=your_twitter_api_secret
+
+# ─── TikTok API ───────────────────────────────────────────────────────────────
+TIKTOK_CLIENT_KEY=your_tiktok_client_key
+TIKTOK_CLIENT_SECRET=your_tiktok_client_secret
+TIKTOK_REDIRECT_URI=http://localhost:3000/api/tiktok/callback
+
+# ─── Instagram Graph API ──────────────────────────────────────────────────────
+# Instagram auth reuses the Facebook app credentials above; only the redirect
+# differs.
+INSTAGRAM_REDIRECT_URI=http://localhost:3000/api/instagram/callback
+
+# ─── LinkedIn API ─────────────────────────────────────────────────────────────
+LINKEDIN_CLIENT_ID=your_linkedin_client_id
+LINKEDIN_CLIENT_SECRET=your_linkedin_client_secret
+LINKEDIN_REDIRECT_URI=http://localhost:3000/api/linkedin/callback
+
 # ─── Google Gemini AI ─────────────────────────────────────────────────────────
 # Used by AIService and hashtagGeneratorService for AI-powered content generation
 GEMINI_API_KEY=your_gemini_api_key_here
+
+# ─── Translation & Text-to-Speech providers (optional) ───────────────────────
+# Server-side only — never expose these via VITE_-prefixed variables, Vite
+# inlines VITE_ vars into the shipped client bundle.
+DEEPL_API_KEY=your_deepl_api_key
+GOOGLE_TRANSLATE_API_KEY=your_google_translate_api_key
+ELEVENLABS_API_KEY=your_elevenlabs_api_key
+GOOGLE_TTS_API_KEY=your_google_tts_api_key
+
+# ─── Stripe Billing ───────────────────────────────────────────────────────────
+# STRIPE_SECRET_KEY is REQUIRED — the backend refuses to start without it.
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_stripe_webhook_secret
 
 # ─── Facebook Graph API ──────────────────────────────────────────────────────
 FACEBOOK_APP_ID=your_facebook_app_id
@@ -77,10 +118,48 @@ FACEBOOK_REDIRECT_URI=http://localhost:3000/api/facebook/callback
 # Graph API version shared by FacebookService and InstagramService (default: v18.0)
 FACEBOOK_API_VERSION=v18.0
 
+# ─── Content Moderation ───────────────────────────────────────────────────────
+# fail-closed (default): block content when the moderation provider is
+# unavailable — safer for production. fail-open requires explicit opt-in.
+MODERATION_MODE=fail-closed
+MODERATION_SENSITIVITY=medium
+
+# ─── AWS S3 ────────────────────────────────────────────────────────────────────
+S3_PRESIGNED_URL_EXPIRY_SECONDS=3600
+
+# ─── Elasticsearch ─────────────────────────────────────────────────────────────
+ELASTICSEARCH_URL=http://localhost:9200
+# Must NOT be 'false' when NODE_ENV=production (disables TLS verification).
+ELASTICSEARCH_TLS_REJECT_UNAUTHORIZED=true
+
+# Log verbosity: error | warn | info | http | verbose | debug | silly
+LOG_LEVEL=info
+
+# ─── Worker Monitor ────────────────────────────────────────────────────────────
+WORKER_MONITOR_INTERVAL_MS=30000
+WORKER_MONITOR_LATENCY_THRESHOLD_MS=60000
+WORKER_MONITOR_STUCK_THRESHOLD_MS=300000
+# Comma-separated list of BullMQ queue names to monitor
+WORKER_MONITOR_QUEUES=
+
+# ─── Required integrations policy ──────────────────────────────────────────────
+# Comma-separated list of integration names that must be configured.
+# If any listed integration is disabled, startup fails.
+# Example: REQUIRE_INTEGRATIONS=youtube,tiktok,stripe
+REQUIRE_INTEGRATIONS=
+
+# ─── Webhooks ───────────────────────────────────────────────────────────────────
+HMAC_TIMESTAMP_TOLERANCE_MS=300000
+
+# ─── Dynamic Config ─────────────────────────────────────────────────────────────
+DYNAMIC_CONFIG_POLL_INTERVAL_MS=60000
+
 # ─── Data Retention & Pruning ─────────────────────────────────────────────────
 # Enable or disable the scheduled data pruning job.
 # Accepted values: 'true' | '1' (enabled) or 'false' | '0' (disabled). Default: true
 # DATA_PRUNING_ENABLED=true
+# Run pruning in dry-run mode (logs what would be pruned without deleting/archiving)
+# DATA_PRUNING_DRY_RUN=false
 # Cron schedule for data pruning (default: daily at 02:00)
 # DATA_PRUNING_CRON=0 2 * * *
 # Retention windows (days)
@@ -88,6 +167,12 @@ FACEBOOK_API_VERSION=v18.0
 # DATA_RETENTION_ANALYTICS_DAYS=90
 # Retention mode: 'archive' moves files to cold-storage; 'delete' removes them permanently
 # DATA_RETENTION_MODE=archive
+# Directory used when DATA_RETENTION_MODE=archive
+# DATA_RETENTION_ARCHIVE_DIR=cold-storage
+# Policy when an archive/log path is missing: 'warn' | 'fail' | 'ignore'
+# DATA_RETENTION_MISSING_PATH_POLICY=warn
+# Number of missing-path occurrences before an alert fires
+# DATA_RETENTION_MISSING_PATH_ALERT_THRESHOLD=3
 
 
 # Used for BullMQ queues and (in production) the rate-limit store

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "data-pruning:dev": "ts-node-dev --respawn --transpile-only src/scripts/data-pruning.ts",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
-    "format": "prettier --write 'src/**/*.ts'"
+    "format": "prettier --write 'src/**/*.ts'",
+    "check:env-example": "node scripts/check-env-example.js"
   },
   "dependencies": {
     "@apollo/server": "^5.5.1",

--- a/backend/scripts/check-env-example.js
+++ b/backend/scripts/check-env-example.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Fails if any environment key read by src/config/config.ts's Zod schema is
+ * missing from .env.example. Run via `npm run check:env-example`.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, '..', 'src', 'config', 'config.ts');
+const ENV_EXAMPLE_PATH = path.join(__dirname, '..', '.env.example');
+
+const configSource = fs.readFileSync(CONFIG_PATH, 'utf8');
+const envExampleSource = fs.readFileSync(ENV_EXAMPLE_PATH, 'utf8');
+
+// Match SCREAMING_SNAKE_CASE identifiers immediately followed by `: z.`
+// inside the envSchema object — this is how every schema key is declared.
+const keyPattern = /^\s*([A-Z][A-Z0-9_]*):\s*z\./gm;
+const schemaKeys = new Set();
+let match;
+while ((match = keyPattern.exec(configSource)) !== null) {
+  schemaKeys.add(match[1]);
+}
+
+const definedKeys = new Set();
+// A key counts as documented whether it's set directly (KEY=...) or shown
+// as a commented-out optional override (# KEY=...), which is how this file
+// documents keys that already have a sensible default in config.ts.
+for (const line of envExampleSource.split('\n')) {
+  const m = line.match(/^#?\s*([A-Z][A-Z0-9_]*)=/);
+  if (m) definedKeys.add(m[1]);
+}
+
+const missing = [...schemaKeys].filter((key) => !definedKeys.has(key)).sort();
+
+if (missing.length > 0) {
+  console.error('The following keys are read by config.ts but missing from .env.example:');
+  for (const key of missing) console.error(`  - ${key}`);
+  process.exit(1);
+}
+
+console.log(`OK — all ${schemaKeys.size} config.ts keys are documented in .env.example`);

--- a/backend/src/__tests__/organizationController.test.ts
+++ b/backend/src/__tests__/organizationController.test.ts
@@ -174,6 +174,40 @@ describe('addMember — member invitation flow', () => {
     expect(res.json).toHaveBeenCalledWith(created);
   });
 
+  // ── Privilege escalation guard ─────────────────────────────────────────────
+
+  it('returns 403 when an admin-role caller tries to add a member with role="owner"', async () => {
+    (prisma.organizationMember.findUnique as jest.Mock).mockResolvedValue({ role: 'admin' });
+
+    const req = makeReq({ orgId: 'org-1' }, { userId: 'new-user-id', role: 'owner' });
+    const res = makeRes();
+
+    await addMember(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Only an owner can grant the owner role' });
+    expect(prisma.organizationMember.create).not.toHaveBeenCalled();
+  });
+
+  it('allows an owner-role caller to add a member with role="owner"', async () => {
+    (prisma.organizationMember.findUnique as jest.Mock).mockResolvedValue({ role: 'owner' });
+    const created = { id: 'mbr-6', organizationId: 'org-1', userId: 'new-user-id', role: 'owner' };
+    (prisma.organizationMember.create as jest.Mock).mockResolvedValue(created);
+
+    const req = makeReq({ orgId: 'org-1' }, { userId: 'new-user-id', role: 'owner' });
+    const res = makeRes();
+
+    await addMember(req, res);
+
+    expect(prisma.organizationMember.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'owner' }),
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(created);
+  });
+
   it('invalidates the org cache and the invited user org-list cache after invitation', async () => {
     (prisma.organizationMember.findUnique as jest.Mock).mockResolvedValue({ role: 'owner' });
     (prisma.organizationMember.create as jest.Mock).mockResolvedValue({
@@ -260,6 +294,7 @@ describe('removeMember — member removal flow', () => {
 
   it('invalidates the org cache and the removed user org-list cache after removal', async () => {
     (prisma.organizationMember.findUnique as jest.Mock).mockResolvedValue({ role: 'owner' });
+    (prisma.organizationMember.count as jest.Mock).mockResolvedValue(2);
     (prisma.organizationMember.delete as jest.Mock).mockResolvedValue({});
 
     const req = makeReq({ orgId: 'org-1', userId: 'target-id' });
@@ -269,5 +304,52 @@ describe('removeMember — member removal flow', () => {
 
     expect(invalidateCachePattern).toHaveBeenCalledWith('org:org-1:*');
     expect(invalidateCachePattern).toHaveBeenCalledWith('org-list:target-id:*');
+  });
+
+  // ── Owner-removal safeguards ────────────────────────────────────────────────
+
+  it('returns 403 when trying to remove the sole owner of an organization', async () => {
+    (prisma.organizationMember.findUnique as jest.Mock).mockResolvedValue({ role: 'owner' });
+    (prisma.organizationMember.count as jest.Mock).mockResolvedValue(1);
+
+    const req = makeReq({ orgId: 'org-1', userId: 'owner-id' });
+    const res = makeRes();
+
+    await removeMember(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Cannot remove the last owner of an organization' });
+    expect(prisma.organizationMember.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows removing an owner when another owner remains', async () => {
+    (prisma.organizationMember.findUnique as jest.Mock).mockResolvedValue({ role: 'owner' });
+    (prisma.organizationMember.count as jest.Mock).mockResolvedValue(2);
+    (prisma.organizationMember.delete as jest.Mock).mockResolvedValue({});
+
+    const req = makeReq({ orgId: 'org-1', userId: 'owner-id' });
+    const res = makeRes();
+
+    await removeMember(req, res);
+
+    expect(prisma.organizationMember.delete).toHaveBeenCalledWith({
+      where: { organizationId_userId: { organizationId: 'org-1', userId: 'owner-id' } },
+    });
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+
+  it('returns 403 when an admin-role caller tries to remove an owner', async () => {
+    (prisma.organizationMember.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ role: 'admin' }) // caller membership
+      .mockResolvedValueOnce({ role: 'owner' }); // target membership
+
+    const req = makeReq({ orgId: 'org-1', userId: 'owner-id' });
+    const res = makeRes();
+
+    await removeMember(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Only an owner can remove an owner' });
+    expect(prisma.organizationMember.delete).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/config/__tests__/cors.test.ts
+++ b/backend/src/config/__tests__/cors.test.ts
@@ -1,0 +1,58 @@
+/**
+ * corsOptions keys ALLOWED_ORIGINS by real NODE_ENV values (development,
+ * test, production) rather than the previous 'local'/'staging'/'prod'
+ * mismatch, which made ALLOWED_ORIGINS['production'] undefined and caused
+ * a silent fallback to the localhost allowlist in real production.
+ */
+
+function loadCorsWithEnv(nodeEnv: string) {
+  let corsOptions: typeof import('../cors').corsOptions;
+  jest.isolateModules(() => {
+    process.env.NODE_ENV = nodeEnv;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    corsOptions = require('../cors').corsOptions;
+  });
+  return corsOptions!;
+}
+
+function callOrigin(
+  corsOptions: import('cors').CorsOptions,
+  origin: string | undefined,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    (corsOptions.origin as (origin: string | undefined, cb: (err: Error | null, allow?: boolean) => void) => void)(
+      origin,
+      (err, allow) => resolve(!err && !!allow),
+    );
+  });
+}
+
+describe('corsOptions', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('rejects a localhost origin and allows the configured production origin when NODE_ENV=production', async () => {
+    const corsOptions = loadCorsWithEnv('production');
+
+    await expect(callOrigin(corsOptions, 'http://localhost:3000')).resolves.toBe(false);
+    await expect(callOrigin(corsOptions, 'https://socialflow.app')).resolves.toBe(true);
+  });
+
+  it('allows localhost origins when NODE_ENV=development', async () => {
+    const corsOptions = loadCorsWithEnv('development');
+
+    await expect(callOrigin(corsOptions, 'http://localhost:3000')).resolves.toBe(true);
+    await expect(callOrigin(corsOptions, 'https://socialflow.app')).resolves.toBe(false);
+  });
+
+  it('rejects requests with no Origin header in production but allows them otherwise', async () => {
+    const prod = loadCorsWithEnv('production');
+    const dev = loadCorsWithEnv('development');
+
+    await expect(callOrigin(prod, undefined)).resolves.toBe(false);
+    await expect(callOrigin(dev, undefined)).resolves.toBe(true);
+  });
+});

--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -2,24 +2,31 @@ import { CorsOptions } from 'cors';
 
 /**
  * Allowed origins per environment.
+ * Keys MUST match the real NODE_ENV values used throughout the codebase
+ * (see backend/src/config/config.ts's Zod schema): development, test, production.
  * To add a new origin: append it to the relevant array below.
- *   - local:   development machines / localhost variants
- *   - staging: staging/preview deployments
- *   - prod:    production domains only
+ *   - development: local dev machines / localhost variants
+ *   - test:        CI / automated test runs (treated like development)
+ *   - production:  production domains only
  */
 const ALLOWED_ORIGINS: Record<string, string[]> = {
-  local: ['http://localhost:3000', 'http://localhost:5173', 'http://127.0.0.1:3000'],
-  staging: ['https://staging.socialflow.app'],
-  prod: ['https://socialflow.app', 'https://www.socialflow.app'],
+  development: ['http://localhost:3000', 'http://localhost:5173', 'http://127.0.0.1:3000'],
+  test: ['http://localhost:3000', 'http://localhost:5173', 'http://127.0.0.1:3000'],
+  production: ['https://socialflow.app', 'https://www.socialflow.app'],
 };
 
-const env = process.env.NODE_ENV ?? 'local';
-const allowedOrigins: string[] = ALLOWED_ORIGINS[env] ?? ALLOWED_ORIGINS.local;
+// Read the same NODE_ENV value the rest of the app validates against, rather
+// than re-reading process.env with a different set of expected values —
+// previously this used 'local'/'staging'/'prod' keys that never matched the
+// actual NODE_ENV of 'development'/'test'/'production', so production
+// silently fell back to the localhost allowlist.
+const env = process.env.NODE_ENV ?? 'development';
+const allowedOrigins: string[] = ALLOWED_ORIGINS[env] ?? ALLOWED_ORIGINS.development;
 
 export const corsOptions: CorsOptions = {
   origin: (origin, callback) => {
     // Allow server-to-server requests (no Origin header) only outside production
-    if (!origin && env !== 'prod') return callback(null, true);
+    if (!origin && env !== 'production') return callback(null, true);
     if (origin && allowedOrigins.includes(origin)) return callback(null, true);
     callback(new Error(`CORS: origin '${origin}' not allowed`));
   },

--- a/backend/src/controllers/organization.ts
+++ b/backend/src/controllers/organization.ts
@@ -96,6 +96,14 @@ export async function addMember(req: AuthRequest, res: Response): Promise<void> 
     return;
   }
 
+  // Only an existing owner can grant the owner role. Without this, an admin
+  // could hand out owner-level access to themselves (an alt account) or an
+  // accomplice — a privilege escalation from admin to owner.
+  if (role === 'owner' && callerMembership.role !== 'owner') {
+    res.status(403).json({ message: 'Only an owner can grant the owner role' });
+    return;
+  }
+
   const member = await prisma.organizationMember.create({
     data: { id: randomUUID(), organizationId: orgId, userId, role },
   });
@@ -119,6 +127,27 @@ export async function removeMember(req: AuthRequest, res: Response): Promise<voi
   if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
     res.status(403).json({ message: 'Insufficient permissions' });
     return;
+  }
+
+  const targetMembership = await prisma.organizationMember.findUnique({
+    where: { organizationId_userId: { organizationId: orgId, userId } },
+  });
+
+  if (targetMembership?.role === 'owner') {
+    // Only another owner may remove an owner-level member.
+    if (callerMembership.role !== 'owner') {
+      res.status(403).json({ message: 'Only an owner can remove an owner' });
+      return;
+    }
+
+    // Never let the org end up without an owner.
+    const ownerCount = await prisma.organizationMember.count({
+      where: { organizationId: orgId, role: 'owner' },
+    });
+    if (ownerCount <= 1) {
+      res.status(403).json({ message: 'Cannot remove the last owner of an organization' });
+      return;
+    }
   }
 
   await prisma.organizationMember.delete({

--- a/docs/fixes/backend-env-example-completeness.md
+++ b/docs/fixes/backend-env-example-completeness.md
@@ -1,0 +1,43 @@
+# Fix: backend/.env.example was missing ~38 keys the config schema validates
+
+## Problem
+
+`backend/src/config/config.ts`'s Zod schema requires (non-optional)
+`TWITTER_API_KEY`, `TWITTER_API_SECRET`, and `STRIPE_SECRET_KEY` — the
+backend throws on boot if any is missing — but none of the three appeared
+in `backend/.env.example`. Roughly 30 more keys the schema reads
+(`STRIPE_WEBHOOK_SECRET`, `LINKEDIN_*`, `TIKTOK_*`,
+`INSTAGRAM_REDIRECT_URI`, `MODERATION_MODE`/`MODERATION_SENSITIVITY`,
+`WORKER_MONITOR_*`, `PGBOUNCER_MODE`, `REQUIRE_INTEGRATIONS`,
+`ELASTICSEARCH_*`, `LOG_LEVEL`, `BACKEND_PORT`, the
+`DATA_RETENTION_*`/`DATA_PRUNING_*` group, `HMAC_TIMESTAMP_TOLERANCE_MS`,
+`DYNAMIC_CONFIG_POLL_INTERVAL_MS`, `S3_PRESIGNED_URL_EXPIRY_SECONDS`) were
+also entirely absent. Copying `.env.example` to `.env` — the standard
+first setup step — produced an opaque `Environment validation failed`
+error listing variables a new developer had never seen documented.
+
+## Fix
+
+- Regenerated `backend/.env.example` to include every key referenced by
+  the `envSchema` object in `config.ts`, grouped to match the schema's own
+  section comments.
+- The three required keys (`TWITTER_API_KEY`, `TWITTER_API_SECRET`,
+  `STRIPE_SECRET_KEY`) are called out explicitly as `REQUIRED` in their
+  section comments.
+- Removed a duplicate `NODE_ENV=development` line (it previously appeared
+  twice in the file) and consolidated it under a new `Server` section
+  alongside `BACKEND_PORT`.
+- Added `backend/scripts/check-env-example.js`, wired up as
+  `npm run check:env-example` in `backend/package.json`. It parses
+  `envSchema`'s declared keys out of `config.ts` and fails with a list of
+  any key missing from `.env.example` (commented-out optional overrides
+  still count as documented).
+
+## Verifying
+
+```
+cd backend
+npm run check:env-example
+```
+
+Currently reports: `OK — all 73 config.ts keys are documented in .env.example`.

--- a/docs/fixes/cors-nodeenv-key-mismatch.md
+++ b/docs/fixes/cors-nodeenv-key-mismatch.md
@@ -1,0 +1,42 @@
+# Fix: cors.ts's NODE_ENV keys ('local'/'staging'/'prod') never matched real NODE_ENV
+
+## Problem
+
+`backend/src/config/cors.ts` read `process.env.NODE_ENV ?? 'local'` and
+looked it up in `ALLOWED_ORIGINS`, whose keys were `local`, `staging`,
+`prod`. Every other part of the codebase — `config.ts`'s Zod schema,
+`csrfProtection.ts` — treats `NODE_ENV` as `development` / `test` /
+`production`. In a real production deployment `NODE_ENV=production`, so
+`ALLOWED_ORIGINS['production']` was `undefined` and the code silently fell
+back to `ALLOWED_ORIGINS.local` (`localhost:3000`/`5173`,
+`127.0.0.1:3000`).
+
+`SocketService.ts` uses `corsOptions.origin` for Socket.io whenever
+`config.NODE_ENV === 'production'` — so in real production, Socket.io
+rejected the actual frontend domain (`socialflow.app`) while incorrectly
+permitting localhost-originated connections.
+
+## Fix
+
+- Renamed the `ALLOWED_ORIGINS` keys to the real `NODE_ENV` values:
+  `development`, `test`, `production` (dropped `staging`, which was never
+  a reachable `NODE_ENV` value to begin with).
+- Updated the `env !== 'prod'` / fallback checks to use `'production'` and
+  `'development'` respectively.
+
+`corsOptions` still reads `process.env.NODE_ENV` directly rather than the
+validated `config.NODE_ENV` singleton, since `cors.ts` has no dependency
+on `config.ts` today and pulling one in was out of scope for this fix —
+the key values now simply match what `config.ts` validates against.
+
+## Tests
+
+Added `backend/src/config/__tests__/cors.test.ts`:
+
+- `NODE_ENV=production`: rejects `http://localhost:3000`, allows
+  `https://socialflow.app`
+- `NODE_ENV=development`: allows localhost, rejects the production origin
+- requests with no `Origin` header: rejected in production, allowed
+  otherwise
+
+Run: `npm test -- cors` (from `backend/`).

--- a/docs/fixes/org-role-privilege-escalation.md
+++ b/docs/fixes/org-role-privilege-escalation.md
@@ -1,0 +1,37 @@
+# Fix: org admin could grant/remove the owner role
+
+## Problem
+
+`backend/src/controllers/organization.ts`:
+
+- `addMember()` only checked that the caller was `owner` **or** `admin`
+  before creating a membership, but took the new member's `role` directly
+  from the request body with no cap relative to the caller's own role. An
+  admin could call the endpoint with `role: 'owner'` and grant themselves
+  (via an alt account) or an accomplice owner-level access.
+- `removeMember()` applied the same `owner`/`admin` check with no
+  protection for the org's owner(s), so any admin could delete the sole
+  owner and leave the organization without one.
+
+## Fix
+
+- `addMember()` now rejects (`403`) any request where `role === 'owner'`
+  unless the caller's own role is already `owner`.
+- `removeMember()` now looks up the target membership before deleting:
+  - If the target is an `owner`, only another `owner` may remove them
+    (`403 Only an owner can remove an owner` otherwise).
+  - If the target is the organization's last remaining `owner`, the
+    removal is rejected (`403 Cannot remove the last owner of an
+    organization`) regardless of who's asking.
+
+## Tests
+
+Added to `backend/src/__tests__/organizationController.test.ts`:
+
+- admin-role caller cannot add a member with `role=owner` (403, no create)
+- owner-role caller can still add a member with `role=owner`
+- sole owner of an org cannot be removed (403, no delete)
+- an owner can be removed once another owner remains
+- an admin-role caller cannot remove an owner (403, no delete)
+
+Run: `npm test -- organizationController` (from `backend/`).

--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { translationService } from '../services/TranslationService';
 import { useTranslation } from '../hooks/useTranslation';
-import { SupportedLanguage } from '@socialflow/shared';
+import { SupportedLanguage, TranslationProvider } from '@socialflow/shared';
 
 const MaterialIcon = ({ name, className }: { name: string; className?: string }) => (
   <span className={`material-symbols-outlined ${className}`}>{name}</span>
@@ -10,11 +10,15 @@ const MaterialIcon = ({ name, className }: { name: string; className?: string })
 export const TranslationPanel: React.FC = () => {
   const [inputText, setInputText] = useState('');
   const [selectedLanguages, setSelectedLanguages] = useState<string[]>(['es', 'fr']);
+  const [providers, setProviders] = useState<TranslationProvider[]>([]);
   const { result, loading, translate } = useTranslation();
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const languages = translationService.getSupportedLanguages();
-  const providers = translationService.getAvailableProviders();
+
+  useEffect(() => {
+    translationService.getAvailableProviders().then(setProviders);
+  }, []);
 
   /**
    * Debounced translate function - waits 400ms after user stops typing

--- a/src/services/TranslationService.ts
+++ b/src/services/TranslationService.ts
@@ -1,32 +1,29 @@
-import { GoogleGenAI } from '@google/genai';
 import {
   TranslationRequest,
   TranslationResult,
-  Translation,
-  PreservedElement,
   SupportedLanguage,
   TranslationProvider,
   BatchTranslationRequest,
   BatchTranslationResult,
 } from '@socialflow/shared';
+import { OpenAPI } from '../api/core/OpenAPI';
+import { request as apiRequest } from '../api/core/request';
 
 /**
  * TranslationService - Multi-language content translation
- * 
- * Features:
- * - Multiple provider support (DeepL, Google Translate, Gemini AI)
- * - Preserves URLs, mentions, hashtags, emojis
- * - Batch translation support
- * - Auto language detection
- * - Translation history
+ *
+ * All actual translation work (Gemini, DeepL, Google Translate) happens
+ * server-side via /api/v1/translation/*. Provider API keys must never be
+ * read from import.meta.env here — Vite inlines VITE_-prefixed vars into
+ * the shipped client bundle, which would leak paid keys to anyone who
+ * inspects it.
  */
 class TranslationService {
-  private genAI: GoogleGenAI | null = null;
-  private model: string | null = null;
   private readonly STORAGE_KEY = 'socialflow_translation_history';
   private readonly MAX_HISTORY = 50;
 
-  // Supported languages
+  // Supported languages (kept locally for instant UI rendering; the
+  // backend's /translation/languages endpoint is the source of truth)
   private readonly LANGUAGES: SupportedLanguage[] = [
     { code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸' },
     { code: 'es', name: 'Spanish', nativeName: 'Español', flag: '🇪🇸' },
@@ -50,286 +47,50 @@ class TranslationService {
     { code: 'cs', name: 'Czech', nativeName: 'Čeština', flag: '🇨🇿' },
   ];
 
-  constructor() {
-    this.initializeAI();
-  }
-
   /**
-   * Initialize Google Gemini AI
-   */
-  private initializeAI(): void {
-    const apiKey = import.meta.env.VITE_API_KEY;
-    
-    if (apiKey && apiKey !== 'your_gemini_api_key_here') {
-      try {
-        this.genAI = new GoogleGenAI({ apiKey });
-        this.model = 'gemini-2.5-flash';
-      } catch (error) {
-        console.warn('Failed to initialize Gemini AI:', error);
-      }
-    }
-  }
-
-  /**
-   * Translate content to multiple languages
+   * Translate content to multiple languages via the backend API
    */
   public async translate(request: TranslationRequest): Promise<TranslationResult> {
-    const {
-      text,
-      sourceLanguage,
-      targetLanguages,
-      preserveFormatting = true,
-      preserveHashtags = true,
-      preserveMentions = true,
-      preserveUrls = true,
-      preserveEmojis = true,
-    } = request;
-
-    // Extract and preserve special elements
-    const { processedText, preservedElements } = this.extractPreservedElements(text, {
-      preserveHashtags,
-      preserveMentions,
-      preserveUrls,
-      preserveEmojis,
+    const result = await apiRequest<TranslationResult>(OpenAPI, {
+      method: 'POST',
+      url: '/translation/translate',
+      body: request,
+      mediaType: 'application/json',
     });
 
-    // Detect source language if not provided
-    const detectedSourceLang = sourceLanguage || await this.detectLanguage(text);
-
-    // Translate to each target language
-    const translations: Translation[] = [];
-    
-    for (const targetLang of targetLanguages) {
-      if (targetLang === detectedSourceLang) {
-        // Skip if target is same as source
-        translations.push({
-          language: targetLang,
-          languageName: this.getLanguageName(targetLang),
-          text: text,
-          confidence: 1.0,
-        });
-        continue;
-      }
-
-      try {
-        const translatedText = await this.translateText(
-          processedText,
-          detectedSourceLang,
-          targetLang
-        );
-
-        // Restore preserved elements
-        const finalText = this.restorePreservedElements(translatedText, preservedElements);
-
-        translations.push({
-          language: targetLang,
-          languageName: this.getLanguageName(targetLang),
-          text: finalText,
-          confidence: 0.95,
-        });
-      } catch (error) {
-        console.error(`Failed to translate to ${targetLang}:`, error);
-        translations.push({
-          language: targetLang,
-          languageName: this.getLanguageName(targetLang),
-          text: text, // Fallback to original
-          confidence: 0,
-        });
-      }
-    }
-
-    const result: TranslationResult = {
-      originalText: text,
-      sourceLanguage: detectedSourceLang,
-      translations,
-      preservedElements,
-      provider: this.model ? 'gemini' : 'google',
-      timestamp: new Date(),
+    const normalized: TranslationResult = {
+      ...result,
+      timestamp: new Date(result.timestamp),
     };
 
-    // Save to history
-    this.saveToHistory(request, result);
+    this.saveToHistory(request, normalized);
 
-    return result;
+    return normalized;
   }
 
   /**
-   * Extract elements to preserve during translation
-   */
-  private extractPreservedElements(
-    text: string,
-    options: {
-      preserveHashtags: boolean;
-      preserveMentions: boolean;
-      preserveUrls: boolean;
-      preserveEmojis: boolean;
-    }
-  ): { processedText: string; preservedElements: PreservedElement[] } {
-    let processedText = text;
-    const preservedElements: PreservedElement[] = [];
-    let placeholderIndex = 0;
-
-    // Preserve URLs
-    if (options.preserveUrls) {
-      const urlRegex = /(https?:\/\/[^\s]+)/g;
-      processedText = processedText.replace(urlRegex, (match) => {
-        const placeholder = `__URL_${placeholderIndex++}__`;
-        preservedElements.push({ type: 'url', value: match, placeholder });
-        return placeholder;
-      });
-    }
-
-    // Preserve mentions (@username)
-    if (options.preserveMentions) {
-      const mentionRegex = /@(\w+)/g;
-      processedText = processedText.replace(mentionRegex, (match) => {
-        const placeholder = `__MENTION_${placeholderIndex++}__`;
-        preservedElements.push({ type: 'mention', value: match, placeholder });
-        return placeholder;
-      });
-    }
-
-    // Preserve hashtags
-    if (options.preserveHashtags) {
-      const hashtagRegex = /#(\w+)/g;
-      processedText = processedText.replace(hashtagRegex, (match) => {
-        const placeholder = `__HASHTAG_${placeholderIndex++}__`;
-        preservedElements.push({ type: 'hashtag', value: match, placeholder });
-        return placeholder;
-      });
-    }
-
-    // Preserve emojis
-    if (options.preserveEmojis) {
-      const emojiRegex = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/gu;
-      processedText = processedText.replace(emojiRegex, (match) => {
-        const placeholder = `__EMOJI_${placeholderIndex++}__`;
-        preservedElements.push({ type: 'emoji', value: match, placeholder });
-        return placeholder;
-      });
-    }
-
-    return { processedText, preservedElements };
-  }
-
-  /**
-   * Restore preserved elements after translation
-   */
-  private restorePreservedElements(
-    translatedText: string,
-    preservedElements: PreservedElement[]
-  ): string {
-    let restoredText = translatedText;
-
-    preservedElements.forEach(element => {
-      restoredText = restoredText.replace(element.placeholder, element.value);
-    });
-
-    return restoredText;
-  }
-
-  /**
-   * Translate text using available provider
-   */
-  private async translateText(
-    text: string,
-    sourceLang: string,
-    targetLang: string
-  ): Promise<string> {
-    // Try Gemini AI first if available
-    if (this.model) {
-      try {
-        return await this.translateWithGemini(text, sourceLang, targetLang);
-      } catch (error) {
-        console.warn('Gemini translation failed, using fallback:', error);
-      }
-    }
-
-    // Fallback to mock translation (in production, use DeepL or Google Translate API)
-    return this.mockTranslate(text, targetLang);
-  }
-
-  /**
-   * Translate using Google Gemini AI
-   */
-  private async translateWithGemini(
-    text: string,
-    sourceLang: string,
-    targetLang: string
-  ): Promise<string> {
-    if (!this.genAI || !this.model) {
-      throw new Error('Gemini AI not initialized');
-    }
-
-    const sourceLanguageName = this.getLanguageName(sourceLang);
-    const targetLanguageName = this.getLanguageName(targetLang);
-
-    const prompt = `Translate the following text from ${sourceLanguageName} to ${targetLanguageName}.
-Preserve the tone, style, and meaning. Only return the translated text, nothing else.
-
-Text to translate: "${text}"
-
-Translation:`;
-
-    const result = await this.genAI.models.generateContent({
-      model: this.model,
-      contents: prompt,
-    });
-    return (result.text ?? '').trim();
-  }
-
-  /**
-   * Mock translation (placeholder for DeepL/Google Translate API)
-   */
-  private mockTranslate(text: string, targetLang: string): string {
-    // In production, replace with actual API calls
-    const mockTranslations: Record<string, Record<string, string>> = {
-      es: {
-        'Hello world': 'Hola mundo',
-        'Thank you': 'Gracias',
-        'Good morning': 'Buenos días',
-      },
-      fr: {
-        'Hello world': 'Bonjour le monde',
-        'Thank you': 'Merci',
-        'Good morning': 'Bonjour',
-      },
-      de: {
-        'Hello world': 'Hallo Welt',
-        'Thank you': 'Danke',
-        'Good morning': 'Guten Morgen',
-      },
-    };
-
-    // Simple mock - in production, call actual API
-    return mockTranslations[targetLang]?.[text] || `[${targetLang.toUpperCase()}] ${text}`;
-  }
-
-  /**
-   * Detect source language
+   * Detect the source language of a text via the backend API
    */
   private async detectLanguage(text: string): Promise<string> {
-    // Simple heuristic-based detection
-    // In production, use proper language detection API
-    
-    // Check for common patterns
-    if (/[а-яА-Я]/.test(text)) return 'ru';
-    if (/[ა-ჰ]/.test(text)) return 'ka';
-    if (/[\u4e00-\u9fa5]/.test(text)) return 'zh';
-    if (/[\u3040-\u309f\u30a0-\u30ff]/.test(text)) return 'ja';
-    if (/[\uac00-\ud7af]/.test(text)) return 'ko';
-    if (/[\u0600-\u06ff]/.test(text)) return 'ar';
-    if (/[\u0900-\u097f]/.test(text)) return 'hi';
-    
-    // Default to English
-    return 'en';
+    try {
+      const result = await apiRequest<{ detectedLanguage: string }>(OpenAPI, {
+        method: 'POST',
+        url: '/translation/detect',
+        body: { text },
+        mediaType: 'application/json',
+      });
+      return result.detectedLanguage;
+    } catch (error) {
+      console.warn('Language detection failed, defaulting to English:', error);
+      return 'en';
+    }
   }
 
   /**
    * Get language name from code
    */
   private getLanguageName(code: string): string {
-    const language = this.LANGUAGES.find(lang => lang.code === code);
+    const language = this.LANGUAGES.find((lang) => lang.code === code);
     return language?.name || code.toUpperCase();
   }
 
@@ -341,156 +102,52 @@ Translation:`;
   }
 
   /**
-   * Get available translation providers
+   * Get available translation providers from the backend.
+   * The backend checks its own (server-side) env vars — no client-side
+   * key is ever read or exposed here.
    */
-  public getAvailableProviders(): TranslationProvider[] {
-    const providers: TranslationProvider[] = [];
-
-    // Gemini AI
-    if (this.model) {
-      providers.push({
-        name: 'Google Gemini AI',
-        available: true,
-        languages: this.LANGUAGES.map(l => l.code),
-        characterLimit: 30000,
+  public async getAvailableProviders(): Promise<TranslationProvider[]> {
+    try {
+      const result = await apiRequest<{ providers: TranslationProvider[] }>(OpenAPI, {
+        method: 'GET',
+        url: '/translation/providers',
       });
+      return result.providers;
+    } catch (error) {
+      console.warn('Failed to fetch translation providers:', error);
+      return [];
     }
-
-    // DeepL (mock - check for API key in production)
-    const deeplApiKey = import.meta.env.VITE_DEEPL_API_KEY;
-    providers.push({
-      name: 'DeepL',
-      available: !!deeplApiKey,
-      languages: ['en', 'es', 'fr', 'de', 'it', 'pt', 'ru', 'ja', 'zh', 'nl', 'pl'],
-      characterLimit: 5000,
-      rateLimit: 500000, // 500k characters/month free tier
-    });
-
-    // Google Translate (mock - check for API key in production)
-    const googleApiKey = import.meta.env.VITE_GOOGLE_TRANSLATE_API_KEY;
-    providers.push({
-      name: 'Google Translate',
-      available: !!googleApiKey,
-      languages: this.LANGUAGES.map(l => l.code),
-      characterLimit: 100000,
-    });
-
-    return providers;
   }
 
   /**
-   * Batch translate multiple texts
+   * Batch translate multiple texts via the backend API
    */
   public async batchTranslate(request: BatchTranslationRequest): Promise<BatchTranslationResult> {
     const startTime = Date.now();
-    const translations: TranslationResult[] = [];
-    let totalCharacters = 0;
 
-    for (const text of request.texts) {
-      totalCharacters += text.length;
-      
-      const result = await this.translate({
-        text,
-        sourceLanguage: request.sourceLanguage,
-        targetLanguages: request.targetLanguages,
-        preserveFormatting: request.preserveFormatting,
-      });
+    const result = await apiRequest<{ translations: TranslationResult[]; totalTexts: number; duration: number }>(
+      OpenAPI,
+      {
+        method: 'POST',
+        url: '/translation/batch',
+        body: {
+          texts: request.texts,
+          sourceLanguage: request.sourceLanguage,
+          targetLanguages: request.targetLanguages,
+        },
+        mediaType: 'application/json',
+      },
+    );
 
-      translations.push(result);
-    }
-
+    const totalCharacters = request.texts.reduce((sum, text) => sum + text.length, 0);
     const duration = Date.now() - startTime;
 
     return {
-      translations,
+      translations: result.translations.map((t) => ({ ...t, timestamp: new Date(t.timestamp) })),
       totalCharacters,
-      provider: this.model ? 'gemini' : 'google',
+      provider: 'backend',
       duration,
     };
-  }
-
-  /**
-   * Translate with DeepL API
-   */
-  public async translateWithDeepL(
-    text: string,
-    sourceLang: string,
-    targetLang: string
-  ): Promise<string> {
-    const apiKey = import.meta.env.VITE_DEEPL_API_KEY;
-    
-    if (!apiKey) {
-      throw new Error('DeepL API key not configured');
-    }
-
-    try {
-      const response = await fetch('https://api-free.deepl.com/v2/translate', {
-        method: 'POST',
-        headers: {
-          'Authorization': `DeepL-Auth-Key ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          text: [text],
-          source_lang: sourceLang.toUpperCase(),
-          target_lang: targetLang.toUpperCase(),
-          preserve_formatting: true,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`DeepL API error: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      return data.translations[0].text;
-    } catch (error) {
-      console.error('DeepL translation error:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Translate with Google Translate API
-   */
-  public async translateWithGoogle(
-    text: string,
-    sourceLang: string,
-    targetLang: string
-  ): Promise<string> {
-    const apiKey = import.meta.env.VITE_GOOGLE_TRANSLATE_API_KEY;
-    
-    if (!apiKey) {
-      throw new Error('Google Translate API key not configured');
-    }
-
-    try {
-      const response = await fetch(
-        `https://translation.googleapis.com/language/translate/v2?key=${apiKey}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            q: text,
-            source: sourceLang,
-            target: targetLang,
-            format: 'text',
-          }),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Google Translate API error: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      return data.data.translations[0].translatedText;
-    } catch (error) {
-      console.error('Google Translate error:', error);
-      throw error;
-    }
   }
 
   /**
@@ -500,7 +157,7 @@ Translation:`;
     try {
       const stored = localStorage.getItem(this.STORAGE_KEY);
       if (!stored) return [];
-      
+
       const history = JSON.parse(stored);
       return history.map((item: any) => ({
         ...item,
@@ -519,10 +176,10 @@ Translation:`;
     try {
       const history = this.getHistory();
       history.unshift(result);
-      
+
       // Keep only last MAX_HISTORY items
       const trimmedHistory = history.slice(0, this.MAX_HISTORY);
-      
+
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify(trimmedHistory));
     } catch (error) {
       console.error('Failed to save translation history:', error);
@@ -555,10 +212,10 @@ Translation:`;
   public estimateCost(
     text: string,
     targetLanguages: string[],
-    provider: 'deepl' | 'google'
+    provider: 'deepl' | 'google',
   ): { characters: number; estimatedCost: number; currency: string } {
     const characters = text.length * targetLanguages.length;
-    
+
     // Pricing estimates (as of 2024)
     const pricing = {
       deepl: 20 / 1000000, // $20 per 1M characters
@@ -581,7 +238,7 @@ Translation:`;
   public async validateTranslation(
     original: string,
     translated: string,
-    targetLang: string
+    targetLang: string,
   ): Promise<{ valid: boolean; issues: string[] }> {
     const issues: string[] = [];
 
@@ -614,7 +271,7 @@ Translation:`;
    * Get language by code
    */
   public getLanguage(code: string): SupportedLanguage | undefined {
-    return this.LANGUAGES.find(lang => lang.code === code);
+    return this.LANGUAGES.find((lang) => lang.code === code);
   }
 
   /**
@@ -622,10 +279,11 @@ Translation:`;
    */
   public searchLanguages(query: string): SupportedLanguage[] {
     const lowerQuery = query.toLowerCase();
-    return this.LANGUAGES.filter(lang =>
-      lang.name.toLowerCase().includes(lowerQuery) ||
-      lang.nativeName.toLowerCase().includes(lowerQuery) ||
-      lang.code.toLowerCase().includes(lowerQuery)
+    return this.LANGUAGES.filter(
+      (lang) =>
+        lang.name.toLowerCase().includes(lowerQuery) ||
+        lang.nativeName.toLowerCase().includes(lowerQuery) ||
+        lang.code.toLowerCase().includes(lowerQuery),
     );
   }
 }


### PR DESCRIPTION
Closes #1317 
Closes #1318 
Closes #1319 
Closes #1320

1. 4a66565 — org admins can no longer grant themselves/others the owner role, and the last owner of an org can't be removed (backend/src/controllers/organization.ts + tests + docs/fixes/org-role-privilege-escalation.md)
2. 40f26a7 — backend/.env.example now documents all 73 keys read by config.ts (previously missing ~38, including 3 required-to-boot keys), plus a check:env-example script (docs/fixes/backend-env-example-completeness.md)
3. 07dc578 — backend/src/config/cors.ts now keys ALLOWED_ORIGINS by real NODE_ENV values instead of local/staging/prod, fixing a silent production→localhost CORS fallback, plus tests (docs/fixes/cors-nodeenv-key-mismatch.md)
4. 2253028 — frontend src/services/TranslationService.ts no longer reads VITE_-prefixed provider API keys or calls Gemini/DeepL/Google Translate directly; all translation now routes through the backend /api/v1/translation/* endpoints