### PR TITLE
fix: IDOR, fail-open IP whitelist, and hardcoded secret fallbacks (CSRF + GraphQL JWT)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,15 @@ JWT_EXPIRES_IN=15m
 JWT_REFRESH_SECRET=
 JWT_REFRESH_EXPIRES_IN=7d
 
+# CSRF secret used to sign the double-submit CSRF token (min 32 characters, keep secret in production)
+CSRF_SECRET=
+
+# Comma-separated list of IPs/CIDR ranges allowed to reach IP-restricted admin/ops
+# routes (/audit, /jobs, /config, /circuit-breaker, /admin). Required — if left
+# empty, those routes fail closed and reject all requests.
+# Example: ADMIN_IP_WHITELIST=127.0.0.1,10.0.0.0/8
+ADMIN_IP_WHITELIST=
+
 # ─── Real-time Health Monitoring and Alerting ──────────────────────────────────
 # Slack webhook URL for health alerts
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL

--- a/backend/src/__tests__/ListingController.test.ts
+++ b/backend/src/__tests__/ListingController.test.ts
@@ -29,6 +29,7 @@ import {
   getListing,
   deleteListing,
   listListings,
+  toggleListingVisibility,
 } from '../controllers/ListingController';
 
 function buildApp(opts: { userId?: string; orgId?: string } = {}) {
@@ -44,6 +45,7 @@ function buildApp(opts: { userId?: string; orgId?: string } = {}) {
   app.get('/listings/:id', getListing);
   app.delete('/listings/:id', deleteListing);
   app.get('/listings', listListings);
+  app.patch('/listings/:id/visibility', toggleListingVisibility);
   // Global error handler
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
     res.status(500).json({ success: false, message: err.message });
@@ -186,6 +188,40 @@ describe('deleteListing', () => {
     const res = await request(app).delete(`/listings/${LISTING_ID}`);
 
     expect(res.status).toBe(500);
+  });
+});
+
+// ── toggleListingVisibility ──────────────────────────────────────────────────
+describe('toggleListingVisibility', () => {
+  it('rejects a forged mentorId in the body when there is no authenticated user', async () => {
+    const app = buildApp({}); // no userId — simulates missing/invalid auth
+
+    const res = await request(app)
+      .patch(`/listings/${LISTING_ID}/visibility`)
+      .send({ isActive: false, mentorId: 'attacker-mentor-id' });
+
+    expect(res.status).toBe(401);
+    expect(listingService.toggleVisibility).not.toHaveBeenCalled();
+  });
+
+  it('ignores a client-supplied mentorId and uses the authenticated user id', async () => {
+    (listingService.toggleVisibility as jest.Mock).mockResolvedValue({
+      ...sampleListing,
+      isActive: false,
+    });
+    const app = buildApp({ userId: MENTOR_ID, orgId: ORG_A });
+
+    const res = await request(app)
+      .patch(`/listings/${LISTING_ID}/visibility`)
+      .send({ isActive: false, mentorId: 'attacker-mentor-id' });
+
+    expect(res.status).toBe(200);
+    expect(listingService.toggleVisibility).toHaveBeenCalledWith(
+      LISTING_ID,
+      MENTOR_ID,
+      false,
+      ORG_A,
+    );
   });
 });
 

--- a/backend/src/__tests__/csrfProtection.test.ts
+++ b/backend/src/__tests__/csrfProtection.test.ts
@@ -10,10 +10,15 @@
  */
 
 // Set required env vars before any module is loaded
-process.env.JWT_SECRET = 'test-secret-csrf';
-process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-csrf';
+process.env.JWT_SECRET = 'test-secret-csrf-that-is-at-least-32-chars!!';
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-csrf-that-is-at-least-32-chars!!';
 process.env.JWT_EXPIRES_IN = '15m';
 process.env.JWT_REFRESH_EXPIRES_IN = '7d';
