### PR TITLE
test: add unit tests for AuthContext, PostsContext, ComposerContext

### DIFF
--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AuthProvider, useAuth } from './AuthContext';
+
+type AuthCtx = ReturnType<typeof useAuth>;
+
+const TOKEN_KEY = 'sf_auth_token';
+const USER_KEY = 'sf_auth_user';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const Consumer: React.FC<{ onReady: (ctx: AuthCtx) => void }> = ({ onReady }) => {
+  const ctx = useAuth();
+  onReady(ctx);
+  return null;
+};
+
+const renderAuth = () => {
+  let ctx!: AuthCtx;
+  render(
+    <AuthProvider>
+      <Consumer
+        onReady={(c) => {
+          ctx = c;
+        }}
+      />
+    </AuthProvider>,
+  );
+  return () => ctx;
+};
+
+describe('AuthContext', () => {
+  test('returns isAuthenticated=false and the DEFAULT_USER before any login', () => {
+    const getCtx = renderAuth();
+
+    expect(getCtx().isAuthenticated).toBe(false);
+    expect(getCtx().user).toEqual({
+      name: 'Alex Morgan',
+      email: 'alex@socialflow.ai',
+      plan: 'Pro Plan',
+    });
+  });
+
+  test('login persists token and user to localStorage and updates context', () => {
+    const getCtx = renderAuth();
+
+    act(() => {
+      getCtx().login('jamie@example.com');
+    });
+
+    expect(getCtx().isAuthenticated).toBe(true);
+    expect(getCtx().user).toMatchObject({ email: 'jamie@example.com', name: 'Jamie' });
+    expect(window.localStorage.getItem(TOKEN_KEY)).toMatch(/^demo-/);
+    expect(JSON.parse(window.localStorage.getItem(USER_KEY) as string)).toEqual(getCtx().user);
+  });
+
+  test('logout clears token and user from localStorage', () => {
+    const getCtx = renderAuth();
+
+    act(() => {
+      getCtx().login('jamie@example.com');
+    });
+    act(() => {
+      getCtx().logout();
+    });
+
+    expect(getCtx().isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(window.localStorage.getItem(USER_KEY)).toBeNull();
+  });
+
+  test('useAuth throws when used outside an AuthProvider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const BadConsumer: React.FC = () => {
+      useAuth();
+      return null;
+    };
+
+    expect(() => render(<BadConsumer />)).toThrow('useAuth must be used within an AuthProvider');
+
+    spy.mockRestore();
+  });
+});

--- a/src/contexts/ComposerContext.test.tsx
+++ b/src/contexts/ComposerContext.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComposerProvider, useComposer } from './ComposerContext';
+
+jest.mock('../components/PostComposer', () => ({
+  PostComposer: ({ open }: { open: boolean }) => (
+    <div data-testid="post-composer">{open ? 'open' : 'closed'}</div>
+  ),
+}));
+
+const Consumer: React.FC = () => {
+  const { openComposer, closeComposer } = useComposer();
+  return (
+    <div>
+      <button onClick={openComposer}>open</button>
+      <button onClick={closeComposer}>close</button>
+    </div>
+  );
+};
+
+describe('ComposerContext', () => {
+  test('toggles the composer open/closed via openComposer/closeComposer', () => {
+    render(
+      <ComposerProvider>
+        <Consumer />
+      </ComposerProvider>,
+    );
+
+    expect(screen.getByTestId('post-composer')).toHaveTextContent('closed');
+
+    act(() => {
+      screen.getByText('open').click();
+    });
+    expect(screen.getByTestId('post-composer')).toHaveTextContent('open');
+
+    act(() => {
+      screen.getByText('close').click();
+    });
+    expect(screen.getByTestId('post-composer')).toHaveTextContent('closed');
+  });
+
+  test('useComposer throws when used outside a ComposerProvider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const BadConsumer: React.FC = () => {
+      useComposer();
+      return null;
+    };
+
+    expect(() => render(<BadConsumer />)).toThrow(
+      'useComposer must be used within a ComposerProvider',
+    );
+
+    spy.mockRestore();
+  });
+});

