### PR TITLE
chore: reconcile modules/content TranslationService with live impleme…

### DIFF
--- a/backend/src/modules/content/services/TranslationService.ts
+++ b/backend/src/modules/content/services/TranslationService.ts
@@ -189,7 +189,7 @@ class TranslationService {
       }),
     });
 
-    const data = await response.json();
+    const data = await response.json() as any;
     return data.translations[0].text;
   }
 
@@ -217,7 +217,7 @@ class TranslationService {
       },
     );
 
-    const data = await response.json();
+    const data = await response.json() as any;
     return data.data.translations[0].translatedText;
   }
 


### PR DESCRIPTION
closes #1273 
closes #1274 
closes #1275 
closes #1276 


…ntation

The module copy had dropped an `as any` cast on the DeepL/Google fetch response that the live services/TranslationService.ts keeps. Without it, tsc fails (fetch().json() resolves to unknown here) — the module copy was only getting away with it because src/modules is excluded from tsconfig.json. Restoring the cast makes the two files byte-identical, closing the last divergence between them.