### PR TITLE
chore: reconcile modules/social TwitterService with canonical impleme…

### DIFF
--- a/backend/src/modules/social/services/TwitterService.ts
+++ b/backend/src/modules/social/services/TwitterService.ts
@@ -1,227 +1,26 @@
-import { circuitBreakerService } from './CircuitBreakerService';
-
 /**
- * Twitter API Response Types
- */
-export interface TwitterPost {
-  id: string;
-  text: string;
-  created_at: string;
-  author_id: string;
-  public_metrics?: {
-    retweet_count: number;
-    reply_count: number;
-    like_count: number;
-    quote_count: number;
-  };
-}
-
-export interface TwitterUser {
-  id: string;
-  username: string;
-  name: string;
-  profile_image_url?: string;
-}
-
-export interface TwitterPostRequest {
-  text: string;
-  media_ids?: string[];
-  reply_to?: string;
-}
-
-/**
- * TwitterService - Wrapper for Twitter API with circuit breaker protection
+ * @deprecated This file is deprecated and will be removed in a future version.
  *
- * Provides resilient Twitter operations with automatic failure handling.
- * Prevents cascading failures when Twitter API is down or rate-limited.
+ * The canonical implementation lives at:
+ * backend/src/services/TwitterService.ts
+ *
+ * This wrapper re-exports from the canonical location for backward compatibility.
+ * Please update your imports to use the canonical location directly:
+ *
+ * Before:
+ *   import { twitterService } from '../services/TwitterService';
+ *
+ * After:
+ *   import { twitterService } from '../../services/TwitterService';
+ *
+ * See backend/docs/module-architecture.md for the migration plan.
  */
-class TwitterService {
-  private readonly API_BASE = 'https://api.twitter.com/2';
-  private readonly bearerToken: string;
 
-  constructor() {
-    this.bearerToken = process.env.TWITTER_BEARER_TOKEN || '';
-  }
-
-  /**
-   * Check if Twitter API is configured
-   */
-  public isConfigured(): boolean {
-    return !!this.bearerToken && this.bearerToken !== 'your_twitter_bearer_token';
-  }
-
-  /**
-   * Post a tweet with circuit breaker protection
-   */
-  public async postTweet(request: TwitterPostRequest): Promise<TwitterPost> {
-    if (!this.isConfigured()) {
-      throw new Error('Twitter API not configured. Please set TWITTER_BEARER_TOKEN.');
-    }
-
-    return circuitBreakerService.execute(
-      'twitter',
-      async () => {
-        const response = await fetch(`${this.API_BASE}/tweets`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${this.bearerToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(request),
-        });
-
-        if (!response.ok) {
-          const error = await response.json();
-          throw new Error(`Twitter API error: ${response.status} - ${JSON.stringify(error)}`);
-        }
-
-        const data = await response.json();
-        return data.data;
-      },
-      async () => {
-        // Fallback: Queue for later or throw
-        throw new Error('Twitter API temporarily unavailable. Post has been queued for retry.');
-      },
-    );
-  }
-
-  /**
-   * Get user timeline with circuit breaker protection
-   */
-  public async getUserTimeline(userId: string, maxResults: number = 10): Promise<TwitterPost[]> {
-    if (!this.isConfigured()) {
-      throw new Error('Twitter API not configured.');
-    }
-
-    return circuitBreakerService.execute(
-      'twitter',
-      async () => {
-        const response = await fetch(
-          `${this.API_BASE}/users/${userId}/tweets?max_results=${maxResults}&tweet.fields=created_at,public_metrics`,
-          {
-            headers: {
-              Authorization: `Bearer ${this.bearerToken}`,
-            },
-          },
-        );
-
-        if (!response.ok) {
-          throw new Error(`Twitter API error: ${response.status}`);
-        }
-
-        const data = await response.json();
-        return data.data || [];
-      },
-      async () => {
-        // Fallback: return empty array
-        console.warn('Twitter circuit breaker open, returning empty timeline');
-        return [];
-      },
-    );
-  }
-
-  /**
-   * Get user info with circuit breaker protection
-   */
-  public async getUserInfo(username: string): Promise<TwitterUser | null> {
-    if (!this.isConfigured()) {
-      throw new Error('Twitter API not configured.');
-    }
-
-    return circuitBreakerService.execute(
-      'twitter',
-      async () => {
-        const response = await fetch(
-          `${this.API_BASE}/users/by/username/${username}?user.fields=profile_image_url`,
-          {
-            headers: {
-              Authorization: `Bearer ${this.bearerToken}`,
-            },
-          },
-        );
-
-        if (!response.ok) {
-          throw new Error(`Twitter API error: ${response.status}`);
-        }
-
-        const data = await response.json();
-        return data.data;
-      },
-      async () => {
-        // Fallback: return null
-        console.warn('Twitter circuit breaker open, returning null user');
-        return null;
-      },
-    );
-  }
-
-  /**
-   * Search tweets with circuit breaker protection
-   */
-  public async searchTweets(query: string, maxResults: number = 10): Promise<TwitterPost[]> {
-    if (!this.isConfigured()) {
-      throw new Error('Twitter API not configured.');
-    }
-
-    return circuitBreakerService.execute(
-      'twitter',
-      async () => {
-        const response = await fetch(
-          `${this.API_BASE}/tweets/search/recent?query=${encodeURIComponent(query)}&max_results=${maxResults}&tweet.fields=created_at,public_metrics`,
-          {
-            headers: {
-              Authorization: `Bearer ${this.bearerToken}`,
-            },
-          },
-        );
-
-        if (!response.ok) {
-          throw new Error(`Twitter API error: ${response.status}`);
-        }
-
-        const data = await response.json();
-        return data.data || [];
-      },
-      async () => {
-        // Fallback: return empty array
-        console.warn('Twitter circuit breaker open, returning empty search results');
-        return [];
-      },
-    );
-  }
-
-  /**
-   * Health check for Twitter API
-   */
-  public async healthCheck(): Promise<boolean> {
-    if (!this.isConfigured()) {
-      return false;
-    }
-
-    try {
-      return await circuitBreakerService.execute(
-        'twitter',
-        async () => {
-          const response = await fetch(`${this.API_BASE}/users/me`, {
-            headers: {
-              Authorization: `Bearer ${this.bearerToken}`,
-            },
-          });
-          return response.ok;
-        },
-        async () => false,
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Get circuit breaker status
-   */
-  public getCircuitStatus() {
-    return circuitBreakerService.getStats('twitter');
-  }
-}
-
-export const twitterService = new TwitterService();
+// Re-export everything from the canonical implementation
+export {
+  TwitterPost,
+  TwitterUser,
+  TwitterPostRequest,
+  TwitterService,
+  twitterService,
+} from '../../../services/TwitterService';


### PR DESCRIPTION
closes #1277 
closes #1278 
closes #1279 
closes #1280 



…ntation

modules/social/services/TwitterService.ts was a standalone 227-line reimplementation missing the PKCE OAuth flow, LockService-guarded posting, lazy bearer-token lookup, and structured logging present in the live backend/src/services/TwitterService.ts. Following the same pattern already used to reconcile FacebookService and YouTubeService (f0f35a2), replace it with a re-export shim of the canonical implementation so the two can no longer diverge.

socialServiceParity.test.ts already exercises the canonical TwitterService and passes unchanged.