### PR TITLE
Resolve conflicts for #1349 (IDOR, fail-open IP whitelist, hardcoded secrets)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,6 +28,15 @@ JWT_EXPIRES_IN=15m
 JWT_REFRESH_SECRET=
 JWT_REFRESH_EXPIRES_IN=7d
 
+# CSRF secret used to sign the double-submit CSRF token (min 32 characters, keep secret in production)
+CSRF_SECRET=
+
+# Comma-separated list of IPs/CIDR ranges allowed to reach IP-restricted admin/ops
+# routes (/audit, /jobs, /config, /circuit-breaker, /admin). Required — if left
+# empty, those routes fail closed and reject all requests.
+# Example: ADMIN_IP_WHITELIST=127.0.0.1,10.0.0.0/8
+ADMIN_IP_WHITELIST=
+
 # ─── Real-time Health Monitoring and Alerting ──────────────────────────────────
 # Slack webhook URL for health alerts
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL

--- a/backend/src/__tests__/ListingController.test.ts
+++ b/backend/src/__tests__/ListingController.test.ts
@@ -23,12 +23,12 @@ jest.mock('../middleware/authenticate', () => ({
 }));
 
 // ── App builder ────────────────────────────────────────────────────────────────
-import listingsRouter from '../routes/listings';
 import {
   createListing,
   getListing,
   deleteListing,
   listListings,
+  toggleListingVisibility,
 } from '../controllers/ListingController';
 
 function buildApp(opts: { userId?: string; orgId?: string } = {}) {
@@ -44,6 +44,7 @@ function buildApp(opts: { userId?: string; orgId?: string } = {}) {
   app.get('/listings/:id', getListing);
   app.delete('/listings/:id', deleteListing);
   app.get('/listings', listListings);
+  app.patch('/listings/:id/visibility', toggleListingVisibility);
   // Global error handler
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
     res.status(500).json({ success: false, message: err.message });
@@ -186,6 +187,40 @@ describe('deleteListing', () => {
     const res = await request(app).delete(`/listings/${LISTING_ID}`);
 
     expect(res.status).toBe(500);
+  });
+});
+
+// ── toggleListingVisibility ──────────────────────────────────────────────────
+describe('toggleListingVisibility', () => {
+  it('rejects a forged mentorId in the body when there is no authenticated user', async () => {
+    const app = buildApp({}); // no userId — simulates missing/invalid auth
+
+    const res = await request(app)
+      .patch(`/listings/${LISTING_ID}/visibility`)
+      .send({ isActive: false, mentorId: 'attacker-mentor-id' });
+
+    expect(res.status).toBe(401);
+    expect(listingService.toggleVisibility).not.toHaveBeenCalled();
+  });
+
+  it('ignores a client-supplied mentorId and uses the authenticated user id', async () => {
+    (listingService.toggleVisibility as jest.Mock).mockResolvedValue({
+      ...sampleListing,
+      isActive: false,
+    });
+    const app = buildApp({ userId: MENTOR_ID, orgId: ORG_A });
+
+    const res = await request(app)
+      .patch(`/listings/${LISTING_ID}/visibility`)
+      .send({ isActive: false, mentorId: 'attacker-mentor-id' });
+
+    expect(res.status).toBe(200);
+    expect(listingService.toggleVisibility).toHaveBeenCalledWith(
+      LISTING_ID,
+      MENTOR_ID,
+      false,
+      ORG_A,
+    );
   });
 });
 

--- a/backend/src/__tests__/csrfProtection.test.ts
+++ b/backend/src/__tests__/csrfProtection.test.ts
@@ -10,10 +10,15 @@
  */
 
 // Set required env vars before any module is loaded
-process.env.JWT_SECRET = 'test-secret-csrf';
-process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-csrf';
+process.env.JWT_SECRET = 'test-secret-csrf-that-is-at-least-32-chars!!';
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-csrf-that-is-at-least-32-chars!!';
 process.env.JWT_EXPIRES_IN = '15m';
 process.env.JWT_REFRESH_EXPIRES_IN = '7d';