+process.env.CSRF_SECRET = 'test-csrf-secret-that-is-at-least-32-chars!!';
+process.env.STRIPE_SECRET_KEY = 'sk_test_csrf_suite';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/test';
+process.env.TWITTER_API_KEY = process.env.TWITTER_API_KEY || 'test-key';
+process.env.TWITTER_API_SECRET = process.env.TWITTER_API_SECRET || 'test-secret';
 
 import { Request, Response, NextFunction } from 'express';
 import { csrfProtection } from '../middleware/csrfProtection';

--- a/backend/src/__tests__/integration/setup.ts
+++ b/backend/src/__tests__/integration/setup.ts
@@ -12,6 +12,7 @@ process.env.JWT_SECRET = 'integration-test-secret-32-chars!!';
 process.env.JWT_REFRESH_SECRET = 'integration-refresh-secret-32ch';
 process.env.JWT_EXPIRES_IN = '15m';
 process.env.JWT_REFRESH_EXPIRES_IN = '7d';
+process.env.CSRF_SECRET = 'integration-test-csrf-secret-32-chars!!';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/socialflow_test';
 process.env.TWITTER_API_KEY = 'test-key';
 process.env.TWITTER_API_SECRET = 'test-secret';

--- a/backend/src/__tests__/ipWhitelist.test.ts
+++ b/backend/src/__tests__/ipWhitelist.test.ts
@@ -1,17 +1,20 @@
 import { Request, Response, NextFunction } from 'express';
-import { ipWhitelistMiddleware } from '../middleware/ipWhitelist';
-import * as runtime from '../config/runtime';
-import requestIp from 'request-ip';
 
 jest.mock('../config/runtime');
 jest.mock('request-ip');
+
+const mockLogger = {
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+};
 jest.mock('../lib/logger', () => ({
-  createLogger: () => ({
-    warn: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  }),
+  createLogger: () => mockLogger,
 }));
