### PR TITLE
 Title: fix: use validated config.JWT_SECRET in realtime SSE route

### DIFF
--- a/backend/src/config/__tests__/circuitBreaker.config.test.ts
+++ b/backend/src/config/__tests__/circuitBreaker.config.test.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_CIRCUIT_CONFIG, CIRCUIT_CONFIGS, FALLBACK_STRATEGIES } from '../circuitBreaker.config';
+
+describe('DEFAULT_CIRCUIT_CONFIG', () => {
+  it('has all required numeric/string fields', () => {
+    expect(DEFAULT_CIRCUIT_CONFIG.timeout).toBeGreaterThan(0);
+    expect(DEFAULT_CIRCUIT_CONFIG.errorThresholdPercentage).toBeGreaterThan(0);
+    expect(DEFAULT_CIRCUIT_CONFIG.resetTimeout).toBeGreaterThan(0);
+    expect(DEFAULT_CIRCUIT_CONFIG.rollingCountTimeout).toBeGreaterThan(0);
+    expect(DEFAULT_CIRCUIT_CONFIG.rollingCountBuckets).toBeGreaterThan(0);
+    expect(DEFAULT_CIRCUIT_CONFIG.volumeThreshold).toBeGreaterThan(0);
+    expect(DEFAULT_CIRCUIT_CONFIG.name).toBe('default');
+  });
+});
+
+describe('CIRCUIT_CONFIGS', () => {
+  const expectedProviders = [
+    'ai',
+    'translation',
+    'twitter',
+    'blockchain',
+    'ipfs',
+    'price',
+    'youtube',
+    'facebook',
+    'instagram',
+    'tiktok',
+    'linkedin',
+    'notification',
+  ];
+
+  it('defines every expected provider entry', () => {
+    for (const provider of expectedProviders) {
+      expect(CIRCUIT_CONFIGS).toHaveProperty(provider);
+    }
+  });
+
+  it.each(Object.entries(CIRCUIT_CONFIGS))('%s has valid, positive config values', (_key, cfg) => {
+    expect(cfg.timeout).toBeGreaterThan(0);
+    expect(cfg.errorThresholdPercentage).toBeGreaterThan(0);
+    expect(cfg.errorThresholdPercentage).toBeLessThanOrEqual(100);
+    expect(cfg.resetTimeout).toBeGreaterThan(0);
+    expect(cfg.rollingCountTimeout).toBeGreaterThan(0);
+    expect(cfg.rollingCountBuckets).toBeGreaterThan(0);
+    expect(cfg.volumeThreshold).toBeGreaterThan(0);
+    expect(cfg.name).toEqual(expect.stringContaining('-service'));
+  });
+});
+
+describe('FALLBACK_STRATEGIES', () => {
+  it('every strategy has an enabled flag and a message', () => {
+    for (const [key, strategy] of Object.entries(FALLBACK_STRATEGIES)) {
+      expect(typeof strategy.enabled).toBe('boolean');
+      expect(typeof strategy.message).toBe('string');
+      expect(strategy.message.length).toBeGreaterThan(0);
+      expect(key.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/backend/src/config/__tests__/cors.test.ts
+++ b/backend/src/config/__tests__/cors.test.ts
@@ -1,0 +1,64 @@
+type OriginCb = (err: Error | null, allow?: boolean) => void;
+
+function callOrigin(origin: string | undefined, opts: { origin: (origin: string | undefined, cb: OriginCb) => void }) {
+  let result: { err: Error | null; allow?: boolean } | undefined;
+  opts.origin(origin, (err, allow) => {
+    result = { err, allow };
+  });
+  return result!;
+}
+
+describe('corsOptions (NODE_ENV=test, falls back to local allow-list)', () => {
+  it('allows configured local origins', async () => {
+    const { corsOptions } = await import('../cors');
+    const result = callOrigin('http://localhost:3000', corsOptions as any);
+    expect(result.err).toBeNull();
+    expect(result.allow).toBe(true);
+  });
+
+  it('rejects an origin not on the allow-list', async () => {
+    const { corsOptions } = await import('../cors');
+    const result = callOrigin('https://evil.example.com', corsOptions as any);
+    expect(result.err).toBeInstanceOf(Error);
+  });
+
+  it('allows requests with no Origin header outside production', async () => {
+    const { corsOptions } = await import('../cors');
+    const result = callOrigin(undefined, corsOptions as any);
+    expect(result.err).toBeNull();
+    expect(result.allow).toBe(true);
+  });
+
+  it('sets credentials and expected methods/headers', async () => {
+    const { corsOptions } = await import('../cors');
+    expect(corsOptions.credentials).toBe(true);
+    expect(corsOptions.methods).toEqual(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']);
+    expect(corsOptions.allowedHeaders).toEqual(['Content-Type', 'Authorization']);
+  });
+});
+
+describe('corsOptions in production', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NODE_ENV = 'prod';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.resetModules();
+  });
+
+  it('rejects requests with no Origin header in production', async () => {
+    const { corsOptions } = await import('../cors');
+    const result = callOrigin(undefined, corsOptions as any);
+    expect(result.err).toBeInstanceOf(Error);
+  });
+
+  it('allows only production domains', async () => {
+    const { corsOptions } = await import('../cors');
+    expect(callOrigin('https://socialflow.app', corsOptions as any).allow).toBe(true);
+    expect(callOrigin('http://localhost:3000', corsOptions as any).err).toBeInstanceOf(Error);
+  });
+});

--- a/backend/src/config/__tests__/inversify.config.test.ts
+++ b/backend/src/config/__tests__/inversify.config.test.ts
@@ -1,0 +1,21 @@
+import { TYPES } from '../types';
+import { container } from '../inversify.config';
+
+describe('inversify container', () => {
+  const boundTypes: Array<keyof typeof TYPES> = [
+    'AlertConfigService',
+    'NotificationManager',
+    'HealthMonitor',
+    'HealthService',
+    'CircuitBreakerService',
+    'AIService',
+  ];
+
+  it.each(boundTypes)('binds %s', (key) => {
+    expect(container.isBound(TYPES[key])).toBe(true);
+  });
+
+  it('does not bind identifiers that were never registered', () => {
+    expect(container.isBound(TYPES.UserService)).toBe(false);
+  });
+});

--- a/backend/src/config/__tests__/runtime.test.ts
+++ b/backend/src/config/__tests__/runtime.test.ts
@@ -1,0 +1,138 @@
+import {
+  getNumber,
+  getBoolean,
+  getBackendPort,
+  getRedisConnection,
+  getConfiguredQueueNames,
+  getAdminIpWhitelist,
+  getDataRetentionConfig,
+} from '../runtime';
+
+describe('getNumber', () => {
+  it('returns the parsed value when valid and positive', () => {
+    expect(getNumber('42', 1)).toBe(42);
+  });
+
+  it('returns the fallback when the value is undefined', () => {
+    expect(getNumber(undefined, 7)).toBe(7);
+  });
+
+  it('returns the fallback when the value is not finite', () => {
+    expect(getNumber('not-a-number', 7)).toBe(7);
+  });
+
+  it('returns the fallback when the value is zero or negative', () => {
+    expect(getNumber('0', 7)).toBe(7);
+    expect(getNumber('-5', 7)).toBe(7);
+  });
+});
+
+describe('getBoolean', () => {
+  it('returns the fallback when value is falsy', () => {
+    expect(getBoolean(undefined, true)).toBe(true);
+    expect(getBoolean('', false)).toBe(false);
+  });
+
+  it.each(['1', 'true', 'yes', 'on', 'TRUE', ' On '])('treats "%s" as true', (value) => {
+    expect(getBoolean(value, false)).toBe(true);
+  });
+
+  it.each(['0', 'false', 'no', 'off', 'FALSE'])('treats "%s" as false', (value) => {
+    expect(getBoolean(value, true)).toBe(false);
+  });
+
+  it('returns the fallback for unrecognized values', () => {
+    expect(getBoolean('maybe', true)).toBe(true);
+    expect(getBoolean('maybe', false)).toBe(false);
+  });
+});
+
+describe('getBackendPort', () => {
+  it('returns the configured backend port', () => {
+    expect(getBackendPort()).toBe(3001);
+  });
+});
+
+describe('getRedisConnection', () => {
+  it('builds a RedisOptions object from config', () => {
+    const conn = getRedisConnection();
+    expect(conn.host).toBe('127.0.0.1');
+    expect(conn.port).toBe(6379);
+    expect(conn.db).toBe(0);
+    expect(conn.maxRetriesPerRequest).toBeNull();
+  });
+
+  it('leaves tls undefined when REDIS_TLS is not enabled', () => {
+    expect(getRedisConnection().tls).toBeUndefined();
+  });
+});
+
+describe('getConfiguredQueueNames', () => {
+  it('returns a parsed, trimmed, non-empty list of queue names', () => {
+    const names = getConfiguredQueueNames();
+    expect(Array.isArray(names)).toBe(true);
+    for (const name of names) {
+      expect(name).toBe(name.trim());
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getAdminIpWhitelist', () => {
+  const original = process.env.ADMIN_IP_WHITELIST;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.ADMIN_IP_WHITELIST;
+    else process.env.ADMIN_IP_WHITELIST = original;
+  });
+
+  it('returns an empty array when ADMIN_IP_WHITELIST is unset', () => {
+    delete process.env.ADMIN_IP_WHITELIST;
+    expect(getAdminIpWhitelist()).toEqual([]);
+  });
+
+  it('returns an empty array when ADMIN_IP_WHITELIST is an empty string', () => {
+    process.env.ADMIN_IP_WHITELIST = '';
+    expect(getAdminIpWhitelist()).toEqual([]);
+  });
+
+  it('parses a comma-separated list and trims whitespace', () => {
+    process.env.ADMIN_IP_WHITELIST = ' 10.0.0.1, 10.0.0.2 ,10.0.0.3';
+    expect(getAdminIpWhitelist()).toEqual(['10.0.0.1', '10.0.0.2', '10.0.0.3']);
+  });
+
+  it('drops empty entries caused by trailing/duplicate commas', () => {
+    process.env.ADMIN_IP_WHITELIST = '10.0.0.1,,10.0.0.2,';
+    expect(getAdminIpWhitelist()).toEqual(['10.0.0.1', '10.0.0.2']);
+  });
+});
+
+describe('getDataRetentionConfig', () => {
+  it('returns a fully populated DataRetentionConfig from defaults', () => {
+    const cfg = getDataRetentionConfig();
+    expect(cfg.mode).toMatch(/^(archive|delete)$/);
+    expect(typeof cfg.enabled).toBe('boolean');
+    expect(typeof cfg.dryRun).toBe('boolean');
+    expect(Array.isArray(cfg.logsPaths)).toBe(true);
+    expect(Array.isArray(cfg.analyticsPaths)).toBe(true);
+    expect(cfg.logsPaths.length).toBeGreaterThan(0);
+    expect(cfg.analyticsPaths.length).toBeGreaterThan(0);
+    expect(cfg.queueName).toBe('data-pruning');
+  });
+
+  it('honors DATA_RETENTION_LOG_PATHS / ANALYTICS_PATHS overrides', () => {
+    const prevLogs = process.env.DATA_RETENTION_LOG_PATHS;
+    const prevAnalytics = process.env.DATA_RETENTION_ANALYTICS_PATHS;
+    process.env.DATA_RETENTION_LOG_PATHS = 'a,b';
+    process.env.DATA_RETENTION_ANALYTICS_PATHS = 'c';
+
+    const cfg = getDataRetentionConfig();
+    expect(cfg.logsPaths).toEqual(['a', 'b']);
+    expect(cfg.analyticsPaths).toEqual(['c']);
+
+    if (prevLogs === undefined) delete process.env.DATA_RETENTION_LOG_PATHS;
+    else process.env.DATA_RETENTION_LOG_PATHS = prevLogs;
+    if (prevAnalytics === undefined) delete process.env.DATA_RETENTION_ANALYTICS_PATHS;
+    else process.env.DATA_RETENTION_ANALYTICS_PATHS = prevAnalytics;
+  });
+});

--- a/backend/src/config/__tests__/swagger.test.ts
+++ b/backend/src/config/__tests__/swagger.test.ts
@@ -1,0 +1,22 @@
+import { swaggerSpec } from '../swagger';
+
+describe('swaggerSpec', () => {
+  it('builds a valid OpenAPI 3.0 document', () => {
+    const spec = swaggerSpec as Record<string, unknown>;
+    expect(spec.openapi).toBe('3.0.3');
+    expect((spec.info as Record<string, unknown>).title).toBe('SocialFlow AI Dashboard API');
+  });
+
+  it('registers the bearerAuth security scheme', () => {
+    const spec = swaggerSpec as any;
+    expect(spec.components.securitySchemes.bearerAuth.type).toBe('http');
+    expect(spec.components.securitySchemes.bearerAuth.scheme).toBe('bearer');
+  });
+
+  it('defines shared schemas used across routes', () => {
+    const spec = swaggerSpec as any;
+    for (const name of ['Error', 'AuthTokens', 'Post', 'Organization']) {
+      expect(spec.components.schemas).toHaveProperty(name);
+    }
+  });
+});

--- a/backend/src/config/__tests__/tts.config.test.ts
+++ b/backend/src/config/__tests__/tts.config.test.ts
@@ -1,0 +1,25 @@
+import { ttsConfig } from '../tts.config';
+
+describe('ttsConfig', () => {
+  it('defines elevenlabs and google provider settings', () => {
+    expect(ttsConfig.elevenlabs.apiUrl).toMatch(/^https:\/\//);
+    expect(ttsConfig.google.apiUrl).toMatch(/^https:\/\//);
+  });
+
+  it('defines sane default speech parameters', () => {
+    expect(ttsConfig.defaults.speed).toBeGreaterThan(0);
+    expect(ttsConfig.defaults.stability).toBeGreaterThanOrEqual(0);
+    expect(ttsConfig.defaults.stability).toBeLessThanOrEqual(1);
+    expect(ttsConfig.defaults.maxSegmentLength).toBeGreaterThan(0);
+  });
+
+  it('every built-in voice has a unique id and required fields', () => {
+    const ids = ttsConfig.voices.map((v) => v.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const voice of ttsConfig.voices) {
+      expect(['elevenlabs', 'google']).toContain(voice.provider);
+      expect(voice.name.length).toBeGreaterThan(0);
+      expect(voice.language.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/backend/src/config/__tests__/types.test.ts
+++ b/backend/src/config/__tests__/types.test.ts
@@ -1,0 +1,14 @@
+import { TYPES } from '../types';
+
+describe('TYPES', () => {
+  it('exposes a symbol for every service identifier', () => {
+    for (const [key, value] of Object.entries(TYPES)) {
+      expect(typeof value).toBe('symbol');
+      expect(value.toString()).toBe(`Symbol(${key})`);
+    }
+  });
+
+  it('reuses the same symbol for a given identifier (Symbol.for semantics)', () => {
+    expect(Symbol.for('HealthService')).toBe(TYPES.HealthService);
+  });
+});

--- a/backend/src/config/__tests__/video.config.test.ts
+++ b/backend/src/config/__tests__/video.config.test.ts
@@ -1,0 +1,28 @@
+import { videoConfig } from '../video.config';
+
+describe('videoConfig', () => {
+  it('defines upload limits and allowed mime types', () => {
+    expect(videoConfig.upload.maxFileSize).toBe(500 * 1024 * 1024);
+    expect(videoConfig.upload.allowedMimeTypes).toContain('video/mp4');
+    expect(videoConfig.upload.allowedMimeTypes.length).toBeGreaterThan(0);
+  });
+
+  it('defines quality presets with valid dimensions', () => {
+    for (const [key, quality] of Object.entries(videoConfig.qualities)) {
+      expect(quality.name).toBe(key);
+      expect(quality.width).toBeGreaterThan(0);
+      expect(quality.height).toBeGreaterThan(0);
+      expect(quality.bitrate).toMatch(/^\d+k$/);
+    }
+  });
+
+  it('defines mp4 and webm format presets', () => {
+    expect(videoConfig.formats.mp4.extension).toBe('mp4');
+    expect(videoConfig.formats.webm.extension).toBe('webm');
+  });
+
+  it('defines a single-concurrency queue', () => {
+    expect(videoConfig.queue.maxConcurrent).toBe(1);
+    expect(videoConfig.queue.jobCleanupAge).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/routes/realtime.ts
+++ b/backend/src/routes/realtime.ts
@@ -3,10 +3,10 @@ import jwt from 'jsonwebtoken';
 import { AuthRequest } from '../middleware/authenticate';
 import { eventBus, JobProgressEvent } from '../lib/eventBus';
 import { createLogger } from '../lib/logger';
+import { config } from '../config/config';
 
 const router = Router();
 const logger = createLogger('SSE');
-const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
 /**
  * @openapi
@@ -46,7 +46,7 @@ router.get('/stream', (req: AuthRequest, res: Response) => {
   }
 
   try {
-    const payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
+    const payload = jwt.verify(token, config.JWT_SECRET) as jwt.JwtPayload;
     userId = payload.sub as string;
   } catch {
     res.status(401).json({ message: 'Invalid or expired token' });

--- a/scripts/db-backup.ts
+++ b/scripts/db-backup.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { S3Client, PutObjectCommand, ListObjectsV2Command, DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { readFileSync } from 'fs';
+import { readFileSync, openSync, closeSync } from 'fs';
 import { join } from 'path';
 
 const DB_URL = process.env.DATABASE_URL;
@@ -23,7 +23,16 @@ const s3Key = `backups/db-backup-${timestamp}.sql`;
 async function backup() {
   try {
     console.log('Starting database backup...');
-    execSync(`pg_dump "${DB_URL}" > "${backupFile}"`, { stdio: 'inherit' });
+    const outFd = openSync(backupFile, 'w');
+    try {
+      const result = spawnSync('pg_dump', [DB_URL], { stdio: ['ignore', outFd, 'inherit'] });
+      if (result.error) throw result.error;
+      if (result.status !== 0) {
+        throw new Error(`pg_dump exited with status ${result.status}`);
+      }
+    } finally {
+      closeSync(outFd);
+    }
 
     console.log('Uploading to S3...');
     const fileContent = readFileSync(backupFile);


### PR DESCRIPTION
PR 1 — branch: fix/realtime-jwt-secret-fallback



## Summary
- `routes/realtime.ts` verified SSE JWTs with its own `JWT_SECRET()` helper that fell back to the hardcoded string `'change-me-in-production'`, independently of `middleware/authenticate.ts` (already fixed to use the validated `config.JWT_SECRET` with no fallback).
- Since `/realtime` is a live, mounted route, an unset `JWT_SECRET` env var would let this endpoint accept tokens signed with the well-known fallback string even though the REST middleware would reject them.
- Now imports `config.JWT_SECRET` from `config/config.ts`, matching `authenticate.ts` exactly. No fallback string remains.

closes #1302

## Test plan
- [ ] Add a test asserting the SSE stream rejects a token signed with the old fallback string
- [ ] `npm test -- realtime` passes
- [ ] `npm run lint && npm run build` pass with zero warnings
PR 2 — branch: fix/db-backup-shell-injection

Title: fix: avoid shell interpolation of DATABASE_URL in db-backup script


## Summary
- `scripts/db-backup.ts` built a shell command via string interpolation (`` execSync(`pg_dump "${DB_URL}" > "${backupFile}"`) ``), so a `DATABASE_URL` containing shell metacharacters (e.g. in the userinfo/password component, which Postgres connection strings permit) would be interpreted by the shell instead of passed literally to `pg_dump`.
- Replaced with `spawnSync('pg_dump', [DB_URL], ...)` — an explicit argument array with no shell involved — and pipe stdout directly to the backup file via a file descriptor instead of shell redirection.

closes #1301

## Test plan
- [ ] Manually run the backup script against a test database and confirm the output file is produced correctly
- [ ] Add a test asserting a `DATABASE_URL` with shell metacharacters doesn't alter the executed command
- [ ] `npm run lint && npm run build` pass with zero warnings
— branch: test/backend-config-coverage

Title: test: add coverage for backend/src/config/*.ts


## Summary
- `backend/src/config/*.ts` (8 files) had zero test coverage, including `runtime.ts`, which backs `getAdminIpWhitelist`/`getRedisConnection`/`getDataRetentionConfig` — functions relied on by the ipWhitelistMiddleware fail-open issue and rate-limiter Redis-store selection.
- Added `backend/src/config/__tests__/` specs for `runtime.ts` (priority: `getAdminIpWhitelist` incl. the empty/blank-list case, `getRedisConnection`, `getDataRetentionConfig`, `getBoolean`/`getNumber`), `circuitBreaker.config.ts` (all provider entries + fallback strategies), `cors.ts` (local vs. production origin behavior), `video.config.ts`, `tts.config.ts`, `types.ts`, `swagger.ts`, and `inversify.config.ts`.

closes #1304

## Test plan
- [ ] `npm test -- backend/src/config` — all new tests pass
- [ ] `npm test` — no regressions
- [ ] Screenshot of passing Jest terminal logs attached
- [ ] `npm run lint && npm run build` pass with zero warnings