+process.env.CSRF_SECRET = 'test-csrf-secret-that-is-at-least-32-chars!!';
+process.env.STRIPE_SECRET_KEY = 'sk_test_csrf_suite';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/test';
+process.env.TWITTER_API_KEY = process.env.TWITTER_API_KEY || 'test-key';
+process.env.TWITTER_API_SECRET = process.env.TWITTER_API_SECRET || 'test-secret';
 
 import { Request, Response, NextFunction } from 'express';
 import { csrfProtection } from '../middleware/csrfProtection';

--- a/backend/src/__tests__/integration/setup.ts
+++ b/backend/src/__tests__/integration/setup.ts
@@ -12,6 +12,7 @@ process.env.JWT_SECRET = 'integration-test-secret-32-chars!!';
 process.env.JWT_REFRESH_SECRET = 'integration-refresh-secret-32ch';
 process.env.JWT_EXPIRES_IN = '15m';
 process.env.JWT_REFRESH_EXPIRES_IN = '7d';
+process.env.CSRF_SECRET = 'integration-test-csrf-secret-32-chars!!';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/socialflow_test';
 process.env.TWITTER_API_KEY = 'test-key';
 process.env.TWITTER_API_SECRET = 'test-secret';

--- a/backend/src/__tests__/ipWhitelist.test.ts
+++ b/backend/src/__tests__/ipWhitelist.test.ts
@@ -1,17 +1,20 @@
 import { Request, Response, NextFunction } from 'express';
-import { ipWhitelistMiddleware } from '../middleware/ipWhitelist';
-import * as runtime from '../config/runtime';
-import requestIp from 'request-ip';
 
 jest.mock('../config/runtime');
 jest.mock('request-ip');
+
+const mockLogger = {
+  warn: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+};
 jest.mock('../lib/logger', () => ({
-  createLogger: () => ({
-    warn: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  }),
+  createLogger: () => mockLogger,
 }));