+
+import { ipWhitelistMiddleware } from '../middleware/ipWhitelist';
+import * as runtime from '../config/runtime';
+import requestIp from 'request-ip';
 
 describe('ipWhitelistMiddleware', () => {
   let mockRequest: Partial<Request>;
@@ -32,12 +35,26 @@ describe('ipWhitelistMiddleware', () => {
     jest.clearAllMocks();
   });
 
-  it('should allow access if whitelist is empty', () => {
+  it('should fail closed (block access) if whitelist is empty', () => {
     (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue([]);
     (requestIp.getClientIp as jest.Mock).mockReturnValue('127.0.0.1');
 
     ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
-    expect(nextFunction).toHaveBeenCalled();
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('should log a loud warning when the whitelist is empty', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue([]);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('127.0.0.1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('ADMIN_IP_WHITELIST is not configured'),
+      expect.any(Object),
+    );
   });
 
   it('should allow access if client IP matches an exact entry', () => {

--- a/backend/src/__tests__/unitSetup.ts
+++ b/backend/src/__tests__/unitSetup.ts
@@ -3,5 +3,6 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-that-is-at-least-32-chars!!';
 process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'test-refresh-secret-32-chars!!!!!';
+process.env.CSRF_SECRET = process.env.CSRF_SECRET || 'test-csrf-secret-that-is-at-least-32-chars!!';
 process.env.TWITTER_API_KEY = process.env.TWITTER_API_KEY || 'test-key';
 process.env.TWITTER_API_SECRET = process.env.TWITTER_API_SECRET || 'test-secret';

--- a/backend/src/config/__tests__/config.test.ts
+++ b/backend/src/config/__tests__/config.test.ts
@@ -4,6 +4,7 @@ const REQUIRED_ENV: Record<string, string> = {
   DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
   JWT_SECRET: 'super-secret-jwt-value-at-least-32-chars',
   JWT_REFRESH_SECRET: 'super-secret-refresh-value-at-least-32-chars',
+  CSRF_SECRET: 'super-secret-csrf-value-at-least-32-chars',
   TWITTER_API_KEY: 'twitter-key',
   TWITTER_API_SECRET: 'twitter-secret',
 };
@@ -182,6 +183,17 @@ describe('validateEnv', () => {
     it('throws when JWT_REFRESH_SECRET is shorter than 32 characters', () => {
       expect(() => validateEnv({ ...REQUIRED_ENV, JWT_REFRESH_SECRET: 'short-secret' })).toThrow(
         'JWT_REFRESH_SECRET must be at least 32 characters',
+      );
+    });
+
+    it('throws when CSRF_SECRET is missing', () => {
+      const { CSRF_SECRET: _, ...env } = REQUIRED_ENV;
+      expect(() => validateEnv(env)).toThrow('Environment validation failed');
+    });
+
+    it('throws when CSRF_SECRET is shorter than 32 characters', () => {
+      expect(() => validateEnv({ ...REQUIRED_ENV, CSRF_SECRET: 'short-secret' })).toThrow(
+        'CSRF_SECRET must be at least 32 characters',
       );
     });
 

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -34,6 +34,11 @@ const envSchema = z.object({
     .min(JWT_SECRET_MIN_LENGTH, `JWT_REFRESH_SECRET must be at least ${JWT_SECRET_MIN_LENGTH} characters`),
   JWT_REFRESH_EXPIRES_IN: z.string().default('7d'),
 
+  // ── CSRF ──────────────────────────────────────────────────────────────────
+  CSRF_SECRET: z
+    .string()
+    .min(JWT_SECRET_MIN_LENGTH, `CSRF_SECRET must be at least ${JWT_SECRET_MIN_LENGTH} characters`),
+
   // ── Redis ─────────────────────────────────────────────────────────────────
   REDIS_HOST: z.string().default('127.0.0.1'),
   REDIS_PORT: z.coerce.number().int().positive().default(6379),

--- a/backend/src/controllers/ListingController.ts
+++ b/backend/src/controllers/ListingController.ts
@@ -68,8 +68,8 @@ export const toggleListingVisibility = async (req: Request, res: Response) => {
     const { id } = req.params;
     const { isActive } = req.body;
 
-    const mentorId = (req as any).user?.id || req.body.mentorId;
-    const orgId: string | undefined = (req as any).user?.organizationId;
+    const mentorId = (req as any).user?.id;
+    const orgId: string | undefined = (req as any).activeOrgId;
 
     if (isActive === undefined) {
       return res.status(400).json({ success: false, message: 'isActive is required' });

--- a/backend/src/graphql/__tests__/context.test.ts
+++ b/backend/src/graphql/__tests__/context.test.ts
@@ -1,0 +1,44 @@
+// #1262 — buildContext must validate tokens against the config-validated
+// JWT_SECRET, not a hardcoded fallback string.
+
+import jwt from 'jsonwebtoken';
+
+const TEST_SECRET = 'test-secret-that-is-at-least-32-chars!!';
+
+jest.mock('../../config/config', () => ({
+  config: { JWT_SECRET: 'test-secret-that-is-at-least-32-chars!!' },
+}));
+
+jest.mock('../../services/AuthBlacklistService', () => ({
+  AuthBlacklistService: {
+    isBlacklisted: jest.fn().mockResolvedValue(false),
+    keyFromPayload: jest.fn().mockReturnValue('mock-key'),
+  },
+}));
+
+import { buildContext } from '../context';
+
+function makeReq(token?: string) {
+  return {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  } as any;
+}
+
+describe('#1262 buildContext JWT_SECRET', () => {
+  it('accepts a token signed with the validated config.JWT_SECRET', async () => {
+    const token = jwt.sign({ sub: 'user-1' }, TEST_SECRET);
+    const ctx = await buildContext({ req: makeReq(token) });
+    expect(ctx.userId).toBe('user-1');
+  });
+
+  it('rejects a token signed with the old hardcoded fallback secret', async () => {
+    const token = jwt.sign({ sub: 'attacker' }, 'change-me-in-production');
+    const ctx = await buildContext({ req: makeReq(token) });
+    expect(ctx.userId).toBeUndefined();
+  });
+
+  it('returns an empty context when no Authorization header is present', async () => {
+    const ctx = await buildContext({ req: makeReq() });
+    expect(ctx).toEqual({});
+  });
+});

--- a/backend/src/graphql/context.ts
+++ b/backend/src/graphql/context.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express';
 import jwt from 'jsonwebtoken';
 import { AuthBlacklistService } from '../services/AuthBlacklistService';
+import { config } from '../config/config';
 
 export interface GraphQLContext {
   /** Authenticated user ID, or undefined for unauthenticated requests. */
@@ -13,8 +14,6 @@ export interface GraphQLContext {
    */
   tokenKey?: string;
 }
-
-const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
 /**
  * Build the per-request GraphQL context.
@@ -31,7 +30,7 @@ export async function buildContext({ req }: { req: Request }): Promise<GraphQLCo
   const token = authHeader.slice(7);
   let payload: jwt.JwtPayload;
   try {
-    payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
+    payload = jwt.verify(token, config.JWT_SECRET) as jwt.JwtPayload;
   } catch {
     return {};
   }

--- a/backend/src/middleware/csrfProtection.ts
+++ b/backend/src/middleware/csrfProtection.ts
@@ -1,10 +1,9 @@
 import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { createLogger } from '../lib/logger';
+import { config } from '../config/config';
 
 const logger = createLogger('middleware:csrfProtection');
-
-const CSRF_SECRET = process.env.CSRF_SECRET ?? 'dev-csrf-secret-change-me';
 const SESSION_COOKIE = 'csrf_sid';
 const TOKEN_COOKIE = 'csrf_token';
 const TOKEN_HEADER = 'x-csrf-token';
@@ -27,7 +26,7 @@ function parseCookies(header?: string): Record<string, string> {
 
 /** Derive the CSRF token from the session ID — binds the token to its session. */
 function signSessionId(sessionId: string): string {
-  return crypto.createHmac('sha256', CSRF_SECRET).update(sessionId).digest('hex');
+  return crypto.createHmac('sha256', config.CSRF_SECRET).update(sessionId).digest('hex');
 }
 
 /**

--- a/backend/src/middleware/ipWhitelist.ts
+++ b/backend/src/middleware/ipWhitelist.ts
@@ -29,13 +29,18 @@ export const ipWhitelistMiddleware = (req: Request, res: Response, next: NextFun
   const clientIp = requestIp.getClientIp(req);
   const whitelist = getAdminIpWhitelist();
 
-  // If no whitelist is configured, allow all by default (per conventional security or block?)
-  // Given the requirement "Restrict access... to specific... IP addresses", 
-  // if the list is empty, we might want to log a warning but allow access if not in production.
-  // For strictness, if the list is expected but empty, we could block.
-  // However, usually, an empty list means the feature is disabled.
+  // Fail closed: an empty whitelist must not grant unrestricted access to the
+  // sensitive admin/ops routes this middleware protects. Configure
+  // ADMIN_IP_WHITELIST to allow trusted IPs through.
   if (whitelist.length === 0) {
-    return next();
+    logger.warn(
+      'ADMIN_IP_WHITELIST is not configured — blocking all requests to IP-restricted routes. ' +
+        'Set ADMIN_IP_WHITELIST to a comma-separated list of allowed IPs/CIDR ranges to grant access.',
+      { path: req.path, method: req.method },
+    );
+    return res.status(403).json({
+      error: 'Access forbidden: IP whitelisting is not configured for this endpoint.',
+    });
   }
 
   if (!clientIp) {

--- a/src/components/ListingVisibilityToggle.tsx
+++ b/src/components/ListingVisibilityToggle.tsx
@@ -11,7 +11,6 @@ interface ListingVisibilityToggleProps {
 export const ListingVisibilityToggle: React.FC<ListingVisibilityToggleProps> = ({
   listingId,
   initialIsActive,
-  mentorId,
   onToggleSuccess,
   onToggleError
 }) => {
@@ -23,14 +22,18 @@ export const ListingVisibilityToggle: React.FC<ListingVisibilityToggleProps> = (
     const previousState = isActive;
     const newState = !isActive;
     try {
-      // Assuming authorization token is passed via headers elsewhere or credentials
+      const token = localStorage.getItem('accessToken');
+      if (!token) {
+        throw new Error('No access token found');
+      }
+
       const response = await fetch(`/api/listings/${listingId}/visibility`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
-          // Usually handled by interceptors, providing Authorization here is project-defined
+          Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ isActive: newState, mentorId }), 
+        body: JSON.stringify({ isActive: newState }),
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary

Four security fixes, each in its own commit:

### 1. `toggleListingVisibility` IDOR via client-supplied `mentorId` (Closes #1259)
`ListingController.ts` resolved the acting mentor as `req.user?.id || req.body.mentorId`, so an unauthenticated/forged request could pass any `mentorId` in the body and toggle another mentor's listing visibility. The handler also read `orgId` from a field the auth middleware never sets, so org-scoping silently never applied.

- Removed the `req.body.mentorId` fallback — the mentor is now always the authenticated `req.user.id`.
- Fixed `orgId` to read `activeOrgId`, matching every other handler in the file.
- `ListingVisibilityToggle.tsx` now sends the `Authorization: Bearer <token>` header (previously sent none) and no longer sends `mentorId` in the body.
- Added an integration test asserting a forged `mentorId` with no/invalid auth is rejected.

### 2. `ipWhitelistMiddleware` fails open when unconfigured (Closes #1260)
The middleware protecting `/audit`, `/jobs`, `/config`, `/circuit-breaker`, and `/admin` routes returned `next()` unconditionally whenever `ADMIN_IP_WHITELIST` was empty — meaning these sensitive routes had **no** IP restriction by default, with no warning.

- Now fails closed: an empty whitelist returns `403` instead of allowing the request through.
- Logs a loud warning identifying the affected route when this triggers.
- Documented `ADMIN_IP_WHITELIST` in `backend/.env.example`.

### 3. `CSRF_SECRET` hardcoded fallback bypasses config validation (Closes #1261)
`csrfProtection.ts` read `process.env.CSRF_SECRET` directly and fell back to the well-known string `'dev-csrf-secret-change-me'` when unset — unlike `JWT_SECRET`/`JWT_REFRESH_SECRET`, which fail startup validation via the Zod config schema if missing or too short.

- Added `CSRF_SECRET` to the config schema with the same 32-character minimum as the JWT secrets.
- `csrfProtection.ts` now reads `config.CSRF_SECRET`; no hardcoded fallback remains.
- Added config tests asserting startup fails when `CSRF_SECRET` is missing or too short.

### 4. GraphQL `context.ts` hardcoded JWT fallback (Closes #1262)
`graphql/context.ts` read `process.env.JWT_SECRET ?? 'change-me-in-production'`, bypassing the validated `config.JWT_SECRET` already used by the REST `authenticate.ts` middleware. If `JWT_SECRET` were ever unset, tokens signed with the literal fallback string would be accepted by every GraphQL query/mutation/subscription.

- Replaced the local `JWT_SECRET()` helper with `config.JWT_SECRET`, matching `authenticate.ts` exactly.
- Added a test asserting `buildContext` rejects a token signed with the old fallback string and accepts one signed with the validated secret.

## Test plan

- [x] `npx jest ListingController` — 47/47 passing, including new IDOR test
- [x] `npx jest ipWhitelist` — all passing, including new fail-closed + warning tests
- [x] `npx jest src/config/__tests__/config.test.ts -t CSRF_SECRET` — new CSRF_SECRET validation tests passing
- [x] `npx jest csrfProtection` — unit + session-bound tests passing (pre-existing, unrelated integration-suite Prisma-mock gap untouched)
- [x] `npx jest src/graphql/__tests__/context.test.ts` — 3/3 passing
- [x] `tsc --noEmit` shows no new errors introduced in touched files (pre-existing unrelated Prisma-typing errors elsewhere untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)