### PR TITLE
Fix/config analytics audit token encryption

### DIFF
--- a/backend/src/__tests__/facebookTokenRefreshJob.test.ts
+++ b/backend/src/__tests__/facebookTokenRefreshJob.test.ts
@@ -43,6 +43,7 @@ jest.mock('../services/FacebookService', () => ({
 }));
 
 import { startFacebookTokenRefreshJob, FACEBOOK_TOKEN_KEY } from '../jobs/facebookTokenRefreshJob';
+import { encryptToken, decryptToken } from '../utils/tokenEncryption';
 
 const NOW = Date.now();
 const SOON = NOW + 5 * 24 * 60 * 60 * 1000;   // 5 days — within 10-day threshold
@@ -67,7 +68,7 @@ function setupScan(keys: string[]) {
 describe('facebookTokenRefreshJob', () => {
   it('refreshes tokens expiring within 10 days', async () => {
     const key = FACEBOOK_TOKEN_KEY('user-1');
-    hashStore[key] = { accessToken: 'old-token', expiresAt: String(SOON) };
+    hashStore[key] = { accessToken: encryptToken('old-token'), expiresAt: String(SOON) };
     setupScan([key]);
 
     const newExpiry = NOW + 60 * 86400_000;
@@ -75,17 +76,38 @@ describe('facebookTokenRefreshJob', () => {
 
     const result = await capturedProcessor!({ id: 'job-1', data: {} });
 
+    // The job must decrypt the stored token before using it...
     expect(mockGetLongLivedUserToken).toHaveBeenCalledWith('old-token');
-    expect(mockRedis.hset).toHaveBeenCalledWith(key, {
-      accessToken: 'new-token',
-      expiresAt: String(newExpiry),
-    });
+
+    // ...and re-encrypt the refreshed token before writing it back.
+    const [, hsetData] = mockRedis.hset.mock.calls.find(([k]) => k === key)!;
+    expect(hsetData.expiresAt).toBe(String(newExpiry));
+    expect(hsetData.accessToken).not.toBe('new-token');
+    expect(decryptToken(hsetData.accessToken)).toBe('new-token');
     expect(result).toEqual({ refreshed: 1, failed: 0 });
+  });
+
+  it('stores the raw Redis hash value encrypted, never as the plaintext token', async () => {
+    const key = FACEBOOK_TOKEN_KEY('user-encryption-check');
+    hashStore[key] = { accessToken: encryptToken('super-secret-fb-token'), expiresAt: String(SOON) };
+    setupScan([key]);
+
+    mockGetLongLivedUserToken.mockResolvedValueOnce({
+      accessToken: 'refreshed-secret-token',
+      expiresAt: NOW + 60 * 86400_000,
+    });
+
+    await capturedProcessor!({ id: 'job-encryption-check', data: {} });
+
+    const rawValueInRedis = hashStore[key].accessToken;
+    expect(rawValueInRedis).not.toBe('refreshed-secret-token');
+    expect(rawValueInRedis).not.toContain('refreshed-secret-token');
+    expect(decryptToken(rawValueInRedis)).toBe('refreshed-secret-token');
   });
 
   it('skips tokens not expiring within 10 days', async () => {
     const key = FACEBOOK_TOKEN_KEY('user-2');
-    hashStore[key] = { accessToken: 'valid-token', expiresAt: String(LATER) };
+    hashStore[key] = { accessToken: encryptToken('valid-token'), expiresAt: String(LATER) };
     setupScan([key]);
 
     const result = await capturedProcessor!({ id: 'job-2', data: {} });
@@ -96,7 +118,7 @@ describe('facebookTokenRefreshJob', () => {
 
   it('counts failures without throwing when refresh fails', async () => {
     const key = FACEBOOK_TOKEN_KEY('user-3');
-    hashStore[key] = { accessToken: 'expiring', expiresAt: String(SOON) };
+    hashStore[key] = { accessToken: encryptToken('expiring'), expiresAt: String(SOON) };
     setupScan([key]);
 
     mockGetLongLivedUserToken.mockRejectedValueOnce(new Error('Facebook API error'));
@@ -106,11 +128,22 @@ describe('facebookTokenRefreshJob', () => {
     expect(result).toEqual({ refreshed: 0, failed: 1 });
   });
 
+  it('counts a decrypt failure as a failure without crashing the job', async () => {
+    const key = FACEBOOK_TOKEN_KEY('user-corrupt');
+    hashStore[key] = { accessToken: 'not-a-valid-encrypted-payload', expiresAt: String(SOON) };
+    setupScan([key]);
+
+    const result = await capturedProcessor!({ id: 'job-corrupt', data: {} });
+
+    expect(mockGetLongLivedUserToken).not.toHaveBeenCalled();
+    expect(result).toEqual({ refreshed: 0, failed: 1 });
+  });
+
   it('handles mixed success and failure across multiple tokens', async () => {
     const key1 = FACEBOOK_TOKEN_KEY('user-4');
     const key2 = FACEBOOK_TOKEN_KEY('user-5');
-    hashStore[key1] = { accessToken: 'tok1', expiresAt: String(SOON) };
-    hashStore[key2] = { accessToken: 'tok2', expiresAt: String(SOON) };
+    hashStore[key1] = { accessToken: encryptToken('tok1'), expiresAt: String(SOON) };
+    hashStore[key2] = { accessToken: encryptToken('tok2'), expiresAt: String(SOON) };
     setupScan([key1, key2]);
 
     mockGetLongLivedUserToken
@@ -132,7 +165,7 @@ describe('facebookTokenRefreshJob', () => {
 
   it('marks token as disconnected and does not count revocation as failure', async () => {
     const key = FACEBOOK_TOKEN_KEY('user-revoked');
-    hashStore[key] = { accessToken: 'dead-token', expiresAt: String(SOON) };
+    hashStore[key] = { accessToken: encryptToken('dead-token'), expiresAt: String(SOON) };
     setupScan([key]);
 
     // Facebook error code 190 + subcode 458 = user removed app
@@ -161,7 +194,7 @@ describe('facebookTokenRefreshJob', () => {
       mockGetLongLivedUserToken.mockReset();
 
       const key = FACEBOOK_TOKEN_KEY(`user-sub-${subcode}`);
-      hashStore[key] = { accessToken: 'tok', expiresAt: String(SOON) };
+      hashStore[key] = { accessToken: encryptToken('tok'), expiresAt: String(SOON) };
       setupScan([key]);
 
       mockGetLongLivedUserToken.mockRejectedValueOnce(
@@ -177,7 +210,7 @@ describe('facebookTokenRefreshJob', () => {
 
   it('counts a non-revocation Facebook error as a retryable failure', async () => {
     const key = FACEBOOK_TOKEN_KEY('user-apierr');
-    hashStore[key] = { accessToken: 'tok', expiresAt: String(SOON) };
+    hashStore[key] = { accessToken: encryptToken('tok'), expiresAt: String(SOON) };
     setupScan([key]);
 
     // code 190 but subcode not in REVOCATION_SUBCODES (999 is not revocation)
@@ -207,8 +240,8 @@ describe('facebookTokenRefreshJob', () => {
   it('processes all keys across multiple Redis SCAN pages', async () => {
     const key1 = FACEBOOK_TOKEN_KEY('page-user-1');
     const key2 = FACEBOOK_TOKEN_KEY('page-user-2');
-    hashStore[key1] = { accessToken: 'tok1', expiresAt: String(SOON) };
-    hashStore[key2] = { accessToken: 'tok2', expiresAt: String(SOON) };
+    hashStore[key1] = { accessToken: encryptToken('tok1'), expiresAt: String(SOON) };
+    hashStore[key2] = { accessToken: encryptToken('tok2'), expiresAt: String(SOON) };
 
     // First SCAN call returns cursor '42' (not '0') to indicate more pages
     mockRedis.scan
@@ -231,9 +264,9 @@ describe('facebookTokenRefreshJob', () => {
     const keyOk = FACEBOOK_TOKEN_KEY('partial-ok');
     const keyFailed = FACEBOOK_TOKEN_KEY('partial-failed');
 
-    hashStore[keyRevoked] = { accessToken: 'dead', expiresAt: String(SOON) };
-    hashStore[keyOk] = { accessToken: 'live', expiresAt: String(SOON) };
-    hashStore[keyFailed] = { accessToken: 'err', expiresAt: String(SOON) };
+    hashStore[keyRevoked] = { accessToken: encryptToken('dead'), expiresAt: String(SOON) };
+    hashStore[keyOk] = { accessToken: encryptToken('live'), expiresAt: String(SOON) };
+    hashStore[keyFailed] = { accessToken: encryptToken('err'), expiresAt: String(SOON) };
     setupScan([keyRevoked, keyOk, keyFailed]);
 
     const newExpiry = NOW + 60 * 86400_000;

--- a/backend/src/jobs/facebookTokenRefreshJob.ts
+++ b/backend/src/jobs/facebookTokenRefreshJob.ts
@@ -3,6 +3,7 @@ import Redis from 'ioredis';
 import { getRedisConnection } from '../config/runtime';
 import { createLogger } from '../lib/logger';
 import { facebookService } from '../services/FacebookService';
+import { encryptToken, decryptToken } from '../utils/tokenEncryption';
 
 const logger = createLogger('facebook-token-refresh-job');
 
@@ -57,7 +58,8 @@ const REFRESH_THRESHOLD_DAYS = 10;
 
 /**
  * Redis key pattern for stored Facebook long-lived tokens.
- * Hash fields: accessToken, expiresAt (unix ms as string)
+ * Hash fields: accessToken (AES-256-GCM encrypted, see utils/tokenEncryption),
+ * expiresAt (unix ms as string)
  *
  * Key: facebook:token:<userId>
  */
@@ -112,10 +114,21 @@ export const startFacebookTokenRefreshJob = async (): Promise<void> => {
           const expiresAt = Number(data.expiresAt);
           if (expiresAt > expiryBefore) continue; // not expiring soon
 
+          let currentAccessToken: string;
           try {
-            const result = await facebookService.getLongLivedUserToken(data.accessToken);
+            currentAccessToken = decryptToken(data.accessToken);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logger.error('Failed to decrypt stored Facebook token', { key, error: message });
+            errors.push({ key, error: 'decrypt_failed' });
+            failed++;
+            continue;
+          }
+
+          try {
+            const result = await facebookService.getLongLivedUserToken(currentAccessToken);
             await redis.hset(key, {
-              accessToken: result.accessToken,
+              accessToken: encryptToken(result.accessToken),
               expiresAt: String(result.expiresAt),
             });
             // Extend Redis TTL to match the new token lifetime (60 days + buffer)

--- a/backend/src/middleware/__tests__/auditRoleAndOrgRoutes.test.ts
+++ b/backend/src/middleware/__tests__/auditRoleAndOrgRoutes.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration tests: role assignment and org membership changes must
+ * produce an audit log entry via the shared audit() middleware. Previously
+ * audit() was only applied to the health-config-update route, so these
+ * security-sensitive authorization changes left no forensic trail.
+ */
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    auditLog: { create: jest.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { Response } from 'express';
+import { audit } from '../audit';
+import { AuditLogStore } from '../../models/AuditLog';
+import { AuthRequest } from '../authenticate';
+
+function makeReq(overrides: Partial<AuthRequest> = {}): AuthRequest {
+  return {
+    params: {},
+    body: {},
+    query: {},
+    headers: {},
+    user: { id: 'actor-1' },
+    ...overrides,
+  } as unknown as AuthRequest;
+}
+
+function makeRes(statusCode = 200): Response & { emitFinish: () => void } {
+  const listeners: Array<() => void> = [];
+  return {
+    statusCode,
+    on: (event: string, cb: () => void) => {
+      if (event === 'finish') listeners.push(cb);
+    },
+    emitFinish: () => listeners.forEach((cb) => cb()),
+  } as unknown as Response & { emitFinish: () => void };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe('audit() applied to role assignment and organization membership routes', () => {
+  it('logs an audit entry after a successful role assignment', async () => {
+    const req = makeReq({ user: { id: 'admin-1' }, body: { userId: 'target-1', role: 'editor' } });
+    const res = makeRes(200);
+    const middleware = audit(
+      'role:assign',
+      'user',
+      (r) => (r.body as { userId?: string }).userId,
+      (r) => ({ role: (r.body as { role?: string }).role }),
+    );
+
+    middleware(req, res, () => {});
+    res.emitFinish();
+    await flush();
+
+    const [entry] = AuditLogStore.forActor('admin-1');
+    expect(entry).toBeDefined();
+    expect(entry.action).toBe('role:assign');
+    expect(entry.resourceType).toBe('user');
+    expect(entry.resourceId).toBe('target-1');
+    expect(entry.metadata).toEqual({ role: 'editor' });
+  });
+
+  it('logs an audit entry after a successful role revocation', async () => {
+    const req = makeReq({ user: { id: 'admin-2' }, params: { userId: 'target-2' } });
+    const res = makeRes(204);
+    const middleware = audit('role:revoke', 'user', (r) => r.params.userId);
+
+    middleware(req, res, () => {});
+    res.emitFinish();
+    await flush();
+
+    const [entry] = AuditLogStore.forActor('admin-2');
+    expect(entry.action).toBe('role:revoke');
+    expect(entry.resourceId).toBe('target-2');
+  });
+
+  it('logs an audit entry after addMember succeeds', async () => {
+    const req = makeReq({
+      user: { id: 'owner-1' },
+      params: { orgId: 'org-1' },
+      body: { userId: 'new-member-1', role: 'admin' },
+    });
+    const res = makeRes(201);
+    const middleware = audit(
+      'org:member:invite',
+      'organization-member',
+      (r) => (r.body as { userId?: string }).userId,
+      (r) => ({ orgId: r.params.orgId, role: (r.body as { role?: string }).role }),
+    );
+
+    middleware(req, res, () => {});
+    res.emitFinish();
+    await flush();
+
+    const [entry] = AuditLogStore.forActor('owner-1');
+    expect(entry.action).toBe('org:member:invite');
+    expect(entry.resourceId).toBe('new-member-1');
+    expect(entry.metadata).toEqual(expect.objectContaining({ orgId: 'org-1', role: 'admin' }));
+  });
+
+  it('logs an audit entry after removeMember succeeds', async () => {
+    const req = makeReq({
+      user: { id: 'owner-2' },
+      params: { orgId: 'org-2', userId: 'removed-member-1' },
+    });
+    const res = makeRes(204);
+    const middleware = audit('org:member:remove', 'organization-member', (r) => r.params.userId, (r) => ({
+      orgId: r.params.orgId,
+    }));
+
+    middleware(req, res, () => {});
+    res.emitFinish();
+    await flush();
+
+    const [entry] = AuditLogStore.forActor('owner-2');
+    expect(entry.action).toBe('org:member:remove');
+    expect(entry.resourceId).toBe('removed-member-1');
+  });
+
+  it('does not log when the response is not a 2xx', async () => {
+    const req = makeReq({ user: { id: 'actor-err' }, params: { userId: 'target-err' } });
+    const res = makeRes(403);
+    const middleware = audit('role:revoke', 'user', (r) => r.params.userId);
+
+    middleware(req, res, () => {});
+    res.emitFinish();
+    await flush();
+
+    expect(AuditLogStore.forActor('actor-err')).toHaveLength(0);
+  });
+});

--- a/backend/src/routes/organizations.ts
+++ b/backend/src/routes/organizations.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { authenticate as authMiddleware } from '../middleware/authenticate';
+import { audit } from '../middleware/audit';
 import {
   createOrganization,
   listOrganizations,
@@ -126,7 +127,16 @@ router.get('/:orgId', getOrganization);
  *       404:
  *         description: Organization or user not found
  */
-router.post('/:orgId/members', addMember);
+router.post(
+  '/:orgId/members',
+  audit(
+    'org:member:invite',
+    'organization-member',
+    (req) => req.body?.userId,
+    (req) => ({ orgId: req.params.orgId, role: req.body?.role }),
+  ),
+  addMember,
+);
 
 /**
  * @openapi
@@ -152,6 +162,15 @@ router.post('/:orgId/members', addMember);
  *       404:
  *         description: Not found
  */
-router.delete('/:orgId/members/:userId', removeMember);
+router.delete(
+  '/:orgId/members/:userId',
+  audit(
+    'org:member:remove',
+    'organization-member',
+    (req) => req.params.userId,
+    (req) => ({ orgId: req.params.orgId }),
+  ),
+  removeMember,
+);
 
 export default router;

--- a/backend/src/routes/roles.ts
+++ b/backend/src/routes/roles.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authenticate as authMiddleware, AuthRequest } from '../middleware/authenticate';
 import { checkPermission } from '../middleware/checkPermission';
 import { validate } from '../middleware/validate';
+import { audit } from '../middleware/audit';
 import { ROLES, PERMISSIONS, RoleStore, RoleName } from '../models/Role';
 import { UserStore } from '../models/User';
 
@@ -110,6 +111,12 @@ router.post(
   authMiddleware,
   checkPermission('roles:manage'),
   validate(assignSchema),
+  audit(
+    'role:assign',
+    'user',
+    (req) => (req.body as { userId?: string })?.userId,
+    (req) => ({ role: (req.body as { role?: string })?.role }),
+  ),
   (req: Request, res: Response) => {
     const { userId, role } = req.body as { userId: string; role: RoleName };
     if (!UserStore.findById(userId)) {
@@ -144,6 +151,7 @@ router.delete(
   '/assign/:userId',
   authMiddleware,
   checkPermission('roles:manage'),
+  audit('role:revoke', 'user', (req) => req.params.userId),
   (req: Request, res: Response) => {
     const { userId } = req.params;
     if (!RoleStore.getRoleName(userId)) {

--- a/backend/src/utils/__tests__/tokenEncryption.test.ts
+++ b/backend/src/utils/__tests__/tokenEncryption.test.ts
@@ -1,0 +1,33 @@
+import { encryptToken, decryptToken } from '../tokenEncryption';
+
+describe('tokenEncryption', () => {
+  it('round-trips a plaintext token', () => {
+    const ciphertext = encryptToken('my-facebook-access-token');
+    expect(decryptToken(ciphertext)).toBe('my-facebook-access-token');
+  });
+
+  it('never returns the plaintext token as-is', () => {
+    const ciphertext = encryptToken('super-secret-token');
+    expect(ciphertext).not.toBe('super-secret-token');
+    expect(ciphertext).not.toContain('super-secret-token');
+  });
+
+  it('produces different ciphertext for the same plaintext (random IV)', () => {
+    const a = encryptToken('same-token');
+    const b = encryptToken('same-token');
+    expect(a).not.toBe(b);
+    expect(decryptToken(a)).toBe('same-token');
+    expect(decryptToken(b)).toBe('same-token');
+  });
+
+  it('throws on a tampered payload', () => {
+    const ciphertext = encryptToken('token-to-tamper');
+    const [iv, tag, data] = ciphertext.split(':');
+    const tampered = [iv, tag, data.slice(0, -2) + 'AA'].join(':');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('throws on a malformed payload', () => {
+    expect(() => decryptToken('not-encrypted')).toThrow();
+  });
+});

--- a/backend/src/utils/tokenEncryption.ts
+++ b/backend/src/utils/tokenEncryption.ts
@@ -1,0 +1,46 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
+import { config } from '../config/config';
+
+/**
+ * AES-256-GCM encryption for OAuth tokens at rest (e.g. Facebook long-lived
+ * access tokens stored in Redis), consistent with how other sensitive
+ * secrets are encrypted in this codebase. The key is derived from
+ * JWT_SECRET so no additional secret needs to be provisioned.
+ */
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const KEY_LENGTH = 32;
+
+let cachedKey: Buffer | null = null;
+function getKey(): Buffer {
+  if (!cachedKey) {
+    cachedKey = scryptSync(config.JWT_SECRET, 'socialflow:token-encryption', KEY_LENGTH);
+  }
+  return cachedKey;
+}
+
+/** Encrypts a plaintext token into a `iv:authTag:ciphertext` base64 payload. */
+export function encryptToken(plaintext: string): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, getKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv.toString('base64'), authTag.toString('base64'), ciphertext.toString('base64')].join(':');
+}
+
+/** Decrypts a payload produced by {@link encryptToken}. */
+export function decryptToken(payload: string): string {
+  const parts = payload.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted token payload');
+  }
+  const [ivB64, authTagB64, ciphertextB64] = parts;
+  const iv = Buffer.from(ivB64, 'base64');
+  const authTag = Buffer.from(authTagB64, 'base64');
+  const ciphertext = Buffer.from(ciphertextB64, 'base64');
+
+  const decipher = createDecipheriv(ALGORITHM, getKey(), iv);
+  decipher.setAuthTag(authTag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}

--- a/src/api/__tests__/configure.test.ts
+++ b/src/api/__tests__/configure.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Integration test for configureApi(): asserts that once the generated
+ * OpenAPI client is configured with a base URL and token getter, a real
+ * generated service call (WebhooksService.getWebhooks) actually sends the
+ * configured Authorization header to the configured base URL.
+ */
+import { configureApi } from '../configure';
+import { OpenAPI } from '../core/OpenAPI';
+import { WebhooksService } from '../services/WebhooksService';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    url: '',
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('configureApi', () => {
+  afterEach(() => {
+    mockFetch.mockReset();
+    OpenAPI.BASE = '/api/v1';
+    OpenAPI.TOKEN = undefined;
+  });
+
+  it('wires OpenAPI.BASE and OpenAPI.TOKEN from the provided options', () => {
+    configureApi({ baseUrl: 'https://api.example.com', getToken: () => 'abc123' });
+
+    expect(OpenAPI.BASE).toBe('https://api.example.com');
+    expect(typeof OpenAPI.TOKEN).toBe('function');
+  });
+
+  it('sends the configured Authorization header on a real generated service call', async () => {
+    configureApi({
+      baseUrl: 'https://api.example.com',
+      getToken: () => 'test-access-token',
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+    await WebhooksService.getWebhooks();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.example.com/webhooks');
+    const headers = init.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer test-access-token');
+  });
+
+  it('omits the Authorization header when no token is available', async () => {
+    configureApi({ baseUrl: 'https://api.example.com', getToken: () => undefined });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+    await WebhooksService.getWebhooks();
+
+    const [, init] = mockFetch.mock.calls[0];
+    const headers = init.headers as Headers;
+    expect(headers.get('Authorization')).toBeNull();
+  });
+});

--- a/src/components/WebhookManager.tsx
+++ b/src/components/WebhookManager.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useReducer, useState } from 'react';
 import type { WebhookDelivery, WebhookSubscription } from '../api/models';
+import { WebhooksService as GeneratedWebhooksService } from '../api/services/WebhooksService';
 
 // Event types sourced from src/schemas/webhooks.ts (frontend mirror)
 type WebhookEventType =
@@ -19,80 +20,29 @@ const SUPPORTED_EVENTS: WebhookEventType[] = [
   'system.health_check',
 ];
 
-// ── Frontend-only webhook store ───────────────────────────────────────────────
-// The generated WebhooksService talks to a backend that is not running in this
-// demo. To keep every button functional in frontend-only mode, we back the
-// manager with an in-memory store that mirrors the same async surface.
-
-const uid = (): string =>
-  (crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)).replace(/-/g, '');
-
-const store: {
-  webhooks: WebhookSubscription[];
-  deliveries: Record<string, WebhookDelivery[]>;
-} = {
-  webhooks: [
-    {
-      id: uid(),
-      url: 'https://hooks.example.com/socialflow',
-      events: ['post.published', 'post.failed'],
-      isActive: true,
-      createdAt: new Date().toISOString(),
-    },
-  ],
-  deliveries: {},
-};
-
-const delay = (ms = 250) => new Promise((r) => setTimeout(r, ms));
-
-function makeDelivery(eventType: WebhookEventType): WebhookDelivery {
-  return {
-    id: uid(),
-    eventType,
-    status: 'success',
-    attempts: 1,
-    responseStatus: 200,
-    createdAt: new Date().toISOString(),
-  };
-}
+// ── Real backend-backed webhook client ────────────────────────────────────────
+// Talks to the generated OpenAPI client (src/api/services/WebhooksService),
+// which is authenticated via configureApi() at app startup (see src/main.tsx).
 
 const WebhooksService = {
   async listWebhooks(): Promise<WebhookSubscription[]> {
-    await delay();
-    return [...store.webhooks];
+    return GeneratedWebhooksService.getWebhooks();
   },
   async createWebhook(input: { url: string; secret: string; events: WebhookEventType[] }): Promise<WebhookSubscription> {
-    await delay();
-    const created: WebhookSubscription = {
-      id: uid(),
-      url: input.url,
-      events: input.events,
-      isActive: true,
-      createdAt: new Date().toISOString(),
-    };
-    store.webhooks = [...store.webhooks, created];
-    return created;
+    return GeneratedWebhooksService.postWebhooks({ requestBody: input });
   },
   async deleteWebhook(id: string): Promise<void> {
-    await delay();
-    store.webhooks = store.webhooks.filter((w) => w.id !== id);
-    delete store.deliveries[id];
+    await GeneratedWebhooksService.deleteWebhooks({ id });
   },
   async testWebhook(id: string, input: { eventType: WebhookEventType }): Promise<{ message: string }> {
-    await delay();
-    const delivery = makeDelivery(input.eventType);
-    store.deliveries[id] = [delivery, ...(store.deliveries[id] ?? [])];
-    return { message: `Test "${input.eventType}" delivered (200 OK).` };
+    const result = await GeneratedWebhooksService.postWebhooksTest({ id, requestBody: input });
+    return { message: result?.message ?? `Test "${input.eventType}" sent.` };
   },
   async listDeliveries(id: string): Promise<WebhookDelivery[]> {
-    await delay();
-    return [...(store.deliveries[id] ?? [])];
+    return GeneratedWebhooksService.getWebhooksDeliveries({ id });
   },
-  async replayDelivery(id: string, _deliveryId: string): Promise<void> {
-    await delay();
-    const original = (store.deliveries[id] ?? []).find((d) => d.id === _deliveryId);
-    const replayed = makeDelivery((original?.eventType as WebhookEventType) ?? 'post.published');
-    store.deliveries[id] = [replayed, ...(store.deliveries[id] ?? [])];
+  async replayDelivery(id: string, deliveryId: string): Promise<void> {
+    await GeneratedWebhooksService.postWebhooksDeliveriesReplay({ id, deliveryId });
   },
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,16 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import { AuthProvider } from './contexts/AuthContext'
 import { ToastProvider } from './contexts/ToastContext'
+import { configureApi } from './api/configure'
 import './index.css'
+
+// Wire the generated OpenAPI client to a real base URL and the stored access
+// token once, at app startup, so every src/api/services/* client call is
+// authenticated and points at the real backend instead of being dead code.
+configureApi({
+  baseUrl: import.meta.env.VITE_API_URL,
+  getToken: () => localStorage.getItem('sf_auth_token') ?? undefined,
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/pages/AnalyticsPage.tsx
+++ b/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ResponsiveContainer,
   AreaChart,
@@ -15,7 +15,8 @@ import {
 } from 'recharts';
 import { GlassCard } from '../components/ui/GlassCard';
 import { StatBadge } from '../components/ui/StatBadge';
-import { buildDailySeries, platformShare } from '../lib/sampleAnalytics';
+import { buildDailySeries, platformShare as samplePlatformShare, DailyPoint, PlatformShare } from '../lib/sampleAnalytics';
+import { AnalyticsService } from '../api/services/AnalyticsService';
 
 const tooltipStyle = {
   background: 'rgba(15,15,22,0.95)',
@@ -25,8 +26,53 @@ const tooltipStyle = {
   color: '#fff',
 };
 
+// Explicit demo/offline mode — the only case sample data is allowed to show
+// without a backend call ever having been attempted.
+const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
+
+function isRealAnalyticsResponse(
+  data: unknown,
+): data is { series: DailyPoint[]; platformShare: PlatformShare[] } {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    Array.isArray((data as { series?: unknown }).series) &&
+    ((data as { series: DailyPoint[] }).series.length > 0) &&
+    Array.isArray((data as { platformShare?: unknown }).platformShare)
+  );
+}
+
 export const AnalyticsPage: React.FC = () => {
-  const series = useMemo(() => buildDailySeries(4), []);
+  const [series, setSeries] = useState<DailyPoint[]>(() => buildDailySeries(4));
+  const [platformShare, setPlatformShare] = useState<PlatformShare[]>(samplePlatformShare);
+  const [isSampleData, setIsSampleData] = useState(true);
+
+  useEffect(() => {
+    if (DEMO_MODE) {
+      // Documented demo/offline mode: sample data is shown intentionally.
+      setIsSampleData(true);
+      return;
+    }
+
+    let cancelled = false;
+    AnalyticsService.getAnalytics({})
+      .then((data) => {
+        if (cancelled) return;
+        if (isRealAnalyticsResponse(data)) {
+          setSeries(data.series);
+          setPlatformShare(data.platformShare);
+          setIsSampleData(false);
+        }
+      })
+      .catch(() => {
+        // Backend unreachable or not yet returning real analytics — keep
+        // showing sample data, clearly labeled below, instead of failing.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const totalReach = series.reduce((a, c) => a + c.reach, 0);
   const totalEngagement = series.reduce((a, c) => a + c.engagement, 0);
@@ -35,6 +81,14 @@ export const AnalyticsPage: React.FC = () => {
 
   return (
     <div className="space-y-10 pb-20">
+      {isSampleData && (
+        <div
+          role="status"
+          className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-xs font-semibold tracking-wide text-yellow-300"
+        >
+          Showing sample data — connect an account or wait for real analytics to sync.
+        </div>
+      )}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
         <StatBadge label="28-Day Reach" value={`${(totalReach / 1000).toFixed(0)}k`} icon="visibility" color="blue" trend="up" />
         <StatBadge label="Engagement" value={`${(totalEngagement / 1000).toFixed(1)}k`} icon="favorite" color="purple" trend="up" />

--- a/src/pages/README.analytics-real-data.md
+++ b/src/pages/README.analytics-real-data.md
@@ -1,0 +1,35 @@
+# AnalyticsPage: real data with sample-data fallback
+
+## Problem
+
+`AnalyticsPage` rendered its entire view (28-day reach, engagement,
+follower gain, engagement rate, and all charts) from
+`buildDailySeries`/`platformShare` in `src/lib/sampleAnalytics.ts`, a seeded
+pseudo-random generator. There was no code path calling a real backend
+analytics endpoint, so every user saw identical fabricated numbers with no
+indication the data wasn't real.
+
+## What changed
+
+- `AnalyticsPage` now calls `AnalyticsService.getAnalytics({})` (the
+  generated client, reachable now that `configureApi()` is wired up — see
+  the companion fix in `src/main.tsx`) once on mount.
+- If the response looks like real data (a non-empty `series` array and a
+  `platformShare` array), it replaces the sample data used for the charts
+  and stat tiles.
+- If the call fails, returns an unexpected shape, or the app is explicitly
+  running with `VITE_DEMO_MODE=true`, the page falls back to the existing
+  sample generator instead of breaking.
+- Whenever sample data is being shown (initial state, fallback, or demo
+  mode), a visible `role="status"` banner reading "Showing sample data —
+  connect an account or wait for real analytics to sync." appears above the
+  charts. The banner disappears once real data loads successfully.
+
+## Tests
+
+`src/pages/__tests__/AnalyticsPage.test.tsx` covers:
+- The real analytics API is called on mount.
+- Real data is rendered and the sample-data indicator is hidden when the
+  API call succeeds.
+- The page falls back to sample data and shows the visible indicator when
+  the API call fails.

--- a/src/pages/__tests__/AnalyticsPage.test.tsx
+++ b/src/pages/__tests__/AnalyticsPage.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * AnalyticsPage tests: asserts it calls the real analytics API when
+ * configured, uses the response when it looks real, and falls back to
+ * sample data (with a visible indicator) when the backend call fails.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AnalyticsPage } from '../AnalyticsPage';
+import { AnalyticsService } from '../../api/services/AnalyticsService';
+
+jest.mock('../../api/services/AnalyticsService', () => ({
+  AnalyticsService: {
+    getAnalytics: jest.fn(),
+  },
+}));
+
+const mockGetAnalytics = AnalyticsService.getAnalytics as jest.Mock;
+
+describe('AnalyticsPage', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls the real analytics API on mount', async () => {
+    mockGetAnalytics.mockResolvedValueOnce({
+      series: [
+        { day: 'Mon W1', reach: 1000, engagement: 50, followers: 100 },
+        { day: 'Tue W1', reach: 1200, engagement: 60, followers: 120 },
+      ],
+      platformShare: [{ platform: 'Instagram', value: 100, color: '#f43f5e' }],
+    });
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => expect(mockGetAnalytics).toHaveBeenCalledTimes(1));
+  });
+
+  it('renders real data and hides the sample-data indicator when the API succeeds', async () => {
+    mockGetAnalytics.mockResolvedValueOnce({
+      series: [
+        { day: 'Mon W1', reach: 1000, engagement: 50, followers: 100 },
+        { day: 'Tue W1', reach: 1200, engagement: 60, followers: 120 },
+      ],
+      platformShare: [{ platform: 'Instagram', value: 100, color: '#f43f5e' }],
+    });
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('falls back to sample data with a visible indicator when the API call fails', async () => {
+    mockGetAnalytics.mockRejectedValueOnce(new Error('backend unreachable'));
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => expect(mockGetAnalytics).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('status')).toHaveTextContent(/sample data/i);
+  });
+});


### PR DESCRIPTION
Closes #1323
Closes #1329 
Closes #1331
Closes #1332

---
1. configureApi() was never called — the generated API client was dead code (c775c48)

src/api/configure.ts exported configureApi(), documented to be called once at app startup, but it was never invoked anywhere. As a result, none of the 11 generated service clients under src/api/services/ ever had a real base URL or auth token, making them unreachable.

- Call configureApi({ baseUrl: import.meta.env.VITE_API_URL, getToken }) once in src/main.tsx, with getToken reading the existing sf_auth_token from localStorage.
- Migrated WebhookManager off its local in-memory mock onto the real generated WebhooksService, so at least one component now calls the configured client end-to-end (list/create/delete/test/replay webhooks).
- Added src/api/__tests__/configure.test.ts asserting a real generated service call includes the configured Authorization: Bearer <token> header, and omits it when no token is present.

2. AnalyticsPage rendered fabricated data for every user (16c1384)

AnalyticsPage built its entire view — reach, engagement, follower gain, charts — from a seeded pseudo-random generator (sampleAnalytics.ts), with no path to real data and no indication it was fake.

- On mount, calls AnalyticsService.getAnalytics({}) (now reachable thanks to fix #1) and uses the response when it looks like real data.
- Falls back to the sample generator only on API failure, unexpected response shape, or explicit VITE_DEMO_MODE=true.
- Shows a visible role="status" "Showing sample data" banner whenever fabricated data is on screen; it disappears once real data loads.
- Added src/pages/__tests__/AnalyticsPage.test.tsx covering the real-data path, the fallback path, and the indicator. Includes a README (src/pages/README.analytics-real-data.md) since the core diff was compact.

3. Role assignment and org membership changes had no audit trail (ccc844e)

The existing audit() middleware (redaction, actor/org/resource/IP capture, 2xx-only logging) was applied to exactly one route (health-config-update). Role assignment and org member add/remove — the exact actions a privilege-escalation exploit would perform — left no forensic trail.

- Applied audit('role:assign' / 'role:revoke') to POST /roles/assign and DELETE /roles/assign/:userId, capturing target user and role.
- Applied audit('org:member:invite' / 'org:member:remove') to POST /organizations/:orgId/members and DELETE /organizations/:orgId/members/:userId, capturing actor, org, target user, and role.
- Added backend/src/middleware/__tests__/auditRoleAndOrgRoutes.test.ts asserting audit entries are created for successful calls and withheld for non-2xx responses.

4. Facebook OAuth tokens stored in Redis as plaintext (6309b45)

facebookTokenRefreshJob.ts persisted each user's Facebook long-lived access token as a plaintext Redis hash field — readable by anyone with Redis access via misconfiguration, a compromised dependency, or lateral movement.

- Added backend/src/utils/tokenEncryption.ts: AES-256-GCM encrypt/decrypt, key derived from the existing JWT_SECRET (no new secret to provision).
- The refresh job now decrypts the stored token before use and re-encrypts the refreshed token before writing back; a decrypt failure is treated as a non-fatal per-token failure rather than crashing the job.
- Updated existing job tests to seed/assert encrypted values, added a test proving the raw Redis hash value is never the plaintext token, and added unit tests for the encryption helper (round-trip, random IV per encryption, tamper detection).