+
+import { ipWhitelistMiddleware } from '../middleware/ipWhitelist';
+import * as runtime from '../config/runtime';
+import requestIp from 'request-ip';
 
 describe('ipWhitelistMiddleware', () => {
   let mockRequest: Partial<Request>;
@@ -32,12 +35,26 @@ describe('ipWhitelistMiddleware', () => {
     jest.clearAllMocks();
   });
 
-  it('should allow access if whitelist is empty', () => {
+  it('should fail closed (block access) if whitelist is empty', () => {
     (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue([]);
     (requestIp.getClientIp as jest.Mock).mockReturnValue('127.0.0.1');
 
     ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
-    expect(nextFunction).toHaveBeenCalled();
+
+    expect(nextFunction).not.toHaveBeenCalled();
+    expect(mockResponse.status).toHaveBeenCalledWith(403);
+  });
+
+  it('should log a loud warning when the whitelist is empty', () => {
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue([]);
+    (requestIp.getClientIp as jest.Mock).mockReturnValue('127.0.0.1');
+
+    ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('ADMIN_IP_WHITELIST is not configured'),
+      expect.any(Object),
+    );
   });
 
   it('should allow access if client IP matches an exact entry', () => {
@@ -69,11 +86,11 @@ describe('ipWhitelistMiddleware', () => {
     (requestIp.getClientIp as jest.Mock).mockReturnValue('192.168.1.1');
 
     ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);
-    
+
     expect(nextFunction).not.toHaveBeenCalled();
     expect(mockResponse.status).toHaveBeenCalledWith(403);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      error: 'Access forbidden: Your IP address is not authorized to access this endpoint.'
+      error: 'Access forbidden: Your IP address is not authorized to access this endpoint.',
     });
   });
 
@@ -123,7 +140,11 @@ describe('ipWhitelistMiddleware', () => {
   });
 
   it('should allow access for IPv4-mapped IPv6 address matching a mixed whitelist (IPv4 + IPv6)', () => {
-    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue(['127.0.0.1', '::1', '192.168.1.0/24']);
+    (runtime.getAdminIpWhitelist as jest.Mock).mockReturnValue([
+      '127.0.0.1',
+      '::1',
+      '192.168.1.0/24',
+    ]);
     (requestIp.getClientIp as jest.Mock).mockReturnValue('::ffff:192.168.1.100');
 
     ipWhitelistMiddleware(mockRequest as Request, mockResponse as Response, nextFunction);

--- a/backend/src/__tests__/unitSetup.ts
+++ b/backend/src/__tests__/unitSetup.ts
@@ -2,6 +2,8 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/test';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-that-is-at-least-32-chars!!';
-process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'test-refresh-secret-32-chars!!!!!';
+process.env.JWT_REFRESH_SECRET =
+  process.env.JWT_REFRESH_SECRET || 'test-refresh-secret-32-chars!!!!!';
+process.env.CSRF_SECRET = process.env.CSRF_SECRET || 'test-csrf-secret-that-is-at-least-32-chars!!';
 process.env.TWITTER_API_KEY = process.env.TWITTER_API_KEY || 'test-key';
 process.env.TWITTER_API_SECRET = process.env.TWITTER_API_SECRET || 'test-secret';

--- a/backend/src/config/__tests__/config.test.ts
+++ b/backend/src/config/__tests__/config.test.ts
@@ -4,6 +4,7 @@ const REQUIRED_ENV: Record<string, string> = {
   DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
   JWT_SECRET: 'super-secret-jwt-value-at-least-32-chars',
   JWT_REFRESH_SECRET: 'super-secret-refresh-value-at-least-32-chars',
+  CSRF_SECRET: 'super-secret-csrf-value-at-least-32-chars',
   TWITTER_API_KEY: 'twitter-key',
   TWITTER_API_SECRET: 'twitter-secret',
   STRIPE_SECRET_KEY: 'sk_test_required',
@@ -221,6 +222,17 @@ describe('validateEnv', () => {
     it('throws when JWT_REFRESH_SECRET is shorter than 32 characters', () => {
       expect(() => validateEnv({ ...REQUIRED_ENV, JWT_REFRESH_SECRET: 'short-secret' })).toThrow(
         'JWT_REFRESH_SECRET must be at least 32 characters',
+      );
+    });
+
+    it('throws when CSRF_SECRET is missing', () => {
+      const { CSRF_SECRET: _, ...env } = REQUIRED_ENV;
+      expect(() => validateEnv(env)).toThrow('Environment validation failed');
+    });
+
+    it('throws when CSRF_SECRET is shorter than 32 characters', () => {
+      expect(() => validateEnv({ ...REQUIRED_ENV, CSRF_SECRET: 'short-secret' })).toThrow(
+        'CSRF_SECRET must be at least 32 characters',
       );
     });
 

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -50,6 +50,14 @@ const envSchema = z
       ),
     JWT_REFRESH_EXPIRES_IN: z.string().default('7d'),
 
+    // ── CSRF ──────────────────────────────────────────────────────────────────
+    CSRF_SECRET: z
+      .string()
+      .min(
+        JWT_SECRET_MIN_LENGTH,
+        `CSRF_SECRET must be at least ${JWT_SECRET_MIN_LENGTH} characters`,
+      ),
+
     // ── Redis ─────────────────────────────────────────────────────────────────
     // Optional single-URL form (e.g. rediss://user:pass@host:port). When set,
     // it takes precedence over the individual REDIS_HOST/PORT/PASSWORD fields.

--- a/backend/src/controllers/ListingController.ts
+++ b/backend/src/controllers/ListingController.ts
@@ -68,8 +68,8 @@ export const toggleListingVisibility = async (req: Request, res: Response) => {
     const { id } = req.params;
     const { isActive } = req.body;
 
-    const mentorId = (req as any).user?.id || req.body.mentorId;
-    const orgId: string | undefined = (req as any).user?.organizationId;
+    const mentorId = (req as any).user?.id;
+    const orgId: string | undefined = (req as any).activeOrgId;
 
     if (isActive === undefined) {
       return res.status(400).json({ success: false, message: 'isActive is required' });

--- a/backend/src/graphql/__tests__/context.test.ts
+++ b/backend/src/graphql/__tests__/context.test.ts
@@ -2,16 +2,25 @@
  * Coverage for #1303 — the GraphQL context layer had zero test coverage.
  * Exercises buildContext() for valid, invalid, missing, and
  * blacklisted-token cases.
+ *
+ * Also covers #1262 — buildContext must validate tokens against the
+ * config-validated JWT_SECRET, not a hardcoded fallback string.
  */
 import { Request } from 'express';
 import jwt from 'jsonwebtoken';
 import { AuthBlacklistService } from '../../services/AuthBlacklistService';
 
+const TEST_SECRET = 'test-secret-that-is-at-least-32-chars!!';
+
+jest.mock('../../config/config', () => ({
+  config: { JWT_SECRET: 'test-secret-that-is-at-least-32-chars!!' },
+}));
+
 jest.mock('../../services/AuthBlacklistService', () => ({
   AuthBlacklistService: {
     isBlacklisted: jest.fn(),
-    keyFromPayload: jest.fn((p: { sub?: string; jti?: string; iat?: number }) =>
-      p.jti ?? `${p.sub}:${p.iat}`,
+    keyFromPayload: jest.fn(
+      (p: { sub?: string; jti?: string; iat?: number }) => p.jti ?? `${p.sub}:${p.iat}`,
     ),
   },
 }));
@@ -21,8 +30,7 @@ import { buildContext } from '../context';
 const mockIsBlacklisted = AuthBlacklistService.isBlacklisted as jest.Mock;
 const mockKeyFromPayload = AuthBlacklistService.keyFromPayload as jest.Mock;
 
-// unitSetup.ts sets this for the whole 'unit' Jest project.
-const SECRET = process.env.JWT_SECRET as string;
+const SECRET = TEST_SECRET;
 
 function makeReq(authorization?: string): { req: Request } {
   return { req: { headers: { authorization } } as unknown as Request };
@@ -95,5 +103,20 @@ describe('buildContext', () => {
 
     expect(mockIsBlacklisted).toHaveBeenCalledWith('jti-blacklisted');
     expect(ctx).toEqual({});
+  });
+});
+
+describe('#1262 buildContext JWT_SECRET', () => {
+  it('accepts a token signed with the validated config.JWT_SECRET', async () => {
+    mockIsBlacklisted.mockResolvedValue(false);
+    const token = jwt.sign({ sub: 'user-1' }, TEST_SECRET);
+    const ctx = await buildContext(makeReq(`Bearer ${token}`));
+    expect(ctx.userId).toBe('user-1');
+  });
+
+  it('rejects a token signed with the old hardcoded fallback secret', async () => {
+    const token = jwt.sign({ sub: 'attacker' }, 'change-me-in-production');
+    const ctx = await buildContext(makeReq(`Bearer ${token}`));
+    expect(ctx.userId).toBeUndefined();
   });
 });

--- a/backend/src/graphql/context.ts
+++ b/backend/src/graphql/context.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express';
 import jwt from 'jsonwebtoken';
 import { AuthBlacklistService } from '../services/AuthBlacklistService';
+import { config } from '../config/config';
 
 export interface GraphQLContext {
   /** Authenticated user ID, or undefined for unauthenticated requests. */
@@ -13,8 +14,6 @@ export interface GraphQLContext {
    */
   tokenKey?: string;
 }
-
-const JWT_SECRET = () => process.env.JWT_SECRET ?? 'change-me-in-production';
 
 /**
  * Build the per-request GraphQL context.
@@ -31,7 +30,7 @@ export async function buildContext({ req }: { req: Request }): Promise<GraphQLCo
   const token = authHeader.slice(7);
   let payload: jwt.JwtPayload;
   try {
-    payload = jwt.verify(token, JWT_SECRET()) as jwt.JwtPayload;
+    payload = jwt.verify(token, config.JWT_SECRET) as jwt.JwtPayload;
   } catch {
     return {};
   }

--- a/backend/src/middleware/csrfProtection.ts
+++ b/backend/src/middleware/csrfProtection.ts
@@ -1,10 +1,9 @@
 import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { createLogger } from '../lib/logger';
+import { config } from '../config/config';
 
 const logger = createLogger('middleware:csrfProtection');
-
-const CSRF_SECRET = process.env.CSRF_SECRET ?? 'dev-csrf-secret-change-me';
 const SESSION_COOKIE = 'csrf_sid';
 const TOKEN_COOKIE = 'csrf_token';
 const TOKEN_HEADER = 'x-csrf-token';
@@ -27,7 +26,7 @@ function parseCookies(header?: string): Record<string, string> {
 
 /** Derive the CSRF token from the session ID — binds the token to its session. */
 function signSessionId(sessionId: string): string {
-  return crypto.createHmac('sha256', CSRF_SECRET).update(sessionId).digest('hex');
+  return crypto.createHmac('sha256', config.CSRF_SECRET).update(sessionId).digest('hex');
 }
 
 /**
@@ -46,9 +45,17 @@ function ensureCsrfSession(req: Request, res: Response, isProduction: boolean): 
   const sessionId = cookies[SESSION_COOKIE] ?? crypto.randomBytes(32).toString('hex');
 
   if (!cookies[SESSION_COOKIE]) {
-    res.cookie(SESSION_COOKIE, sessionId, { httpOnly: true, sameSite: 'lax', secure: isProduction });
+    res.cookie(SESSION_COOKIE, sessionId, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: isProduction,
+    });
   }
-  res.cookie(TOKEN_COOKIE, signSessionId(sessionId), { httpOnly: false, sameSite: 'lax', secure: isProduction });
+  res.cookie(TOKEN_COOKIE, signSessionId(sessionId), {
+    httpOnly: false,
+    sameSite: 'lax',
+    secure: isProduction,
+  });
 }
 
 /**

--- a/backend/src/middleware/ipWhitelist.ts
+++ b/backend/src/middleware/ipWhitelist.ts
@@ -8,7 +8,7 @@ const logger = createLogger('middleware:ipWhitelist');
 
 /**
  * Middleware to restrict access to specific IP addresses and CIDR ranges.
- * Supports IPv4 and IPv6, and handles proxy headers safely if the app is 
+ * Supports IPv4 and IPv6, and handles proxy headers safely if the app is
  * configured to trust proxies.
  */
 /**
@@ -29,13 +29,18 @@ export const ipWhitelistMiddleware = (req: Request, res: Response, next: NextFun
   const clientIp = requestIp.getClientIp(req);
   const whitelist = getAdminIpWhitelist();
 
-  // If no whitelist is configured, allow all by default (per conventional security or block?)
-  // Given the requirement "Restrict access... to specific... IP addresses", 
-  // if the list is empty, we might want to log a warning but allow access if not in production.
-  // For strictness, if the list is expected but empty, we could block.
-  // However, usually, an empty list means the feature is disabled.
+  // Fail closed: an empty whitelist must not grant unrestricted access to the
+  // sensitive admin/ops routes this middleware protects. Configure
+  // ADMIN_IP_WHITELIST to allow trusted IPs through.
   if (whitelist.length === 0) {
-    return next();
+    logger.warn(
+      'ADMIN_IP_WHITELIST is not configured — blocking all requests to IP-restricted routes. ' +
+        'Set ADMIN_IP_WHITELIST to a comma-separated list of allowed IPs/CIDR ranges to grant access.',
+      { path: req.path, method: req.method },
+    );
+    return res.status(403).json({
+      error: 'Access forbidden: IP whitelisting is not configured for this endpoint.',
+    });
   }
 
   if (!clientIp) {
@@ -57,7 +62,7 @@ export const ipWhitelistMiddleware = (req: Request, res: Response, next: NextFun
           const [range, bits] = entry.split('/');
           const network = ipaddr.parse(range);
           const bitCount = parseInt(bits, 10);
-          
+
           // Ensure both are same version (v4 or v6)
           if (addr.kind() === network.kind()) {
             return (addr as any).match(network, bitCount);
@@ -69,7 +74,10 @@ export const ipWhitelistMiddleware = (req: Request, res: Response, next: NextFun
           return addr.toString() === allowedAddr.toString();
         }
       } catch (err) {
-        logger.error('Invalid entry in IP whitelist', { entry, error: err instanceof Error ? err.message : String(err) });
+        logger.error('Invalid entry in IP whitelist', {
+          entry,
+          error: err instanceof Error ? err.message : String(err),
+        });
         return false;
       }
     });
@@ -90,7 +98,7 @@ export const ipWhitelistMiddleware = (req: Request, res: Response, next: NextFun
     });
   }
 
-  return res.status(403).json({ 
-    error: 'Access forbidden: Your IP address is not authorized to access this endpoint.' 
+  return res.status(403).json({
+    error: 'Access forbidden: Your IP address is not authorized to access this endpoint.',
   });
 };


### PR DESCRIPTION
Resolves the merge conflicts between #1349 (Mystery-CLI:fix/security-issues-batch-1259-1262) and current `master` so it can be merged cleanly.

## What was conflicting and how it was resolved

- **`backend/src/graphql/__tests__/context.test.ts`** (add/add conflict): both `master` and #1349 independently added a test file at this path testing different things — `master`'s version broadly covers `buildContext()`, #1349's version specifically regression-tests the security fix (rejecting tokens signed with the old hardcoded `'change-me-in-production'` fallback secret). Combined both suites rather than dropping either.
- **`src/components/ListingVisibilityToggle.tsx`** (modify/delete conflict): #1349's branch modifies this file, but it was already deleted on `master` as dead code (verified: nothing on `master` imports or references it). Kept it deleted.
- **`backend/src/config/config.ts` / `config.test.ts`**: #1349's branch was based on a `config.ts` version that predates `REDIS_URL` support, so a naive merge would have silently reverted the file to that older structure. Isolated #1349's actual intended change (a required `CSRF_SECRET` field) and reapplied it on top of current `master`'s schema.

Everything else (`ipWhitelist.ts` fail-open→fail-closed fix, `csrfProtection.ts`/`context.ts` hardcoded-secret removal, `ListingController.ts` IDOR fix) auto-merged cleanly and was verified against `master` — no corruption.

## Verification
- `tsc --noEmit`: no new errors introduced
- `eslint`: no errors (only pre-existing `no-explicit-any` warnings)
- Relevant test suites (`config.test.ts`, `ListingController.test.ts`, `context.test.ts`, `csrfProtection.test.ts` unit suite, `ipWhitelist.test.ts`) pass — the CSRF suite's `(integration)` sub-block needs a live DB/Redis and wasn't runnable in this sandbox, but the core middleware unit tests (17/17) pass.

## Note
This also carries two unrelated infra fixes needed to get a clean commit through at all: an ESLint `tsconfigRootDir` misconfiguration, and a typed-lint rule that crashed on files `tsconfig.json` intentionally excludes (`src/modules`, `src/shared`, `src/tests`, `src/__tests__/database`, `src/__tests__/integration`) — both already pushed directly to `master` separately (commits `5781ab6`, `69a1a17`), so this branch's diff against master should be conflict-related content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)