--- a/src/contexts/PostsContext.test.tsx
+++ b/src/contexts/PostsContext.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PostsProvider, usePosts, ScheduledPost } from './PostsContext';
+
+type PostsCtx = ReturnType<typeof usePosts>;
+
+const STORAGE_KEY = 'sf_scheduled_posts';
+
+let setItemSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+});
+
+afterEach(() => {
+  setItemSpy.mockRestore();
+});
+
+const Consumer: React.FC<{ onReady: (ctx: PostsCtx) => void }> = ({ onReady }) => {
+  const ctx = usePosts();
+  onReady(ctx);
+  return <div data-testid="count">{ctx.posts.length}</div>;
+};
+
+const renderPosts = () => {
+  let ctx!: PostsCtx;
+  render(
+    <PostsProvider>
+      <Consumer
+        onReady={(c) => {
+          ctx = c;
+        }}
+      />
+    </PostsProvider>,
+  );
+  return () => ctx;
+};
+
+describe('PostsContext', () => {
+  test('seeds initial posts when localStorage is empty', () => {
+    renderPosts();
+    expect(screen.getByTestId('count')).toHaveTextContent('3');
+  });
+
+  test('falls back to seed() when localStorage contains corrupt JSON, without throwing', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not-valid-json');
+    expect(renderPosts).not.toThrow();
+    expect(screen.getByTestId('count')).toHaveTextContent('3');
+  });
+
+  test('addPost prepends a new post with a generated id and default status', () => {
+    const getCtx = renderPosts();
+
+    act(() => {
+      getCtx().addPost({
+        content: 'hello world',
+        platform: 'x',
+        hashtags: [],
+        mediaType: 'text',
+        scheduledAt: Date.now(),
+        reachScore: 50,
+      });
+    });
+
+    const [first] = getCtx().posts;
+    expect(getCtx().posts).toHaveLength(4);
+    expect(first.content).toBe('hello world');
+    expect(first.id).toMatch(/^post-/);
+    expect(first.status).toBe('scheduled');
+  });
+
+  test('removePost removes the post with the matching id', () => {
+    const getCtx = renderPosts();
+
+    act(() => {
+      getCtx().removePost('seed-1');
+    });
+
+    expect(getCtx().posts.find((p: ScheduledPost) => p.id === 'seed-1')).toBeUndefined();
+    expect(getCtx().posts).toHaveLength(2);
+  });
+
+  test('updateStatus updates the status of the matching post only', () => {
+    const getCtx = renderPosts();
+
+    act(() => {
+      getCtx().updateStatus('seed-1', 'published');
+    });
+
+    expect(getCtx().posts.find((p: ScheduledPost) => p.id === 'seed-1')?.status).toBe('published');
+    expect(getCtx().posts.find((p: ScheduledPost) => p.id === 'seed-2')?.status).toBe('scheduled');
+  });
+
+  test('persists to localStorage on every state change', () => {
+    const getCtx = renderPosts();
+    setItemSpy.mockClear();
+
+    act(() => {
+      getCtx().removePost('seed-1');
+    });
+    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String));
+
+    setItemSpy.mockClear();
+
+    act(() => {
+      getCtx().updateStatus('seed-2', 'published');
+    });
+    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String));
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/contexts/AuthContext.test.tsx`: covers `login()` persisting token/user to localStorage, `logout()` clearing both keys, `useAuth()` throwing outside a provider, and explicitly asserts the pre-login `user`/`isAuthenticated` values (the DEFAULT_USER leak).
- Add `src/contexts/PostsContext.test.tsx`: covers `addPost`/`removePost`/`updateStatus`, seeding from empty localStorage, falling back to `seed()` on corrupt JSON without throwing, and `localStorage.setItem` running on every state change.
- Add `src/contexts/ComposerContext.test.tsx`: covers the open/close toggle and `useComposer()` throwing outside its provider.

Closes #1212
Closes #1213
Closes #1214

## Test plan
- [x] Reviewed against each context's actual implementation for correctness
- [x] Type-checked with `tsc --noEmit` (no new errors introduced)
- [ ] Not run through the local test runner as part of this change (per task instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)